### PR TITLE
Add fixed top bar, mobile bottom navigation and homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,15 +23,20 @@
   
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
   <style>
+:root {
+  --top-bar-height: 64px;
+  --bottom-nav-height: 78px;
+}
+
 body {
   font-family: 'Orbitron', sans-serif;
   background: #0b0f1a;
   color: #e0f0ff;
   margin: 0;
-    padding: 20px;
-    max-width: 1200px;
-    margin-left: auto;
-    margin-right: auto;
+  padding: calc(var(--top-bar-height) + 16px) 20px calc(var(--bottom-nav-height) + 24px);
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
   }
     /* Fond futuriste dynamique style TRON */
 body::before {
@@ -55,6 +60,121 @@ body[data-snapshotting="true"]::before {
   content: none !important;
   display: none !important;
 }   
+
+/* Barre haute fixe */
+.top-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--top-bar-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 18px;
+  background: linear-gradient(120deg, rgba(7, 20, 34, 0.96), rgba(7, 36, 54, 0.92));
+  border-bottom: 1px solid rgba(0, 240, 255, 0.35);
+  box-shadow: 0 6px 18px rgba(0, 240, 255, 0.12);
+  z-index: 1600;
+  backdrop-filter: blur(8px);
+}
+
+.top-bar__title {
+  font-size: 1.2rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #bff8ff;
+  text-shadow: 0 0 8px rgba(0, 240, 255, 0.55);
+}
+
+.top-bar__subtitle {
+  margin-left: 12px;
+  font-size: 0.85rem;
+  color: rgba(200, 240, 255, 0.75);
+  text-transform: uppercase;
+}
+
+@media (max-width: 640px) {
+  .top-bar {
+    justify-content: center;
+    text-align: center;
+    gap: 6px;
+  }
+  .top-bar__title {
+    font-size: 1rem;
+  }
+  .top-bar__subtitle {
+    display: none;
+  }
+}
+
+/* Accueil */
+.home-section {
+  margin: 24px 0 36px;
+  padding: 24px;
+  border-radius: 22px;
+  background: linear-gradient(145deg, rgba(10, 22, 34, 0.9), rgba(8, 16, 28, 0.88));
+  border: 1px solid rgba(0, 240, 255, 0.2);
+  box-shadow: 0 0 18px rgba(0, 240, 255, 0.2);
+  position: relative;
+  z-index: 1;
+}
+
+.home-hero {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.home-hero h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #00f0ff;
+  text-shadow: 0 0 12px rgba(0, 240, 255, 0.55);
+}
+
+.home-hero p {
+  margin: 0;
+  line-height: 1.6;
+  color: #d3ecff;
+}
+
+.home-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.home-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.home-card {
+  background: rgba(8, 18, 28, 0.9);
+  border-radius: 18px;
+  padding: 18px;
+  border: 1px solid rgba(0, 240, 255, 0.2);
+  box-shadow: inset 0 0 14px rgba(0, 240, 255, 0.15);
+}
+
+.home-card h3 {
+  margin: 0 0 10px;
+  font-size: 1.1rem;
+  color: #8ff7ff;
+}
+
+.home-card ul {
+  margin: 0;
+  padding-left: 18px;
+  line-height: 1.6;
+}
+
+.home-card p {
+  margin: 0;
+  color: rgba(210, 235, 255, 0.9);
+}
     
 /* Conteneur principal futuriste */
 .header-container {
@@ -1731,10 +1851,10 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
 /* ---------------------- Panneau général ---------------------- */
 #side-panel {
   position: fixed;
-  top: 0;
+  top: var(--top-bar-height);
   right: -300px;
   width: 300px;
-  height: 100%;
+  height: calc(100% - var(--top-bar-height));
   background: #0b0f1a;
   color: #0ff;
   transition: right 0.3s ease-in-out;
@@ -1749,76 +1869,84 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   right: 0;
 }
 
-/* Barre onglets */
+/* Menu bas (onglets en icônes) */
 #tabs {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: var(--bottom-nav-height);
   display: flex;
   align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 10px;
-  padding: 12px 16px 10px;
-  margin: 18px 18px 8px;
-  background: linear-gradient(140deg, rgba(0, 26, 40, 0.4), rgba(0, 12, 26, 0.32));
-  border-radius: 22px;
-  border: 1px solid rgba(0, 240, 255, 0.2);
-  box-shadow: inset 0 0 12px rgba(0, 240, 255, 0.12);
+  justify-content: space-around;
+  gap: 12px;
+  padding: 10px 16px 14px;
+  background: linear-gradient(140deg, rgba(6, 18, 30, 0.96), rgba(8, 30, 46, 0.92));
+  border-top: 1px solid rgba(0, 240, 255, 0.35);
+  box-shadow: 0 -6px 18px rgba(0, 240, 255, 0.2);
+  z-index: 1500;
 }
 
-#side-panel .tab {
-  display: inline-flex;
+#tabs .tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 8px 16px;
+  gap: 4px;
+  padding: 8px 10px;
   margin: 0;
   min-width: 0;
   max-width: none;
+  width: auto;
   text-align: center;
   text-transform: none;
   letter-spacing: 0.02em;
-  font-size: 0.9rem;
+  font-size: 0.78rem;
   font-weight: 700;
   color: #cfffff;
-  background: linear-gradient(135deg, rgba(0, 25, 35, 0.9), rgba(0, 12, 24, 0.78));
-  border: 1px solid rgba(0, 255, 255, 0.35);
-  border-radius: 999px;
-  box-shadow: 0 0 12px rgba(0, 255, 255, 0.22);
+  background: rgba(4, 16, 26, 0.6);
+  border: 1px solid rgba(0, 255, 255, 0.2);
+  border-radius: 14px;
+  box-shadow: none;
   cursor: pointer;
   transition: transform 0.12s ease, box-shadow 0.2s ease, border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
 }
 
-#side-panel .tab:hover {
+#tabs .tab .tab-icon {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+#tabs .tab:hover {
   border-color: #00ffff;
   color: #ffffff;
-  box-shadow: 0 0 20px rgba(0, 255, 255, 0.32), inset 0 0 10px rgba(0, 255, 255, 0.18);
+  box-shadow: 0 0 14px rgba(0, 255, 255, 0.2);
 }
-  
-#side-panel .tab:active {
+
+#tabs .tab:active {
   transform: translateY(1px) scale(0.99);
 }
 
-#side-panel .tab.active {
+#tabs .tab.active {
   border-color: #00ffff;
   color: #ffffff;
-  box-shadow: 0 0 22px rgba(0, 255, 255, 0.42), inset 0 0 14px rgba(0, 255, 255, 0.24);
   background: linear-gradient(135deg, rgba(0, 40, 55, 0.92), rgba(0, 18, 32, 0.82));
+  box-shadow: 0 0 18px rgba(0, 255, 255, 0.3);
 }
 
-#side-panel .tab:focus-visible {
+#tabs .tab:focus-visible {
   outline: 2px solid rgba(0, 240, 255, 0.9);
   outline-offset: 2px;
 }
 
 @media (max-width: 480px) {
   #tabs {
-    margin: 14px 12px 6px;
-    padding: 10px 12px 8px;
+    padding: 10px 12px 12px;
     gap: 8px;
   }
-
-  #side-panel .tab {
-    padding: 7px 12px;
-    font-size: 0.82rem;
+  #tabs .tab {
+    font-size: 0.72rem;
   }
 }
 
@@ -1866,10 +1994,10 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
 /* ---------------------- Panneau latéral gauche ---------------------- */
 #side-panel-left {
   position: fixed;
-  top: 0;
+  top: var(--top-bar-height);
   left: -300px; /* caché par défaut */
   width: 300px;
-  height: 100%;
+  height: calc(100% - var(--top-bar-height));
   background: rgba(0,0,0,0.85);
   border-right: 2px solid #0ff;
   box-shadow: 2px 0 10px rgba(0,255,255,0.5);
@@ -5070,6 +5198,11 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
 </head>
 <body>
 
+<header class="top-bar">
+  <div class="top-bar__title">La Bétaillère</div>
+  <div class="top-bar__subtitle">BER Nancy/Metz • Luxembourg</div>
+</header>
+
 <div id="gtfsLoadingOverlay" class="is-hidden" aria-hidden="true" role="status" aria-live="polite">
   <div class="gtfs-loading-box">
     <div class="gtfs-spinner" aria-hidden="true"></div>
@@ -5212,6 +5345,34 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
 </div>
 
   </div>
+  <section id="home" class="home-section">
+    <div class="home-hero">
+      <h2>Bienvenue sur la Bétaillère</h2>
+      <p>Une page d’accueil simple, pensée pour mobile : accède vite aux bétaillères favorites, aux infos trafic et à ton espace de connexion.</p>
+      <div class="home-actions">
+        <button class="auth-button" type="button" data-open-auth>Se connecter</button>
+        <a class="auth-button auth-button--ghost" href="#selection-betail">Lancer une sélection rapide</a>
+      </div>
+    </div>
+    <div class="home-grid">
+      <article class="home-card">
+        <h3>⭐ Tes favorites</h3>
+        <ul>
+          <li>Matin : BER Nancy → Metz → Luxembourg</li>
+          <li>Soir : Luxembourg → Thionville → Metz</li>
+          <li>Alertes directes sur tes numéros favoris</li>
+        </ul>
+      </article>
+      <article class="home-card">
+        <h3>🔐 Espace de connexion</h3>
+        <p>Connecte-toi pour sauvegarder tes listes, activer le chargement automatique et retrouver tes favoris sur tous tes appareils.</p>
+      </article>
+      <article class="home-card">
+        <h3>📍 Accès rapides</h3>
+        <p>Utilise le menu en bas pour ouvrir le trafic trains ou bus/tram en un geste. Tout reste lisible, même sur petit écran.</p>
+      </article>
+    </div>
+  </section>
   <div id="lbAuthModal" class="lb-auth-modal" aria-hidden="true">
     <div class="lb-auth-card" role="dialog" aria-modal="true" aria-labelledby="lbAuthTitle">
       <button id="lbBtnCloseAuth" class="lb-auth-close tron-close-button" type="button" aria-label="Fermer"></button>
@@ -5421,7 +5582,7 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
 
 
 <!-- Console de Commande -->
-<div class="command-console">
+<div class="command-console" id="selection-betail">
   <div class="console-header"> Console de Commande – Sélection des Bétaillères</div>
 
   <!-- 1) GÉNÉRATION RAPIDE -->
@@ -6123,12 +6284,6 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
   <!-- Poignée verticale -->
   <button id="toggle-btn">Trafic 🇱🇺</button>
 
-  <!-- Onglets -->
-  <div id="tabs">
-    <button class="tab active" data-tab="trains">Trains</button>
-    <button class="tab" data-tab="bustram">Bus/Tram</button>
-  </div>
-
   <!-- Contenu des onglets -->
   <div id="trains" class="tab-content active">
     <h2>Trains</h2>
@@ -6165,6 +6320,17 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
     </div>
   </div>
 </div>
+
+<nav id="tabs" aria-label="Navigation rapide">
+  <button class="tab active" type="button" data-tab="trains" aria-controls="trains">
+    <span class="tab-icon" aria-hidden="true">🚆</span>
+    <span class="tab-label">Trains</span>
+  </button>
+  <button class="tab" type="button" data-tab="bustram" aria-controls="bustram">
+    <span class="tab-icon" aria-hidden="true">🚌</span>
+    <span class="tab-label">Bus/Tram</span>
+  </button>
+</nav>
 
     <!-- Modale plein écran pour isoler le tableau -->
 <div id="tableModal" class="table-modal" aria-hidden="true">
@@ -14177,6 +14343,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const panel = document.getElementById("side-panel");
   const btn = document.getElementById("toggle-btn");
   const cflToggle = document.getElementById('includeCFLStatic');
+  const authTrigger = document.getElementById('lbBtnOpenAuth');
 
   if (cflToggle) {
     cflToggle.addEventListener('change', () => {
@@ -14185,7 +14352,15 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // ouverture / fermeture panneau
-  btn.addEventListener("click", () => panel.classList.toggle("open"));
+  if (btn && panel) {
+    btn.addEventListener("click", () => panel.classList.toggle("open"));
+  }
+
+  document.querySelectorAll('[data-open-auth]').forEach(trigger => {
+    trigger.addEventListener('click', () => {
+      authTrigger?.click();
+    });
+  });
 
   // navigation onglets
   document.querySelectorAll(".tab").forEach(tab => {
@@ -14194,6 +14369,7 @@ document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll(".tab-content").forEach(c => c.classList.remove("active"));
       tab.classList.add("active");
       document.getElementById(tab.dataset.tab).classList.add("active");
+      panel?.classList.add("open");
     });
   });
 


### PR DESCRIPTION
### Motivation
- Simplify mobile UX by converting side tabs into a compact bottom icon menu and providing a fixed full-width top title bar. 
- Provide a clear, mobile-first landing area with a welcome message, favorites summary and a login CTA to guide users. 
- Keep existing functionality (side panels, selection console, favorites) accessible while improving layout and touch ergonomics.

### Description
- Added CSS variables for header/footer sizing and implemented a fixed top bar (`.top-bar`) with title/subtitle and layout spacing adjustments in `index.html`. 
- Introduced a fixed bottom navigation (`#tabs`) with icon-style tab buttons and moved the tab controls from the side panel into this bottom nav, plus responsive styles for small screens. 
- Added a new home section (`#home` / `.home-section`) containing welcome text, favorites summary, login CTA and a quick link to the selection console. 
- Updated JS to wire the home login CTA (`data-open-auth`) to trigger the existing auth modal and to ensure tab clicks open the traffic side panel; also moved side panels down to account for the fixed top bar and added an anchor id `selection-betail` to the selection console.

### Testing
- Launched a local HTTP server and used Playwright to render the page at a mobile viewport (`390x844`) and capture a screenshot; screenshot was produced at `artifacts/home-mobile.png` successfully. 
- Verified the top bar and bottom navigation appear and that the home login CTA triggers the auth modal in the automated rendering. 
- No additional automated unit tests were required for these static HTML/CSS/JS changes and the visual check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69789c17d104832d8f64737cd3365f3c)