### PR TITLE
Fix top header as compact app bar and add profile pseudo to bottom nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,155 @@ body {
     max-width: 1200px;
     margin-left: auto;
     margin-right: auto;
+    padding-top: 120px;
+    padding-bottom: 120px;
   }
+
+:root {
+  --app-surface: rgba(10, 16, 26, 0.82);
+  --app-border: rgba(0, 255, 255, 0.16);
+  --app-glow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  --app-accent: #00f0ff;
+}
+
+.dashboard-shell {
+  position: relative;
+  z-index: 1;
+  margin: 10px 0 20px;
+}
+
+.dashboard-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 16px;
+}
+
+.dashboard-card {
+  background: var(--app-surface);
+  border: 1px solid var(--app-border);
+  border-radius: 20px;
+  padding: 18px;
+  box-shadow: var(--app-glow);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 140px;
+}
+
+.dashboard-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #9af7ff;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.dashboard-card p {
+  margin: 0;
+  color: #e6f6ff;
+  line-height: 1.5;
+  font-size: 0.98rem;
+}
+
+.dashboard-pill {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #0b0f1a;
+  background: linear-gradient(135deg, #00f0ff, #00b1ff);
+  box-shadow: 0 10px 25px rgba(0, 240, 255, 0.35);
+}
+
+.dashboard-link {
+  color: var(--app-accent);
+  text-decoration: none;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dashboard-link:hover {
+  text-shadow: 0 0 12px rgba(0, 240, 255, 0.6);
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(960px, 92vw);
+  background: rgba(9, 12, 20, 0.9);
+  border: 1px solid rgba(0, 255, 255, 0.2);
+  border-radius: 26px;
+  padding: 10px 14px;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(18px);
+  z-index: 25;
+}
+
+.bottom-nav a,
+.bottom-nav button {
+  color: #d9f9ff;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.72rem;
+  text-decoration: none;
+  background: none;
+  border: none;
+  padding: 6px 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.bottom-nav a:hover,
+.bottom-nav button:hover {
+  color: #00f0ff;
+}
+
+.bottom-nav .nav-icon {
+  font-size: 1.2rem;
+}
+
+.bottom-nav .nav-meta {
+  font-size: 0.62rem;
+  color: rgba(160, 230, 255, 0.85);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+#home,
+#trainInfo,
+#favTrainsWidget,
+#stats-section {
+  scroll-margin-top: 120px;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 14px;
+    padding-bottom: 110px;
+  }
+
+  .dashboard-card {
+    padding: 16px;
+  }
+
+  .bottom-nav {
+    bottom: 12px;
+    width: min(96vw, 680px);
+  }
+}
     /* Fond futuriste dynamique style TRON */
 body::before {
   content: "";
@@ -3356,6 +3504,104 @@ body.modal-open{ overflow:hidden; }
   box-shadow: inset 0 0 14px rgba(0,220,255,.12);
 }
 
+/* ======= TOP BAR APP ======= */
+.header-container.hero-compact{
+  position: fixed;
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(960px, 92vw);
+  min-height: auto;
+  padding: 10px 14px;
+  border-radius: 26px;
+  background: rgba(9, 12, 20, 0.92);
+  border: 1px solid rgba(0, 255, 255, 0.22);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(18px);
+  z-index: 30;
+}
+
+.header-container.hero-compact::after{
+  opacity: 0.4;
+}
+
+.hero-compact .hero-inner{
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hero-compact .logo-container{
+  position: static;
+  transform: none;
+}
+
+.hero-compact .logo-container img{
+  height: 52px;
+  max-height: 52px;
+}
+
+.hero-compact .hero-title{
+  position: static;
+  transform: none;
+  max-width: 60%;
+  row-gap: 0;
+}
+
+.hero-compact .hero-heading{
+  width: clamp(220px, 36vw, 420px);
+}
+
+.hero-compact .hero-sub{
+  padding: 4px 18px;
+  font-size: 0.78rem;
+}
+
+.hero-compact .auth-actions{
+  position: static;
+  transform: none;
+  min-width: 120px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.hero-compact .auth-button{
+  padding: 8px 12px;
+  font-size: 0.85rem;
+  border-radius: 14px;
+}
+
+@media (max-width: 720px){
+  .header-container.hero-compact{
+    top: 12px;
+    width: min(96vw, 680px);
+    padding: 8px 12px;
+  }
+
+  .hero-compact .hero-inner{
+    min-height: 64px;
+  }
+
+  .hero-compact .logo-container img{
+    height: 44px;
+  }
+
+  .hero-compact .hero-title{
+    max-width: 55%;
+  }
+
+  .hero-compact .hero-sub{
+    display: none;
+  }
+
+  .hero-compact .auth-button{
+    padding: 7px 10px;
+    font-size: 0.78rem;
+  }
+}
+
 .lb-auth-modal{
   position: fixed;
   inset: 0;
@@ -5110,7 +5356,7 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
   </div>
 </div>
 <!-- Bandeau supérieur TRON (compact, sans vidéo) -->
-<div class="header-container hero-compact">
+<div id="home" class="header-container hero-compact">
   <div class="hero-inner">
     <!-- Logo (à gauche) -->
     <div class="logo-container">
@@ -5374,6 +5620,23 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
       <div id="lbPrefsMsg" class="lb-auth-msg"></div>
     </div>
   </div>
+
+<section id="homeDashboard" class="dashboard-shell" aria-label="Tableau d'accueil">
+  <div class="dashboard-row">
+    <article class="dashboard-card">
+      <span class="dashboard-pill">🌤️ Météo</span>
+      <h3>Infos météo par gare</h3>
+      <p>Retrouve la météo directement dans les tableaux trains pour chaque arrêt. C’est le même service, mais avec un accès rapide depuis l’accueil.</p>
+      <a class="dashboard-link" href="#trainInfo">Voir la météo par gare →</a>
+    </article>
+    <article class="dashboard-card">
+      <span class="dashboard-pill">👋 Bienvenue</span>
+      <h3>Bienvenue dans La Bétaillère</h3>
+      <p>Accède à tes bétaillères favorites, lance une génération rapide et garde un œil sur les stats, le tout dans une interface plus mobile.</p>
+      <a class="dashboard-link" href="#favTrainsWidget">Aller aux favoris →</a>
+    </article>
+  </div>
+</section>
 
 <!-- Widget Favoris Matin / Soir (visible si connecté) -->
 <section id="favTrainsWidget" class="fav-widget" style="display:none; position:relative; z-index:2;">
@@ -15786,6 +16049,11 @@ function getGtfsDelayForStop(trainNumber, stopName){
 
   let lbIsAuthed = false;
   window.lbIsAuthed = false;
+  const updatePseudoDisplay = (label) => {
+    const pseudoEl = document.getElementById('lbPseudoDisplay');
+    if (!pseudoEl) return;
+    pseudoEl.textContent = label || 'Invité';
+  };
   const refreshAccountUI = async () => {
     const openBtn = $("lbBtnOpenAuth");
     const logoutBtn = $("lbBtnLogout");
@@ -15802,6 +16070,9 @@ function getGtfsDelayForStop(trainNumber, stopName){
       const me = await api("/me");
       lbIsAuthed = true;
       window.lbIsAuthed = true;
+      const rawName = me?.user?.pseudo || me?.user?.username || me?.user?.email || '';
+      const fallbackName = rawName ? String(rawName).split('@')[0] : 'Mon profil';
+      updatePseudoDisplay(fallbackName);
       if (typeof window.updateStatsConsoleAuth === "function") {
         window.updateStatsConsoleAuth(true);
       }
@@ -15829,6 +16100,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
       if (authSwitch) authSwitch.style.display = "grid";
       if (contactBtn) contactBtn.style.display = "none";
       if (deleteLinkWrap) deleteLinkWrap.style.display = "none";
+      updatePseudoDisplay('Invité');
       const prefsModal = $("lbPrefsModal");
       if (prefsModal) {
         prefsModal.style.display = "none";
@@ -15891,6 +16163,17 @@ function getGtfsDelayForStop(trainNumber, stopName){
   closeBtn.addEventListener("click", closeModal);
   modal.addEventListener("click", (e) => {
     if (e.target === modal) closeModal();
+  });
+
+  document.querySelectorAll('[data-profile-open]').forEach((trigger) => {
+    trigger.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (prefsBtn && prefsBtn.style.display !== 'none') {
+        prefsBtn.click();
+        return;
+      }
+      openBtn.click();
+    });
   });
 
   submitBtn.addEventListener("click", async () => {
@@ -16537,6 +16820,30 @@ function getGtfsDelayForStop(trainNumber, stopName){
   }
 })();
 </script>
+
+<nav class="bottom-nav" aria-label="Navigation principale">
+  <a href="#home">
+    <span class="nav-icon" aria-hidden="true">🏠</span>
+    <span>Accueil</span>
+  </a>
+  <a href="#trainInfo">
+    <span class="nav-icon" aria-hidden="true">🗺️</span>
+    <span>Trains</span>
+  </a>
+  <a href="#favTrainsWidget">
+    <span class="nav-icon" aria-hidden="true">⭐</span>
+    <span>Favoris</span>
+  </a>
+  <a href="#stats-section">
+    <span class="nav-icon" aria-hidden="true">📊</span>
+    <span>Stats</span>
+  </a>
+  <button type="button" data-profile-open>
+    <span class="nav-icon" aria-hidden="true">👤</span>
+    <span>Profil</span>
+    <span class="nav-meta" id="lbPseudoDisplay">Invité</span>
+  </button>
+</nav>
 
 
 <!-- ===================== LIVE (GTFS-RT + VOIES) ===================== -->


### PR DESCRIPTION
### Motivation
- Make the top header match the new bottom app-style navigation so the UI is compact and consistent on desktop and mobile.
- Reserve a small profile/pseudo area (for future chat and preferences) and provide a direct shortcut to preferences from the bottom nav.
- Prevent content overlap by adding spacing for the fixed header.

### Description
- CSS: add compact fixed top-bar styles (`.header-container.hero-compact`) and small UI tokens (`.bottom-nav .nav-meta`) and increase `body` top/bottom padding to account for fixed bars and `scroll-margin-top` for anchor targets.
- HTML: add `id="home"` to the header container and insert a `#homeDashboard` section with two `dashboard-card` items (weather / welcome) for quick mobile-first access.
- Navigation: add a profile entry in the bottom navigation with a pseudo display element (`id="lbPseudoDisplay"`) and change the profile button attribute from `data-auth-open` to `data-profile-open`.
- JS: add `updatePseudoDisplay(label)` and update `refreshAccountUI()` to set the displayed pseudo on login/logout; wire `[data-profile-open]` clicks to open preferences when available (fallback to auth modal).

All changes are contained in `index.html` (styles, markup and inline scripts).

### Testing
- Started a local static server with `python -m http.server 8000` and confirmed it served the site successfully.
- Ran a Playwright script that loads `http://127.0.0.1:8000/index.html` and captured a full-page screenshot saved as `artifacts/topbar-bottomnav.png`, which completed successfully.
- No backend or automated integration tests were run as changes are client-side HTML/CSS/JS only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971d71c290c832dbd6a9deba8813f68)