### PR TITLE
Show punctuality for stop stats, tighten chips and improve train chart/table responsiveness

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -4084,7 +4084,7 @@ body.modal-open{ overflow:hidden; }
   max-height:96px;
   overflow:auto;
 }
-.stats-pill{
+  .stats-pill{
   border:1px solid rgba(0,240,255,0.25);
   border-radius:999px;
   padding:6px 10px;
@@ -4094,9 +4094,9 @@ body.modal-open{ overflow:hidden; }
   cursor:pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
-.stats-pill:hover{
-  box-shadow:0 0 10px rgba(0,240,255,0.25);
-}
+  .stats-pill:hover{
+    box-shadow:0 0 10px rgba(0,240,255,0.25);
+  }
 .stats-pill:active{
   transform:scale(0.98);
 }
@@ -4399,7 +4399,7 @@ body.modal-open{ overflow:hidden; }
   .stats-grid-charts,
   .stats-grid-lists{ grid-template-columns:repeat(2,minmax(0,1fr)); }
 }
-  @media (max-width: 720px){
+@media (max-width: 720px){
   .stats-express-grid{
     grid-template-columns:1fr;
   }
@@ -4468,6 +4468,119 @@ body.modal-open{ overflow:hidden; }
     scroll-snap-align:start;
   }
   .stats-canvas{ height:220px; }
+
+  .stats-pill{
+    padding:4px 8px;
+    font-size:0.66rem;
+  }
+
+  .stats-listbox .name{
+    font-size:0.8rem;
+  }
+
+  .stats-listbox .count{
+    font-size:0.68rem;
+  }
+
+  .stats-pills{
+    max-height:120px;
+  }
+}
+
+@media (max-width: 600px){
+  .stats-grid-lists{
+    grid-template-columns:1fr;
+    grid-auto-flow:row;
+    overflow-x:visible;
+    scroll-snap-type:none;
+  }
+  .stats-listbox{
+    min-width:0;
+  }
+}
+
+@media (max-width: 768px){
+  body{
+    padding: 6px;
+    max-width: 100%;
+  }
+
+  #side-panel,
+  #side-panel-left,
+  #retards-panel{
+    display: none !important;
+  }
+
+  #trainInfo table th,
+  #trainInfo table td{
+    font-size: 11px;
+    padding: 4px 4px;
+  }
+
+  #trainInfo table{
+    table-layout: auto;
+  }
+
+  #trainInfo table th,
+  #trainInfo table td{
+    width: 1%;
+    white-space: nowrap;
+  }
+
+  #trainInfo table{
+    box-shadow: 0 0 18px #00f0ff88, 0 0 26px #00ffff88;
+  }
+
+  #trainInfo{
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+  }
+
+  #trainInfo .table-scroll{
+    width: 100vw;
+    border-radius: 10px;
+  }
+
+  #trainInfo table th:first-child,
+  #trainInfo table td:first-child{
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    background: #0b0f1a;
+    box-shadow: 6px 0 10px rgba(0, 240, 255, 0.12);
+    white-space: nowrap;
+    width: 1%;
+    max-width: none;
+  }
+
+  #trainInfo table thead th:first-child{
+    z-index: 3;
+  }
+}
+
+.stats-status-on-time{
+  color: #39f78c;
+  font-weight: 700;
+  text-shadow: 0 0 8px rgba(57,247,140,0.45);
+}
+
+.stats-status-delayed{
+  color: #ff9f43;
+  font-weight: 700;
+  text-shadow: 0 0 8px rgba(255,159,67,0.35);
+}
+
+.stats-status-partial{
+  color: #ffd166;
+  font-weight: 700;
+  text-shadow: 0 0 8px rgba(255,209,102,0.35);
+}
+
+.stats-status-canceled{
+  color: #ff6b6b;
+  font-weight: 700;
+  text-shadow: 0 0 8px rgba(255,107,107,0.45);
 }
     
 </style>
@@ -5200,11 +5313,11 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
           <div class="stats-canvas"><canvas id="statsChStopVolumes"></canvas></div>
         </div>
 
-        <div class="stats-card" style="grid-column:span 6">
-          <div class="head">
-            <div class="title">% pas à l’heure à cet arrêt (par jour)</div>
-            <div class="meta" id="statsStopNotePct">—</div>
-          </div>
+          <div class="stats-card" style="grid-column:span 6">
+            <div class="head">
+              <div class="title">Ponctualité à cet arrêt (par jour)</div>
+              <div class="meta" id="statsStopNotePct">—</div>
+            </div>
           <div class="stats-canvas"><canvas id="statsChStopPct"></canvas></div>
         </div>
       </div>
@@ -5224,7 +5337,7 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
                 <th class="num">Supprimés</th>
                 <th class="num">Partiels</th>
                 <th class="num">Pas à l’heure</th>
-                <th class="num">% pas à l’heure</th>
+                <th class="num">Ponctualité</th>
               </tr>
             </thead>
             <tbody id="statsStopTbody"></tbody>
@@ -12089,19 +12202,43 @@ document.addEventListener('DOMContentLoaded', () => {
     setTrendView(initial);
   }
 
-  function statusFlags(statusRaw){
+  function statusFlags(statusRaw, extra){
     const s = String(statusRaw || "").trim().toUpperCase();
     const isCanceled =
       s === "CANCELED" || s === "CANCELLED" ||
-      s.includes("CANCELED") || s.includes("CANCELLED");
+      s.includes("CANCELED") || s.includes("CANCELLED") ||
+      s.includes("SUPPR") || s.includes("ANNUL");
     const isPartial =
       s === "PARTIAL_CANCELLATION" ||
       s === "PARTIALLY_CANCELED" ||
       s === "PARTIALLY_CANCELLED" ||
       (s.includes("PARTIAL") && (s.includes("CANCEL") || s.includes("CANCELL"))) ||
-      s.includes("PARTIAL_CANCELLATION");
+      s.includes("PARTIAL_CANCELLATION") ||
+      (s.includes("PART") && s.includes("SUPPR"));
     const isDelayedFlag = (s === "DELAYED" || s.includes("DELAY"));
-    return { isCanceled, isPartial, isDelayedFlag, s };
+
+    const extraObj = (extra && typeof extra === "object") ? extra : {};
+    const extraCanceled = Boolean(
+      extraObj.cancelled ||
+      extraObj.canceled ||
+      extraObj.cancel ||
+      extraObj.supprime ||
+      extraObj.suppressed ||
+      extraObj.annule
+    );
+    const extraPartial = Boolean(
+      extraObj.partial ||
+      extraObj.partial_canceled ||
+      extraObj.partial_cancelled ||
+      extraObj.partial_cancellation
+    );
+
+    return {
+      isCanceled: isCanceled || extraCanceled,
+      isPartial: isPartial || extraPartial,
+      isDelayedFlag,
+      s
+    };
   }
 
   function maxDelayFromStops(stops){
@@ -12257,34 +12394,30 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!chTrain){
       chTrain = new Chart($("statsChTrain"), {
-        type: "line",
+        type: "bar",
         data: {
           labels: [],
           datasets: [
             {
               label:"Retard (min)",
               data: [],
-              tension: 0.25,
-              pointRadius: 2,
-              spanGaps: true,
-              borderColor: statsPalette.delayed
+              backgroundColor: statsPalette.delayed,
+              borderColor: statsPalette.delayed,
+              borderWidth: 1
             },
             {
               label:"Supprimé",
               data: [],
-              showLine:false,
-              pointStyle:"cross",
-              pointRadius:6,
+              backgroundColor: statsPalette.canceled,
               borderColor: statsPalette.canceled,
-              backgroundColor: statsPalette.canceled
-
+              borderWidth: 1,
+              minBarLength: 6
             }
           ]
         },
         options: {
           responsive:true,
           maintainAspectRatio:false,
-          parsing: false,
           scales:{
             x:{ grid:{ color: gridColor }, ticks:{ color: tickColor } },
             y:{ beginAtZero:true, grid:{ color: gridColor }, ticks:{ color: tickColor } }
@@ -12293,15 +12426,14 @@ document.addEventListener('DOMContentLoaded', () => {
             tooltip:{
               callbacks:{
                 label: (ctx)=>{
-                  const raw = ctx.raw;
                   if (ctx.dataset?.label === "Supprimé") return "Supprimé";
-                  if (raw == null) return "ANNULÉ — pas de point";
-                  const y = (raw && typeof raw === "object") ? raw.y : raw;
-                  const bucket = raw?.bucket;
-                  const st = raw?.status;
-                  const isPartial = !!raw?.partial;
-                  const star = isPartial ? "*" : "";
-                  let line = `${ctx.dataset.label}: ${fmtInt(y)}${star}`;
+                  if (Number.isNaN(ctx.parsed?.y)) return null;
+                  const y = ctx.parsed?.y;
+                  let line = `${ctx.dataset.label}: ${fmtInt(y)}`;
+                  const bucket = ctx.raw?.bucket;
+                  const st = ctx.raw?.status;
+                  const isPartial = !!ctx.raw?.partial;
+                  if (isPartial) line += " *";
                   if (bucket) line += ` • ${bucket}`;
                   if (st) line += ` • status=${st}`;
                   return line;
@@ -12367,13 +12499,13 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!chStopPct){
       chStopPct = new Chart($("statsChStopPct"), {
         type: "line",
-        data: { labels: [], datasets: [{ label:"% pas à l’heure à l’arrêt", data: [], tension:0.25, pointRadius:2, borderColor: statsPalette.delayed }] },
+        data: { labels: [], datasets: [{ label:"Ponctualité à l’arrêt", data: [], tension:0.25, pointRadius:2, borderColor: statsPalette.onTime }] },
         options: {
           responsive:true,
           maintainAspectRatio:false,
           scales:{
             x:{ grid:{ color: gridColor }, ticks:{ color: tickColor } },
-            y:{ beginAtZero:true, max:100, grid:{ color: gridColor }, ticks:{ color: tickColor } }
+            y:{ beginAtZero:true, max:100, grid:{ color: gridColor }, ticks:{ color: tickColor, callback: (v)=>`${v}%` } }
           }
         }
       });
@@ -12474,7 +12606,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     for (const trainNum of Object.keys(trains)){
       const t = trains[trainNum] || {};
-      const { isCanceled, isPartial, isDelayedFlag } = statusFlags(t.status);
+      const { isCanceled, isPartial, isDelayedFlag } = statusFlags(t.status, t);
       const maxDelay = maxDelayFromStops(t.stops);
       const isDelayed = (!isCanceled && !isPartial) && (isDelayedFlag || maxDelay > 0);
 
@@ -12516,7 +12648,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       total += 1;
 
-      const { isCanceled, isPartial } = statusFlags(t.status);
+      const { isCanceled, isPartial } = statusFlags(t.status, t);
       const delayAtStop = Number(stops[stopName] || 0);
       const isDelayedAtStop = (!isCanceled && !isPartial) && Number.isFinite(delayAtStop) && delayAtStop > 0;
 
@@ -12548,7 +12680,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const t = raw.trains?.[trainId];
     if (!t) return null;
 
-    const { isCanceled, isPartial, isDelayedFlag, s } = statusFlags(t.status);
+    const { isCanceled, isPartial, isDelayedFlag, s } = statusFlags(t.status, t);
 
     let value = 0;
     let hasStop = false;
@@ -12602,7 +12734,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const trains = raw?.trains || {};
       for (const trainNum of Object.keys(trains)){
         const t = trains[trainNum] || {};
-        const { isCanceled, isPartial } = statusFlags(t.status);
+        const { isCanceled, isPartial } = statusFlags(t.status, t);
         const maxDelay = maxDelayFromStops(t.stops);
         const entry = map.get(trainNum) || { trainNo: trainNum, cancelled7: 0, partial7: 0, delayMin7: 0 };
         if (isCanceled) entry.cancelled7 += 1;
@@ -12809,15 +12941,40 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function renderTrain(trainId, optStopName, range){
     const s = range.series || [];
-    const labels = s.map(x=>x.date);
+    const labels = s.map(x => x?.date ?? "");
+
+    if (!s.length) {
+      chTrain.data.labels = [];
+      chTrain.data.datasets[0].data = [];
+      chTrain.data.datasets[1].data = [];
+      chTrain.update();
+      chTrainDonut.data.datasets[0].data = [0, 0, 0, 0];
+      chTrainDonut.update();
+      $("statsTrainChartNote").textContent = "—";
+      $("statsTrainMeta").textContent = "Train " + trainId + " — aucune donnée";
+      $("statsTrainWarn").style.display = "none";
+      $("statsTrainWarn").textContent = "";
+      return;
+    }
 
     const points = s.map(r => {
-      if (r.value == null) return null;
-      return { x: r.date, y: Number(r.value||0), partial: !!r.partial, bucket: r.bucket, status: r.status };
+      if (!r) return { x: "", y: Number.NaN };
+      const b = r?.bucket ?? r?.status ?? "NO_DATA";
+      const y = (b === "CANCELED" || b === "PARTIAL" || b === "NOT_RUNNING" || b === "NO_DATA")
+        ? Number.NaN
+        : (Number.isFinite(Number(r.value)) ? Number(r.value) : Number.NaN);
+      return {
+        x: r.date ?? "",
+        y,
+        bucket: r.bucket,
+        status: r.status,
+        partial: r.partial
+      };
     });
-    const canceledPoints = s
-      .filter(r => r.bucket === "CANCELED")
-      .map(r => ({ x: r.date, y: 0, bucket: r.bucket, status: r.status }));
+    const canceledPoints = s.map(r => {
+      const b = r?.bucket ?? r?.status ?? "NO_DATA";
+      return { x: r?.date ?? "", y: (b === "CANCELED") ? 0 : Number.NaN };
+    });
 
     chTrain.data.labels = labels;
     if (optStopName) {
@@ -12826,14 +12983,16 @@ document.addEventListener('DOMContentLoaded', () => {
       chTrain.data.datasets[0].label = "Retard max (min)";
     }
     chTrain.data.datasets[0].data = points;
+    chTrain.data.datasets[0].hidden = points.every(v => Number.isNaN(v.y));
     chTrain.data.datasets[1].data = canceledPoints;
     chTrain.update();
 
     let on=0, del=0, part=0, can=0;
     for (const r of s){
-      if (r.bucket === "CANCELED") can++;
-      else if (r.bucket === "PARTIAL") part++;
-      else if (r.bucket === "DELAYED") del++;
+      const b = r?.bucket ?? r?.status ?? "NO_DATA";
+      if (b === "CANCELED") can++;
+      else if (b === "PARTIAL") part++;
+      else if (b === "DELAYED") del++;
       else on++;
     }
     chTrainDonut.data.datasets[0].data = [on, del, part, can];
@@ -12849,7 +13008,7 @@ document.addEventListener('DOMContentLoaded', () => {
       $("statsTrainMeta").textContent = "Train " + trainId + " — valeur = retard max";
     }
 
-    const hasPartial = s.some(r => r.bucket === "PARTIAL");
+    const hasPartial = s.some(r => (r?.bucket ?? r?.status ?? "") === "PARTIAL");
     const warn = $("statsTrainWarn");
     if (hasPartial){
       warn.style.display = "block";
@@ -12868,16 +13027,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const tbody = $("statsTrainTbody");
     tbody.innerHTML = "";
+    const statusMap = {
+      ON_TIME: { label: "À l’heure", className: "stats-status-on-time" },
+      DELAYED: { label: "Retard", className: "stats-status-delayed" },
+      PARTIAL: { label: "Partiel *", className: "stats-status-partial" },
+      CANCELED: { label: "Supprimé", className: "stats-status-canceled" }
+    };
     for (const r of s){
-      let star = "";
-      if (r.bucket === "PARTIAL") {
-        star = " *";
-      }
+      const statusInfo = statusMap[r.bucket] || { label: r.bucket, className: "" };
       const tr = document.createElement("tr");
-      const valueCell = (r.value == null) ? "—" : (fmtInt(r.value) + star);
+      let valueCell = (r.value == null) ? "—" : fmtInt(r.value);
+      if (r.bucket === "PARTIAL") {
+        valueCell += " *";
+      }
+      if (r.bucket === "CANCELED") {
+        valueCell = "<span class=\"stats-status-canceled\">Supprimé</span>";
+      }
       tr.innerHTML =
         "<td>" + r.date + "</td>" +
-        "<td>" + r.bucket + "</td>" +
+        "<td class=\"" + statusInfo.className + "\">" + statusInfo.label + "</td>" +
         "<td class=\"num\">" + valueCell + "</td>";
       tbody.appendChild(tr);
     }
@@ -12900,7 +13068,11 @@ document.addEventListener('DOMContentLoaded', () => {
     chStopVolumes.update();
 
     chStopPct.data.labels = labels;
-    chStopPct.data.datasets[0].data = s.map(x=>Number(x.pct_not_on_time || 0));
+    chStopPct.data.datasets[0].data = s.map(x => {
+      const notOnTime = Number(x.pct_not_on_time || 0);
+      const onTime = Math.max(0, 100 - notOnTime);
+      return onTime;
+    });
     chStopPct.update();
 
     $("statsStopMeta").textContent =
@@ -12919,7 +13091,7 @@ document.addEventListener('DOMContentLoaded', () => {
         "<td class=\"num\">" + fmtInt(r.canceled) + "</td>" +
         "<td class=\"num\">" + fmtInt(r.partial) + "</td>" +
         "<td class=\"num\">" + fmtInt(r.not_on_time) + "</td>" +
-        "<td class=\"num\">" + fmtPct(r.pct_not_on_time) + "</td>";
+        "<td class=\"num\">" + fmtPct(100 - Number(r.pct_not_on_time || 0)) + "</td>";
       tbody.appendChild(tr);
     }
     $("statsStopTableCount").textContent =


### PR DESCRIPTION
### Motivation
- Afficher la ponctualité (pourcentage de trains à l’heure) plutôt que le « % pas à l’heure » pour les statistiques d’arrêt afin d’être cohérent avec les autres KPI. 
- Améliorer l’affichage mobile des listes et des chips (taille réduite, empilement en colonne) pour rendre les détails lisibles sur petits écrans. 
- Rendre les graphiques et tableaux liés aux trains plus robustes (bar chart pour les valeurs/cancellations, métadonnées conservées pour les tooltips) et fiabiliser la détection des statuts depuis les enregistrements bruts.

### Description
- Remplacé le libellé et la source de données du graphe `statsChStopPct` pour afficher la `Ponctualité` comme `100 - pct_not_on_time` et ajouté un `y` tick callback pour afficher les pourcentages. 
- Mis à jour le tableau d’arrêts pour remplacer la colonne « % pas à l’heure » par `Ponctualité` et calculer sa valeur via `fmtPct(100 - Number(r.pct_not_on_time || 0))`. 
- Ajusté le CSS pour compacter les `stats-pill`, réduire les tailles de police des éléments de liste et forcer l’empilement/scroll correct des `stats-grid-lists` sur mobile, ainsi que rendre la première colonne de `#trainInfo` sticky et le tableau responsive. 
- Amélioré le rendu des séries train : conversion du graphe train en `bar`, datasets fournis comme objets `{x,y,...meta}` avec série séparée pour `canceled` points, tooltips mis à jour pour utiliser `ctx.parsed?.y` et inclure métadonnées et avertissement de suppression partielle. 
- Étendu `statusFlags` pour accepter un paramètre `extra` (le record) et détecter des variantes/francisations (`SUPPR`, `ANNUL`, etc.) et propriétés additionnelles (`cancelled`, `partial_*`) pour une détection de statut plus robuste, et mis à jour les appels pour transmettre l’enregistrement.

### Testing
- Démarré un serveur statique avec `python -m http.server 8000`, commande lancée et serveur démarré avec succès. 
- Exécuté un script Playwright qui charge `index2.html` et sauvegarde une capture d’écran visuelle, produisant l’artifact `artifacts/index2-stop-punctuality.png` avec succès. 
- Aucun test unitaire automatisé n’a été ajouté.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968890362d4832db431e2f1dae4d4aa)