### PR TITLE
Compact manual selection with bétaillère styling; sticky column and reduced-seat alert detection

### DIFF
--- a/index1.html
+++ b/index1.html
@@ -1395,6 +1395,17 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   border-color:transparent !important; 
   box-shadow:none !important;
 } 
+ .train-header.reduced-seats,
+ .reduced-seats {
+  color: #bf00ff;
+  text-shadow: 0 0 5px #bf00ff, 0 0 10px #8000ff;
+ }
+ .reduced-seat-icon{
+  color: #bf00ff;
+  text-shadow: 0 0 4px rgba(191,0,255,.75);
+  display: block;
+  margin-top: 2px;
+ }
   /* Compo inconnue : texte blanc, aucun fond */
 .train-header.no-compo-text{
   color: #fff !important;     /* texte blanc uniquement */
@@ -1502,7 +1513,7 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
 }
 
     
-  #alertes {
+#alertes {
   display: none; /* caché au départ */
   margin: 20px 0;
   max-width: 960px;
@@ -1519,6 +1530,27 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   gap: 14px;
   font-size: 1.1rem;
   position: relative;
+}
+
+.alertes-disruptions-row{
+  display: flex;
+  gap: 16px;
+  align-items: stretch;
+  flex-wrap: wrap;
+  margin: 20px 0 32px;
+}
+
+.alertes-disruptions-row #disruptionsSummary,
+.alertes-disruptions-row #alertes{
+  margin: 0;
+  max-width: none;
+  flex: 1 1 360px;
+}
+
+@media (max-width: 900px){
+  .alertes-disruptions-row{
+    flex-direction: column;
+  }
 }
 
 #alertes .alertes-header {
@@ -1643,6 +1675,19 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   margin-top: 8px;
   border: 1px solid #00f0ff33;
   border-radius: 8px;
+}
+
+#trainInfo table th:first-child,
+#trainInfo table td:first-child{
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background: #0b0f1a;
+  box-shadow: 6px 0 10px rgba(0, 240, 255, 0.12);
+}
+
+#trainInfo table thead th:first-child{
+  z-index: 3;
 }
 
 .table-toolbar{
@@ -2494,25 +2539,49 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
 }
 
 /* ===== Sélecteur manuel compact (input + Ajouter + Vider sur la même ligne) ===== */
+#selectionBlock .selection-manual-card{
+  margin:8px 0 10px;
+  padding:10px 12px;
+  border-radius:12px;
+  border:1px solid rgba(0,255,255,0.2);
+  background:linear-gradient(180deg, rgba(0,18,30,0.65), rgba(0,12,20,0.45));
+  box-shadow: inset 0 0 12px rgba(0,255,255,0.08);
+}
+#selectionBlock .selection-manual-card__title{
+  font-size:0.85rem;
+  font-weight:700;
+  color:#9ffcff;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+  margin-bottom:6px;
+  display:flex;
+  align-items:center;
+  gap:6px;
+}
+#selectionBlock .selection-manual-card__hint{
+  margin-top:6px;
+  font-size:0.78rem;
+  color:rgba(191,245,255,0.8);
+}
 #selectionBlock .chips-manual{
   display:flex;
   align-items:center;
   gap:8px;
-  margin:6px 0 4px;
+  margin:4px 0 0;
   flex-wrap:nowrap;              /* tout sur une ligne autant que possible */
-  padding:0 12px;                /* aligne avec la grille */
+  padding:0;                     /* compact */
 }
 #selectionBlock .chips-manual input{
   flex:1 1 auto;
   min-width:0;
-  padding:8px 10px;
+  padding:7px 10px;
   border-radius:10px;
   background:#0b1325;
   color:#00f0ff;
   border:1px solid #00f0ff55;
   box-shadow:0 0 6px #00f0ff44 inset;
   font-family:'Orbitron', sans-serif;
-  font-size:1rem;
+  font-size:0.95rem;
 }
 
 /* (optionnel) wrapper si tu l’utilises dans le HTML */
@@ -4775,12 +4844,19 @@ body.modal-open{ overflow:hidden; }
   }
 
   #trainInfo table{
-    table-layout: auto;
+    table-layout: fixed;
+    width: max-content;
+    min-width: 100%;
+    overflow: visible;
+    border-collapse: separate;
+    border-spacing: 0;
   }
 
   #trainInfo table th,
   #trainInfo table td{
-    width: 1%;
+    width: 56px;
+    min-width: 56px;
+    max-width: 72px;
     white-space: nowrap;
   }
 
@@ -4801,14 +4877,15 @@ body.modal-open{ overflow:hidden; }
 
   #trainInfo table th:first-child,
   #trainInfo table td:first-child{
+    width: 130px;
+    min-width: 130px;
+    max-width: 160px;
     position: sticky;
     left: 0;
     z-index: 2;
     background: #0b0f1a;
     box-shadow: 6px 0 10px rgba(0, 240, 255, 0.12);
     white-space: nowrap;
-    width: 1%;
-    max-width: none;
   }
 
   #trainInfo table thead th:first-child{
@@ -6933,12 +7010,16 @@ td{font-size:.92rem;}
           <div class="chips-count"><span id="selCount">0</span> sélection(s)</div>
         </div>
         
-        <div class="chips-manual">
-          <input id="manualTrainInput" type="text" inputmode="numeric" pattern="\d{5,6}" placeholder="Ajouter un n° (ex : 88532)">
-          <div class="manual-actions">
-            <button id="btnAddTrain" class="btn btn-compact" type="button">+ Ajouter</button>
-            <button id="btnClearSelection" class="btn btn-compact ghost" type="button" title="Vider la sélection">🧹 Vider</button>
+        <div class="selection-manual-card">
+          <div class="selection-manual-card__title">🐮 Saisie rapide</div>
+          <div class="chips-manual">
+            <input id="manualTrainInput" type="text" inputmode="numeric" pattern="\d{5,6}" placeholder="N° train (5-6 chiffres)">
+            <div class="manual-actions">
+              <button id="btnAddTrain" class="btn btn-compact" type="button">Ajouter</button>
+              <button id="btnClearSelection" class="btn btn-compact ghost" type="button" title="Vider la sélection">🧹 Vider</button>
+            </div>
           </div>
+          <div class="selection-manual-card__hint">Astuce : ajoute plusieurs trains en les saisissant un par un.</div>
         </div>
         
         <div id="selectionChips" aria-live="polite"></div>
@@ -6979,10 +7060,14 @@ td{font-size:.92rem;}
   </div>
 </div>
   
-<!-- BLOC 1 : Perturbations -->
-<div id="disruptionsSummary" class="command-console" style="display:none;">
-  <div class="disruption-header">Perturbations en cours</div>
-  <div id="disruptionsContent"></div>
+<!-- BLOC 1 : Perturbations + Informations -->
+<div class="alertes-disruptions-row">
+  <div id="disruptionsSummary" class="command-console" style="display:none;">
+    <div class="disruption-header">Perturbations en cours</div>
+    <div id="disruptionsContent"></div>
+  </div>
+
+  <div id="alertes" style="display:none;"></div>
 </div>
 
 <!-- BLOC 2 : Infos trains -->
@@ -6991,9 +7076,6 @@ td{font-size:.92rem;}
 <div id="refreshContainer" style="display:none; text-align:center; margin:18px 0;">
   <button id="refreshButton" class="refresh-btn">Actualiser les données</button>
 </div>
-
-<!-- BLOC 3 : Alertes générales -->
-<div id="alertes" style="display:none;"></div>
 
    <div style="font-size: 0.9em; line-height: 1.6; border-top: 1px solid #ccc; margin-top: 1em; padding-top: 0.5em;"></div>
   
@@ -13569,14 +13651,17 @@ async function chargerEtAfficherAlertes() {
 
       // 3) Rendu : titre + “trains concernés” (uniquement nos trains affichés)
       alertesFiltres.forEach(alerte => {
-        const effetCode = Number(alerte.effect);
-        const styleMeta = getStyleParCauseCode(effetCode);
+        const effetCode = Number.parseInt(alerte.effect, 10);
+        const causeCode = Number.parseInt(alerte.cause, 10);
+        const code = Number.isFinite(effetCode) ? effetCode : causeCode;
+        const styleMeta = getStyleParCauseCode(code);
 
         const titre = (alerte.header_text || styleMeta.label).trim();
         const description = stripHtml(alerte.description_text || '');
+        const reductionKeywords = /réduction\s+du\s+nombre\s+de\s+places\s+assises|reduction\s+du\s+nombre\s+de\s+places\s+assises/i;
+        const isReducedSeats = code === 2 || reductionKeywords.test(titre) || reductionKeywords.test(description);
 
-        const trainsCibles = Array.from(new Set(
-          (alerte.informed_entities || []).map(ent => {
+        const trainsFromEntities = (alerte.informed_entities || []).map(ent => {
             // 1) trip structuré → on cherche le n° de train depuis GTFS
             const tripId = ent.trip_id || ent.vehicle_journey_id || null;
             if (tripId && sets.tripIds.has(tripId)) {
@@ -13588,17 +13673,44 @@ async function chargerEtAfficherAlertes() {
             const blob = [ent.name, ent.trip_id, ent.vehicle_journey_id, ent.route_id].filter(Boolean).join(' ');
             const num2 = extractTrainNumber(blob);
             return (num2 && sets.displayedNums.has(num2)) ? num2 : null;
-          }).filter(Boolean)
-        ));
+          }).filter(Boolean);
+
+        const trainsFromText = [];
+        if (!trainsFromEntities.length) {
+          const textBlob = `${titre} ${description}`;
+          const numFromText = extractTrainNumber(textBlob);
+          if (numFromText && sets.displayedNums.has(numFromText)) {
+            trainsFromText.push(numFromText);
+          }
+        }
+
+        const trainsCibles = Array.from(new Set([...trainsFromEntities, ...trainsFromText]));
 
         // hint visuel “US” si effect=2 et si train affiché
         const targetsDisplayed = trainsCibles.filter(n => sets.displayedNums.has(n));
-        if (effetCode === 2 && targetsDisplayed.length){
+        const findHeaderByNumber = (numeroTrain) => {
+          const normalized = extractTrainNumber(numeroTrain);
+          if (!normalized) return null;
+          return Array.from(document.querySelectorAll('th[data-train-number]'))
+            .find(th => extractTrainNumber(th.dataset.trainNumber || '') === normalized) || null;
+        };
+        if (isReducedSeats && targetsDisplayed.length){
           targetsDisplayed.forEach(numeroTrain => {
-            const header = document.querySelector(`th[data-train-number="${numeroTrain}"]`);
+            const header = findHeaderByNumber(numeroTrain);
             if (header) {
-              header.classList.add('us-train');
+              header.classList.add('reduced-seats');
               header.title = "Service réduit : réduction du nombre de places (UM ➜ US)";
+              const headRow = header.parentElement;
+              const index = headRow ? Array.from(headRow.children).indexOf(header) : -1;
+              const iconRow = header.closest('thead')?.querySelector('tr:nth-child(2)');
+              const iconCell = iconRow && index >= 0 ? iconRow.children[index] : null;
+              if (iconCell && !iconCell.querySelector('.reduced-seat-icon')) {
+                const iconSpan = document.createElement('span');
+                iconSpan.className = 'icon reduced-seat-icon';
+                iconSpan.textContent = styleMeta.icone || '⚠️';
+                iconSpan.title = "Service réduit : réduction du nombre de places";
+                iconCell.appendChild(iconSpan);
+              }
             }
           });
         }


### PR DESCRIPTION
### Motivation
- Simplify and densify the manual train selection UI to follow common compact patterns while keeping the "bétaillère" visual identity. 
- Make the first table column behave like desktop on mobile so station names remain visible while horizontally scrolling. 
- Detect and highlight alerts that imply a reduction of seats and surface a small icon on affected train headers for clearer UX.

### Description
- UI/HTML: Replace the inline manual selection block with a `selection-manual-card` wrapper containing a titled compact input, action buttons and a short hint; move `#alertes` to sit beside `#disruptionsSummary` inside a new `.alertes-disruptions-row` container so alerts and disruptions can be shown side-by-side on wide viewports. 
- CSS: Add styles for `.selection-manual-card` (compact spacing, card background, hint), tighten paddings and font-size for the manual input, and add rules to allow sticky first-column behavior (`position: sticky`, `border-collapse: separate`, `table-layout: fixed`, explicit mobile column widths) plus styles for `.reduced-seats` and `.reduced-seat-icon`. 
- JS: Improve alert processing in `chargerEtAfficherAlertes` by parsing `effect`/`cause` with `Number.parseInt`, collecting train numbers from `informed_entities` and fallback text, applying a `reduced-seats` class and appending a `.reduced-seat-icon` to matching header cells when an alert implies reduced seating, and a small helper `findHeaderByNumber` is used to robustly find headers.

### Testing
- Started a local server with `python -m http.server 8000` to serve `index1.html` and visually inspect the changes, which succeeded. 
- Ran a Playwright script that opened `http://127.0.0.1:8000/index1.html` and captured a full-page screenshot, producing `artifacts/manual-selection-compact.png` successfully. 
- No automated unit tests were added or run beyond the visual screenshot verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b003cc3a0832da681b5f96ccfa311)