### PR TITLE
Link cross-border trains by departure time

### DIFF
--- a/carte.html
+++ b/carte.html
@@ -1528,6 +1528,21 @@ const GTFS_RT_STOP_META_KEYS = new Set([
     };
   }
 
+  function buildCancelledDelayInfo(station){
+    const title = station ? `Train supprimé à ${station}` : 'Train supprimé';
+    return {
+      label:'Supprimé',
+      minutes:null,
+      station,
+      severity:'cancelled',
+      badgeClass:'train-delay-badge train-delay-badge--cancelled',
+      title,
+      panelText:title,
+      panelContext: trainDelayTooltipSuffix ? `Source temps réel — ${trainDelayTooltipSuffix}` : '',
+      sourceLabel: trainDelaySourceLabel
+    };
+  }
+
   function computeDelayInfoFromPerStation(perStation, train){
     if (!perStation || !perStation.size) return null;
 
@@ -1780,8 +1795,28 @@ function adaptDelayEntryForStop(entry, stopMeta){
       realtimeStopDataByTrip.delete(tripId);
       return null;
     }
-    const normalizedKey = normalizeTrainNumberKey(numberKey);
-    const perStation = normalizedKey ? trainDelaysByNumber.get(String(normalizedKey)) : null;
+    const delayKeyCandidates = [];
+    const pushDelayKey = (value)=>{
+      if (value == null) return;
+      const candidate = extractTrainNumberCandidate(value) ?? value;
+      const normalized = normalizeTrainNumberKey(candidate);
+      if (!normalized && normalized !== 0) return;
+      const keyStr = String(normalized);
+      if (!keyStr || delayKeyCandidates.includes(keyStr)) return;
+      delayKeyCandidates.push(keyStr);
+    };
+
+    pushDelayKey(numberKey);
+    const staticHint = staticRelatedNumbersByTrip.get(tripId);
+    if (staticHint && Array.isArray(staticHint.related)){
+      for (const rel of staticHint.related){
+        pushDelayKey(rel.normalizedKey);
+        pushDelayKey(rel.numberCandidate);
+        pushDelayKey(rel.rawNumber);
+        pushDelayKey(rel.displayNumber);
+      }
+    }
+    const perStation = delayKeyCandidates.map(key => trainDelaysByNumber.get(String(key))).find(Boolean) || null;
     const startPlanned = seq[0]?.departure ?? seq[0]?.arrival ?? null;
     const lastStop = seq[seq.length - 1] || null;
     const endPlanned = lastStop?.arrival ?? lastStop?.departure ?? null;
@@ -3981,7 +4016,16 @@ function stationNameMatchesKeywords(name, keywords){
       const endPlanned = lastStop?.arrival ?? lastStop?.departure;
       const startEffective = realtimeProfile?.startRealtime ?? startPlanned;
       const endEffective = realtimeProfile?.endRealtime ?? endPlanned;
-      if (startEffective==null || endEffective==null || nowSec<startEffective || nowSec>endEffective) continue;
+      const cancellationInfo = realtimeProfile?.cancellation;
+      const cancellationStartPlanned = (cancellationInfo && cancellationInfo.index != null && cancellationInfo.index < seq.length)
+        ? (seq[cancellationInfo.index]?.departure ?? seq[cancellationInfo.index]?.arrival ?? null)
+        : null;
+      const cancellationEndPlanned = cancellationStartPlanned != null ? endPlanned : null;
+      const insideCancelledWindow = cancellationStartPlanned != null
+        && cancellationEndPlanned != null
+        && nowSec >= cancellationStartPlanned
+        && nowSec <= cancellationEndPlanned;
+      if (startEffective==null || endEffective==null || nowSec<startEffective || (nowSec>endEffective && !insideCancelledWindow)) continue;
       const totalSpan = endEffective - startEffective;
       const tripProgress = totalSpan > 0 ? (nowSec - startEffective) / totalSpan : null;
       const headsign = (()=>{
@@ -3993,20 +4037,7 @@ function stationNameMatchesKeywords(name, keywords){
 
       let positioned = false;
 
-      for (let i=0;i<seq.length;i++){
-        const stop = seq[i];
-        const profileStop = realtimeProfile?.stops?.[i];
-        const arr = profileStop?.arrivalRealtime ?? stop.arrival;
-        const dep = profileStop?.departureRealtime ?? stop.departure;
-        if (arr==null || dep==null || dep<=arr) continue;
-        if (nowSec < arr || nowSec > dep) continue;
-
-        const stopMeta = stopsById.get(stop.stop_id);
-        if (!stopMeta) continue;
-
-        const nextStopMeta = seq[i+1] ? stopsById.get(seq[i+1].stop_id) : null;
-        const etaSec = Math.max(0, Math.round(dep - nowSec));
-
+      const buildNumberLists = ()=>{
         const displayForList = branding.displayNumber || numberDisplay || rawNumber || null;
         const numberList = displayForList ? [displayForList] : [];
         const delayNumberKeys = [];
@@ -4038,6 +4069,24 @@ function stationNameMatchesKeywords(name, keywords){
             }
           }
         }
+        return { numberList, delayNumberKeys };
+      };
+
+      for (let i=0;i<seq.length;i++){
+        const stop = seq[i];
+        const profileStop = realtimeProfile?.stops?.[i];
+        const arr = profileStop?.arrivalRealtime ?? stop.arrival;
+        const dep = profileStop?.departureRealtime ?? stop.departure;
+        if (arr==null || dep==null || dep<=arr) continue;
+        if (nowSec < arr || nowSec > dep) continue;
+
+        const stopMeta = stopsById.get(stop.stop_id);
+        if (!stopMeta) continue;
+
+        const nextStopMeta = seq[i+1] ? stopsById.get(seq[i+1].stop_id) : null;
+        const etaSec = Math.max(0, Math.round(dep - nowSec));
+
+        const { numberList, delayNumberKeys } = buildNumberLists();
         const source = trip?.source === 'CFL' ? 'CFL' : 'SNCF';
 
         items.push({
@@ -4093,37 +4142,7 @@ function stationNameMatchesKeywords(name, keywords){
         const { lat, lon } = pos;
         const etaSec = Math.max(0, Math.round(tB - nowSec));
 
-        const displayForList = branding.displayNumber || numberDisplay || rawNumber || null;
-        const numberList = displayForList ? [displayForList] : [];
-        const delayNumberKeys = [];
-        if (numberKey != null) delayNumberKeys.push(String(numberKey));
-        const staticHint = staticRelatedNumbersByTrip.get(trip_id);
-        if (staticHint && Array.isArray(staticHint.related)){
-          for (const rel of staticHint.related){
-            const candidateDisplay = rel.displayNumber || rel.rawNumber || null;
-            if (!candidateDisplay) continue;
-            const str = String(candidateDisplay).trim();
-            if (!str) continue;
-            if (!numberList.includes(str)) numberList.push(str);
-            const normalized = rel.normalizedKey != null ? String(rel.normalizedKey) : null;
-            if (normalized && !delayNumberKeys.includes(normalized)){
-              delayNumberKeys.push(normalized);
-              continue;
-            }
-            const relCandidate = rel.numberCandidate != null ? normalizeTrainNumberKey(rel.numberCandidate) : null;
-            if (relCandidate != null){
-              const keyStr = String(relCandidate);
-              if (keyStr && !delayNumberKeys.includes(keyStr)) delayNumberKeys.push(keyStr);
-              continue;
-            }
-            const fallbackCandidate = extractTrainNumberCandidate(str);
-            const fallbackKey = fallbackCandidate != null ? normalizeTrainNumberKey(fallbackCandidate) : null;
-            if (fallbackKey != null){
-              const keyStr = String(fallbackKey);
-              if (keyStr && !delayNumberKeys.includes(keyStr)) delayNumberKeys.push(keyStr);
-            }
-          }
-        }
+        const { numberList, delayNumberKeys } = buildNumberLists();
         const source = trip?.source === 'CFL' ? 'CFL' : 'SNCF';
 
         items.push({
@@ -4155,6 +4174,64 @@ function stationNameMatchesKeywords(name, keywords){
           delayNumberKeys
         });
         break;
+      }
+
+      if (!positioned && insideCancelledWindow && cancellationInfo && cancellationInfo.index != null && cancellationInfo.index < seq.length){
+        const cancelStartIdx = Math.max(0, cancellationInfo.index);
+        const cancelDelayInfo = buildCancelledDelayInfo(cancellationInfo.station);
+        const cancelStartTime = cancellationStartPlanned ?? startPlanned;
+        const cancelEndTime = cancellationEndPlanned ?? endPlanned;
+        const cancelSpan = (cancelEndTime != null && cancelStartTime != null && cancelEndTime > cancelStartTime)
+          ? (cancelEndTime - cancelStartTime)
+          : null;
+        const cancelProgress = cancelSpan ? (nowSec - cancelStartTime) / cancelSpan : null;
+        for (let i=cancelStartIdx;i<seq.length-1;i++){
+          const A = seq[i], B = seq[i+1];
+          const tA = A.departure ?? A.arrival ?? null;
+          const tB = B.arrival ?? B.departure ?? null;
+          if (tA == null || tB == null || tB <= tA) continue;
+          if (nowSec < tA || nowSec > tB) continue;
+          const sA = stopsById.get(A.stop_id), sB = stopsById.get(B.stop_id);
+          if (!sA || !sB) continue;
+          const r = (nowSec - tA)/(tB - tA);
+          const path = pathBetweenStops(sA, sB);
+          const pos = positionAlongPath(path, r) || { lat: lerp(sA.lat, sB.lat, r), lon: lerp(sA.lon, sB.lon, r) };
+          const { lat, lon } = pos;
+          const etaSec = Math.max(0, Math.round(tB - nowSec));
+          const { numberList, delayNumberKeys } = buildNumberLists();
+          const source = trip?.source === 'CFL' ? 'CFL' : 'SNCF';
+
+          items.push({
+            id: trip_id,
+            headsign,
+            from: sA.name || A.stop_id,
+            to: sB.name || B.stop_id,
+            etaSec,
+            lat,
+            lon,
+            route_id: trip.route_id,
+            number: numberDisplay,
+            numberRaw: rawNumber || null,
+            numberDigits: branding.digits || null,
+            numberKey,
+            branding,
+            startSec: cancelStartTime,
+            endSec: cancelEndTime,
+            scheduledStartSec: startPlanned,
+            scheduledEndSec: endPlanned,
+            progress: cancelProgress,
+            segmentIndex: i,
+            segmentProgress: r,
+            nowSec,
+            stopsCount: seq.length,
+            currentDelaySec: null,
+            source,
+            numberList,
+            delayNumberKeys,
+            delayInfo: cancelDelayInfo
+          });
+          break;
+        }
       }
     }
     return mergeCrossBorderTrains(items);
@@ -4220,10 +4297,65 @@ function stationNameMatchesKeywords(name, keywords){
     };
   }
 
+  function computeTripAnchors(tripId, seq){
+    if (!tripId || !Array.isArray(seq) || seq.length < 2) return [];
+    const anchors = [];
+    const candidates = [seq[0], seq[seq.length - 1]];
+    for (let i=0;i<candidates.length;i++){
+      const st = candidates[i];
+      if (!st) continue;
+      const meta = stopsById.get(st.stop_id);
+      const name = meta?.name || meta?.stop_name || meta?.stop_desc || st.stop_id;
+      const norm = normalizeStationName(name);
+      if (!norm) continue;
+      const time = st.departure ?? st.arrival ?? null;
+      if (time == null) continue;
+      anchors.push({
+        station: norm,
+        bucket: Math.round(time / 300),
+        time,
+        type: i === 0 ? 'start' : 'end'
+      });
+    }
+    return anchors;
+  }
+
+  function buildStaticMergeEntry(tripId){
+    const trip = tripsById.get(tripId) || {};
+    const route = trip?.route_id ? routesById.get(trip.route_id) : null;
+    const rawNumber = trainNumberForTrip(trip, route, tripId);
+    const numberCandidate = extractTrainNumberCandidate(rawNumber) || extractTrainNumberCandidate(tripId) || null;
+    const branding = computeTrainBranding(tripId, trip, route, rawNumber, numberCandidate || null);
+    const displayNumber = branding.displayNumber || rawNumber || (numberCandidate != null ? String(numberCandidate) : null);
+    const normalizedKey = numberCandidate != null ? normalizeTrainNumberKey(numberCandidate) : null;
+    return {
+      tripId,
+      source: determineTripSource(tripId),
+      displayNumber,
+      numberCandidate,
+      normalizedKey,
+      rawNumber,
+      digits: branding.digits || null
+    };
+  }
+
+  function registerStaticRelations(baseEntry, relatedEntries, signature){
+    if (!baseEntry || !relatedEntries || !relatedEntries.length) return;
+    const existing = staticRelatedNumbersByTrip.get(baseEntry.tripId) || { signature:null, related:[] };
+    const combined = Array.isArray(existing.related) ? existing.related.slice() : [];
+    for (const rel of relatedEntries){
+      if (!rel || rel.tripId === baseEntry.tripId) continue;
+      if (combined.some(r => r.tripId === rel.tripId)) continue;
+      combined.push(rel);
+    }
+    staticRelatedNumbersByTrip.set(baseEntry.tripId, { signature: existing.signature || signature || null, related: combined });
+  }
+
   function rebuildStaticMergeData(){
     tripMergeSignatureCache.clear();
     staticRelatedNumbersByTrip.clear();
     const groups = new Map();
+    const departureGroups = new Map();
     for (const [tripId, seq] of stopTimesByTrip.entries()){
       const meta = buildTripMergeSignature(tripId, seq);
       if (!meta) continue;
@@ -4234,24 +4366,7 @@ function stationNameMatchesKeywords(name, keywords){
 
     for (const [signature, entries] of groups.entries()){
       if (!entries || entries.length < 2) continue;
-      const enriched = entries.map(({ tripId }) => {
-        const trip = tripsById.get(tripId) || {};
-        const route = trip?.route_id ? routesById.get(trip.route_id) : null;
-        const rawNumber = trainNumberForTrip(trip, route, tripId);
-        const numberCandidate = extractTrainNumberCandidate(rawNumber) || extractTrainNumberCandidate(tripId) || null;
-        const branding = computeTrainBranding(tripId, trip, route, rawNumber, numberCandidate || null);
-        const displayNumber = branding.displayNumber || rawNumber || (numberCandidate != null ? String(numberCandidate) : null);
-        const normalizedKey = numberCandidate != null ? normalizeTrainNumberKey(numberCandidate) : null;
-        return {
-          tripId,
-          source: determineTripSource(tripId),
-          displayNumber,
-          numberCandidate,
-          normalizedKey,
-          rawNumber,
-          digits: branding.digits || null
-        };
-      });
+      const enriched = entries.map(({ tripId }) => buildStaticMergeEntry(tripId)).filter(Boolean);
       const sourcesPresent = new Set(enriched.map(e => e.source));
       if (sourcesPresent.size < 2) continue;
       for (const entry of enriched){
@@ -4266,9 +4381,76 @@ function stationNameMatchesKeywords(name, keywords){
             rawNumber: e.rawNumber,
             digits: e.digits
           }));
-        if (related.length){
-          staticRelatedNumbersByTrip.set(entry.tripId, { signature, related });
+        registerStaticRelations(entry, related, signature);
+      }
+    }
+
+    const anchorGroups = new Map();
+    for (const [tripId, seq] of stopTimesByTrip.entries()){
+      const anchors = computeTripAnchors(tripId, seq);
+      if (!anchors.length) continue;
+      const entry = buildStaticMergeEntry(tripId);
+      if (!entry) continue;
+      for (const anchor of anchors){
+        const key = `${anchor.station}#${anchor.bucket ?? '?'}`;
+        if (!anchorGroups.has(key)) anchorGroups.set(key, []);
+        anchorGroups.get(key).push({ anchor, entry });
+      }
+
+      const first = seq[0] || null;
+      const depTime = first?.departure ?? first?.arrival ?? null;
+      if (depTime != null){
+        const meta = stopsById.get(first.stop_id);
+        const name = meta?.name || meta?.stop_name || meta?.stop_desc || first.stop_id;
+        const norm = normalizeStationName(name);
+        if (norm){
+          if (!departureGroups.has(norm)) departureGroups.set(norm, []);
+          departureGroups.get(norm).push({ time: depTime, entry });
         }
+      }
+    }
+
+    const ANCHOR_TOLERANCE_SEC = 300;
+    for (const [anchorKey, entries] of anchorGroups.entries()){
+      if (!entries || entries.length < 2) continue;
+      const sources = new Set(entries.map(e => e.entry?.source));
+      if (sources.size < 2) continue;
+      for (const { entry: baseEntry, anchor } of entries){
+        const related = entries
+          .filter(e => e.entry.tripId !== baseEntry.tripId)
+          .filter(e => Math.abs((e.anchor?.time ?? 0) - (anchor?.time ?? 0)) <= ANCHOR_TOLERANCE_SEC)
+          .map(e => ({
+            tripId: e.entry.tripId,
+            source: e.entry.source,
+            displayNumber: e.entry.displayNumber,
+            numberCandidate: e.entry.numberCandidate,
+            normalizedKey: e.entry.normalizedKey,
+            rawNumber: e.entry.rawNumber,
+            digits: e.entry.digits
+          }));
+        registerStaticRelations(baseEntry, related, `anchor:${anchorKey}`);
+      }
+    }
+
+    const DEPARTURE_TOLERANCE_SEC = 120;
+    for (const [station, entries] of departureGroups.entries()){
+      if (!entries || entries.length < 2) continue;
+      const sources = new Set(entries.map(e => e.entry?.source));
+      if (sources.size < 2) continue;
+      for (const { entry: baseEntry, time } of entries){
+        const related = entries
+          .filter(e => e.entry.tripId !== baseEntry.tripId)
+          .filter(e => Math.abs((e.time ?? 0) - (time ?? 0)) <= DEPARTURE_TOLERANCE_SEC)
+          .map(e => ({
+            tripId: e.entry.tripId,
+            source: e.entry.source,
+            displayNumber: e.entry.displayNumber,
+            numberCandidate: e.entry.numberCandidate,
+            normalizedKey: e.entry.normalizedKey,
+            rawNumber: e.entry.rawNumber,
+            digits: e.entry.digits
+          }));
+        registerStaticRelations(baseEntry, related, `depart:${station}`);
       }
     }
   }
@@ -4564,7 +4746,7 @@ function stationNameMatchesKeywords(name, keywords){
 
     for (const t of list){
       seen.add(t.id);
-      const delayInfo = computeTrainDelayInfo(t);
+      const delayInfo = t.delayInfo || computeTrainDelayInfo(t);
       t.delayInfo = delayInfo;
       const labelWithTrain = formatTrainLabel(t, { includeTrainWord:true, fallbackId:t.id });
       const displayName = t.headsign ? `${t.headsign} — ${labelWithTrain}` : labelWithTrain;


### PR DESCRIPTION
## Summary
- record departures per station and compare times to relate cross-border trips sharing the same start
- register those departure-based relations so CFL delay keys propagate even when routes diverge later

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c899d42e8832dbb76aaca96d54c28)