### PR TITLE
Simplify manual selection UI for search

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -3164,6 +3164,95 @@ body.modal-open{ overflow:hidden; }
   font-size:.9rem;
   color:#cfffff;
 }
+.manual-compact .manual-compact-grid{
+  display:grid;
+  grid-template-columns: minmax(160px, 200px) 1fr;
+  gap:16px;
+  align-items:start;
+}
+.manual-compact .compact-presets{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  padding:10px;
+  border-radius:14px;
+  border:1px solid rgba(0, 240, 255, 0.25);
+  background:rgba(0, 12, 22, 0.55);
+}
+.manual-compact .compact-presets__title{
+  font-size:.75rem;
+  text-transform:uppercase;
+  letter-spacing:.08em;
+  color:#7fe7ff;
+}
+.manual-compact .preset-stack{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.manual-compact .compact-presets .preset-btn{
+  width:100%;
+  justify-content:flex-start;
+  padding:6px 10px !important;
+  font-size:.85rem !important;
+}
+.manual-compact .compact-fields{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+.manual-compact .station-stack{
+  position:relative;
+  border:1px solid rgba(0, 240, 255, 0.35);
+  border-radius:14px;
+  background:rgba(6, 16, 28, 0.7);
+  overflow:hidden;
+  box-shadow:0 0 14px rgba(0,255,255,.12) inset;
+}
+.manual-compact .station-row{
+  display:grid;
+  grid-template-columns: 36px 1fr;
+  align-items:center;
+  gap:8px;
+  padding:10px 12px;
+  border-bottom:1px solid rgba(0, 240, 255, 0.12);
+}
+.manual-compact .station-row:last-child{
+  border-bottom:none;
+}
+.manual-compact .station-label{
+  font-weight:700;
+  color:#bff7ff;
+}
+.manual-compact .station-stack .station-search{
+  padding:6px 0;
+  border:none;
+  background:transparent;
+  box-shadow:none;
+  color:#e7fbff;
+}
+.manual-compact .station-stack .station-search:focus{
+  transform:none;
+  box-shadow:none;
+}
+.manual-compact .swap-btn--center{
+  position:absolute;
+  left:50%;
+  top:50%;
+  transform:translate(-50%, -50%);
+  width:34px;
+  height:34px;
+  border-radius:50%;
+  padding:0;
+  font-size:1rem;
+  background:linear-gradient(135deg, #00f0ff, #6cfaff);
+  color:#02131f;
+  border:1px solid rgba(0, 240, 255, 0.6);
+  box-shadow:0 0 12px rgba(0,255,255,.5);
+}
+.manual-compact .swap-btn--center:hover{
+  transform:translate(-50%, -50%) scale(1.03);
+}
 .manual-compact .station-search{
   padding:8px 12px;
   font-size:.95rem;
@@ -3204,6 +3293,9 @@ body.modal-open{ overflow:hidden; }
 }
 @media (max-width:900px){
   .manual-compact .filters-date-time{
+    grid-template-columns:1fr;
+  }
+  .manual-compact .manual-compact-grid{
     grid-template-columns:1fr;
   }
 }
@@ -6537,41 +6629,7 @@ td{font-size:.92rem;}
 <div class="command-console" id="search">
   <div class="console-header"> Console de Commande – Sélection des Bétaillères</div>
 
-  <!-- 1) GÉNÉRATION RAPIDE -->
-  <details id="customGenerationSection" class="console-section">
-    <summary class="section-summary">
-      <span class="section-icon" aria-hidden="true">⚡</span>
-      <span class="section-title">Génération rapide</span>
-    </summary>
-    <div class="section-content">
-      <div class="filters-row">
-        <div class="filter-item rapid-preset-row" style="justify-content:flex-start; gap:12px;">
-          <button id="btnMatin" class="mini-btn preset-btn" type="button" title="Matin" data-preset-kind="AM">
-            <span aria-hidden="true">🌅</span>
-            <span class="preset-label" data-preset-label="AM">Matin</span>
-          </button>
-          <button id="btnSoir"  class="mini-btn preset-btn" type="button" title="Soir" data-preset-kind="PM">
-            <span aria-hidden="true">🌇</span>
-            <span class="preset-label" data-preset-label="PM">Soir</span>
-          </button>
-          <button id="btnListe3" class="mini-btn preset-btn" type="button" title="Liste 3" data-preset-kind="L3" style="display:none;">
-            <span aria-hidden="true">🧾</span>
-            <span class="preset-label" data-preset-label="L3">Liste 3</span>
-          </button>
-          <button id="btnListe4" class="mini-btn preset-btn" type="button" title="Liste 4" data-preset-kind="L4" style="display:none;">
-            <span aria-hidden="true">🧾</span>
-            <span class="preset-label" data-preset-label="L4">Liste 4</span>
-          </button>
-          <button id="lbQuickAddList" class="mini-btn preset-btn preset-btn--add" type="button" title="Ajouter une liste" style="display:none;">
-            <span>+ Ajouter</span>
-          </button>
-        </div>
-      </div>
-      
-    </div>
-  </details>
-
-  <!-- 2) GÉNÉRATION PERSONNALISÉE -->
+  <!-- 1) GÉNÉRATION PERSONNALISÉE -->
   <details class="console-section">
     <summary class="section-summary">
       <span class="section-icon" aria-hidden="true">🧭</span>
@@ -6579,53 +6637,77 @@ td{font-size:.92rem;}
     </summary>
 
     <div class="section-content manual-compact">
-        <!-- De / À -->
-      <div class="filters-row filters-dea">
-      <div class="filter-item station-field">
-        <span class="field-caption">🚉 Gare de départ</span>
-        <label class="visually-hidden" for="startStationSearch">Gare de départ</label>
-        <select id="startStation" class="station-select-hidden" aria-hidden="true" tabindex="-1" hidden></select>
-        <input type="search" id="startStationSearch" class="station-search" list="stationNamesList"
-               placeholder="Ex : Nancy, Champigneulles..." aria-label="Rechercher une gare de départ" autocomplete="off">
-      </div>
-
-      <div class="filter-item station-swap">
-        <button id="swapStations" class="mini-btn swap-btn" type="button" aria-label="Inverser départ et arrivée">⇆ Inverser</button>
-      </div>
-
-      <div class="filter-item station-field">
-        <span class="field-caption">🏁 Gare d'arrivée</span>
-        <label class="visually-hidden" for="endStationSearch">Gare d'arrivée</label>
-        <select id="endStation" class="station-select-hidden" aria-hidden="true" tabindex="-1" hidden></select>
-        <input type="search" id="endStationSearch" class="station-search" list="stationNamesList"
-               placeholder="Ex : Metz, Luxembourg..." aria-label="Rechercher une gare d'arrivée" autocomplete="off">
-      </div>
-    </div>
-
-   <!-- Date + horaire -->
-      <div class="filters-row filters-date-time">
-        <div class="filter-item date-field">
-          <span class="field-caption">🗓️ Date</span>
-          <label class="visually-hidden" for="trainDate">Date</label>
-          <div class="date-picker-wrap">
-            <input type="date" id="trainDate" />
+      <div class="manual-compact-grid">
+        <aside class="compact-presets">
+          <div class="compact-presets__title">Raccourcis</div>
+          <div class="preset-stack">
+            <button id="btnMatin" class="mini-btn preset-btn" type="button" title="Matin" data-preset-kind="AM">
+              <span aria-hidden="true">🌅</span>
+              <span class="preset-label" data-preset-label="AM">Matin</span>
+            </button>
+            <button id="btnSoir"  class="mini-btn preset-btn" type="button" title="Soir" data-preset-kind="PM">
+              <span aria-hidden="true">🌇</span>
+              <span class="preset-label" data-preset-label="PM">Soir</span>
+            </button>
+            <button id="btnListe3" class="mini-btn preset-btn" type="button" title="Liste 3" data-preset-kind="L3" style="display:none;">
+              <span aria-hidden="true">🧾</span>
+              <span class="preset-label" data-preset-label="L3">Liste 3</span>
+            </button>
+            <button id="btnListe4" class="mini-btn preset-btn" type="button" title="Liste 4" data-preset-kind="L4" style="display:none;">
+              <span aria-hidden="true">🧾</span>
+              <span class="preset-label" data-preset-label="L4">Liste 4</span>
+            </button>
+            <button id="lbQuickAddList" class="mini-btn preset-btn preset-btn--add" type="button" title="Ajouter une liste" style="display:none;">
+              <span>+ Ajouter</span>
+            </button>
           </div>
-        </div>
-        <div class="filter-item time-range">
-          <label for="timeSlider">Plage horaire</label>
-          <div class="time-grid">
-            <div class="time-col">
-              <div id="timeSlider" class="time-slider"></div>
+        </aside>
 
-              <div class="time-values" style="display:flex;align-items:center;gap:8px;">
-                <span id="timeFromLabel">06:00</span>
-                <span class="time-sep">→</span>
-                <span id="timeToLabel">10:00</span>
+        <div class="compact-fields">
+          <div class="station-stack" aria-label="Sélection des gares">
+            <div class="station-row">
+              <span class="station-label">De</span>
+              <label class="visually-hidden" for="startStationSearch">Gare de départ</label>
+              <select id="startStation" class="station-select-hidden" aria-hidden="true" tabindex="-1" hidden></select>
+              <input type="search" id="startStationSearch" class="station-search" list="stationNamesList"
+                     placeholder="Gare ou ville" aria-label="Rechercher une gare de départ" autocomplete="off">
+            </div>
+            <div class="station-row">
+              <span class="station-label">À</span>
+              <label class="visually-hidden" for="endStationSearch">Gare d'arrivée</label>
+              <select id="endStation" class="station-select-hidden" aria-hidden="true" tabindex="-1" hidden></select>
+              <input type="search" id="endStationSearch" class="station-search" list="stationNamesList"
+                     placeholder="Gare ou ville" aria-label="Rechercher une gare d'arrivée" autocomplete="off">
+            </div>
+            <button id="swapStations" class="mini-btn swap-btn swap-btn--center" type="button" aria-label="Inverser départ et arrivée">↕</button>
+          </div>
+
+          <!-- Date + horaire -->
+          <div class="filters-row filters-date-time">
+            <div class="filter-item date-field">
+              <span class="field-caption">🗓️ Date</span>
+              <label class="visually-hidden" for="trainDate">Date</label>
+              <div class="date-picker-wrap">
+                <input type="date" id="trainDate" />
               </div>
+            </div>
+            <div class="filter-item time-range">
+              <label for="timeSlider">Plage horaire</label>
+              <div class="time-grid">
+                <div class="time-col">
+                  <div id="timeSlider" class="time-slider"></div>
 
-              <!-- Inputs cachés (compat JS) -->
-              <input type="time" id="timeFrom" value="06:00" class="visually-hidden" aria-hidden="true" tabindex="-1">
-              <input type="time" id="timeTo"   value="10:00" class="visually-hidden" aria-hidden="true" tabindex="-1">
+                  <div class="time-values" style="display:flex;align-items:center;gap:8px;">
+                    <span id="timeFromLabel">06:00</span>
+                    <span class="time-sep">→</span>
+                    <span id="timeToLabel">10:00</span>
+                  </div>
+
+                  <!-- Inputs cachés (compat JS) -->
+                  <input type="time" id="timeFrom" value="06:00" class="visually-hidden" aria-hidden="true" tabindex="-1">
+                  <input type="time" id="timeTo"   value="10:00" class="visually-hidden" aria-hidden="true" tabindex="-1">
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/index2.html
+++ b/index2.html
@@ -3132,8 +3132,7 @@ body.modal-open{ overflow:hidden; }
   opacity:.85;
 }
 .manual-compact .itinerary-preview{
-  padding:10px 12px;
-  margin-bottom:10px;
+  display:none;
 }
 .manual-compact .itinerary-preview .preview-line{ font-size:1rem; }
 .manual-compact .itinerary-preview .preview-subline{ font-size:.82rem; }
@@ -3165,8 +3164,25 @@ body.modal-open{ overflow:hidden; }
   font-size:.9rem;
   color:#cfffff;
 }
+.manual-compact .station-search{
+  padding:8px 12px;
+  font-size:.95rem;
+}
+.manual-compact .station-swap{
+  min-width:110px;
+}
+.manual-compact .swap-btn{
+  padding:8px 14px;
+  font-size:.9rem;
+}
 .manual-compact .time-grid{
   grid-template-columns: 1fr;
+}
+.manual-compact .time-slider{
+  margin:8px 0;
+}
+.manual-compact .time-values{
+  font-size:.85rem;
 }
 .manual-compact .helper-text{
   font-size:.78rem;
@@ -6563,14 +6579,6 @@ td{font-size:.92rem;}
     </summary>
 
     <div class="section-content manual-compact">
-      <div class="itinerary-preview" id="itineraryPreview" aria-live="polite">
-        <span class="preview-icon">🚆</span>
-        <div class="preview-text">
-          <div class="preview-line" id="itineraryLine">Prêt à embarquer ?</div>
-          <div class="preview-subline" id="itinerarySubtitle">Choisis ta gare de départ et ta gare d'arrivée pour lancer la magie.</div>
-        </div>
-      </div>
-
         <!-- De / À -->
       <div class="filters-row filters-dea">
       <div class="filter-item station-field">
@@ -6601,14 +6609,10 @@ td{font-size:.92rem;}
           <label class="visually-hidden" for="trainDate">Date</label>
           <div class="date-picker-wrap">
             <input type="date" id="trainDate" />
-            <div class="quick-button-group" data-group="date" aria-label="Raccourcis de date">
-              <button type="button" class="mini-btn quick-btn quick-day" data-day="today">Aujourd'hui</button>
-            </div>
           </div>
         </div>
         <div class="filter-item time-range">
           <label for="timeSlider">Plage horaire</label>
-          <span class="helper-text">Amplitude par défaut : 3h autour de maintenant.</span>
           <div class="time-grid">
             <div class="time-col">
               <div id="timeSlider" class="time-slider"></div>
@@ -6617,10 +6621,6 @@ td{font-size:.92rem;}
                 <span id="timeFromLabel">06:00</span>
                 <span class="time-sep">→</span>
                 <span id="timeToLabel">10:00</span>
-              </div>
-
-              <div class="quick-button-group" data-group="time" aria-label="Raccourcis horaires">
-                <button type="button" class="mini-btn quick-btn quick-time" data-range="now">🚀 Maintenant +3h</button>
               </div>
 
               <!-- Inputs cachés (compat JS) -->

--- a/index2.html
+++ b/index2.html
@@ -3130,7 +3130,72 @@ body.modal-open{ overflow:hidden; }
   font-size:.92rem;
   color:#9ae7ff;
   opacity:.85;
-}    
+}
+.manual-compact .itinerary-preview{
+  padding:10px 12px;
+  margin-bottom:10px;
+}
+.manual-compact .itinerary-preview .preview-line{ font-size:1rem; }
+.manual-compact .itinerary-preview .preview-subline{ font-size:.82rem; }
+.manual-compact .filters-row{
+  gap:8px;
+  margin-bottom:6px;
+}
+.manual-compact .filters-date-time{
+  display:grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(260px, 2fr);
+  gap:12px;
+  align-items:start;
+}
+.manual-compact .date-picker-wrap{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  flex-wrap:wrap;
+}
+.manual-compact .quick-button-group{
+  gap:6px;
+}
+.manual-compact .quick-button-group .mini-btn{
+  padding:6px 12px;
+  font-size:.82rem;
+}
+.manual-compact .time-range label{
+  font-weight:700;
+  font-size:.9rem;
+  color:#cfffff;
+}
+.manual-compact .time-grid{
+  grid-template-columns: 1fr;
+}
+.manual-compact .helper-text{
+  font-size:.78rem;
+  color:rgba(224, 240, 255, 0.75);
+}
+.manual-compact .filters-options{
+  justify-content:flex-start;
+}
+.manual-compact .option-toggle{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 10px;
+  border-radius:999px;
+  border:1px solid rgba(0, 240, 255, 0.3);
+  background:rgba(0, 12, 22, 0.6);
+  color:#dffbff;
+  font-size:.85rem;
+}
+@media (max-width:900px){
+  .manual-compact .filters-date-time{
+    grid-template-columns:1fr;
+  }
+}
+.manual-compact .field-caption{
+  font-size:.75rem;
+  letter-spacing:.06em;
+  text-transform:uppercase;
+}
 .command-console .filters-dea{
   display:grid;
   gap:12px;
@@ -6497,7 +6562,7 @@ td{font-size:.92rem;}
       <span class="section-title">Génération personnalisée</span>
     </summary>
 
-    <div class="section-content">
+    <div class="section-content manual-compact">
       <div class="itinerary-preview" id="itineraryPreview" aria-live="polite">
         <span class="preview-icon">🚆</span>
         <div class="preview-text">
@@ -6509,11 +6574,11 @@ td{font-size:.92rem;}
         <!-- De / À -->
       <div class="filters-row filters-dea">
       <div class="filter-item station-field">
-        <span class="field-caption">🚉 Tu montes où ?</span>
+        <span class="field-caption">🚉 Gare de départ</span>
         <label class="visually-hidden" for="startStationSearch">Gare de départ</label>
         <select id="startStation" class="station-select-hidden" aria-hidden="true" tabindex="-1" hidden></select>
         <input type="search" id="startStationSearch" class="station-search" list="stationNamesList"
-               placeholder="Tape Nancy, Champigneulles..." aria-label="Rechercher une gare de départ" autocomplete="off">
+               placeholder="Ex : Nancy, Champigneulles..." aria-label="Rechercher une gare de départ" autocomplete="off">
       </div>
 
       <div class="filter-item station-swap">
@@ -6521,38 +6586,30 @@ td{font-size:.92rem;}
       </div>
 
       <div class="filter-item station-field">
-        <span class="field-caption">🏁 Tu descends où ?</span>
+        <span class="field-caption">🏁 Gare d'arrivée</span>
         <label class="visually-hidden" for="endStationSearch">Gare d'arrivée</label>
         <select id="endStation" class="station-select-hidden" aria-hidden="true" tabindex="-1" hidden></select>
         <input type="search" id="endStationSearch" class="station-search" list="stationNamesList"
-               placeholder="...et où tu descends ?" aria-label="Rechercher une gare d'arrivée" autocomplete="off">
+               placeholder="Ex : Metz, Luxembourg..." aria-label="Rechercher une gare d'arrivée" autocomplete="off">
       </div>
     </div>
 
-   <!-- Date -->
-      <div class="filters-row filters-date">
+   <!-- Date + horaire -->
+      <div class="filters-row filters-date-time">
         <div class="filter-item date-field">
-          <span class="field-caption">🗓️ Jour de mission</span>
+          <span class="field-caption">🗓️ Date</span>
           <label class="visually-hidden" for="trainDate">Date</label>
           <div class="date-picker-wrap">
             <input type="date" id="trainDate" />
             <div class="quick-button-group" data-group="date" aria-label="Raccourcis de date">
               <button type="button" class="mini-btn quick-btn quick-day" data-day="today">Aujourd'hui</button>
-              <button type="button" class="mini-btn quick-btn quick-day" data-day="tomorrow">Demain</button>
-              <button type="button" class="mini-btn quick-btn quick-day" data-day="weekend">Week-end</button>
             </div>
           </div>
         </div>
-      </div>
-
-    <datalist id="stationNamesList"></datalist>
-
-      <!-- Slider horaire -->
-      <div class="filters-row filters-datetime">
-        <div class="filter-item time-range" style="width:100%">
-          <label for="timeSlider">Plage horaire :</label>
-
-          <div class="time-grid" style="grid-template-columns: 1fr;">
+        <div class="filter-item time-range">
+          <label for="timeSlider">Plage horaire</label>
+          <span class="helper-text">Amplitude par défaut : 3h autour de maintenant.</span>
+          <div class="time-grid">
             <div class="time-col">
               <div id="timeSlider" class="time-slider"></div>
 
@@ -6564,9 +6621,6 @@ td{font-size:.92rem;}
 
               <div class="quick-button-group" data-group="time" aria-label="Raccourcis horaires">
                 <button type="button" class="mini-btn quick-btn quick-time" data-range="now">🚀 Maintenant +3h</button>
-                <button type="button" class="mini-btn quick-btn quick-time" data-range="rush-am">☕️ Matin boulot</button>
-                <button type="button" class="mini-btn quick-btn quick-time" data-range="rush-pm">🍻 Sortie bureau</button>
-                <button type="button" class="mini-btn quick-btn quick-time" data-range="late">🌙 Derniers trains</button>
               </div>
 
               <!-- Inputs cachés (compat JS) -->
@@ -6577,31 +6631,21 @@ td{font-size:.92rem;}
         </div>
       </div>
 
+    <datalist id="stationNamesList"></datalist>
+
       
       <!-- Options (ex-Options avancées) -->
-<div class="filters-row filters-transfer">
+<div class="filters-row filters-options">
         <div class="filter-item" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
-          <label for="allowTransfer" style="display:flex;align-items:center;gap:8px;">
+          <label for="allowTransfer" class="option-toggle">
             <input id="allowTransfer" type="checkbox" checked>
-            <span>Autoriser correspondance</span>
+            <span>Correspondances</span>
           </label>
 
-          <label for="includeCFLStatic" class="cfl-toggle" style="display:flex;align-items:center;gap:8px;">
+          <label for="includeCFLStatic" class="option-toggle cfl-toggle">
             <input id="includeCFLStatic" type="checkbox">
-            <span>Inclure trains CFL (statique)</span>
+            <span>Trains CFL</span>
           </label>
-
-          <div style="display:flex;align-items:center;gap:6px;">
-            <label for="minTransfer">Min :</label>
-            <input id="minTransfer" type="number" value="5" min="1" step="1" style="width:4.5rem;">
-            <span>min</span>
-          </div>
-          
-        <div style="display:flex;align-items:center;gap:6px;">
-            <label for="maxTransfer">Max :</label>
-            <input id="maxTransfer" type="number" value="25" min="1" step="1" style="width:4.5rem;">
-            <span>min</span>
-          </div>
         </div>
       </div>
     


### PR DESCRIPTION
### Motivation
- Make the manual selection panel more compact and easier to understand, focusing on: `Gare de départ` / `Gare d'arrivée`, a single date picker, a simple time amplitude (default today, +3h), and two toggles for correspondances and CFL trains.

### Description
- Added a `.manual-compact` CSS set to tighten spacing, reduce font sizes, and adapt layout for the custom generation panel including `.filters-date-time` grid and compact `quick-button-group` styling.
- Updated the custom generation HTML to use `class="section-content manual-compact"`, relabeled station fields to `Gare de départ` / `Gare d'arrivée`, simplified placeholders, and grouped date + time into a single `filters-date-time` section.
- Reduced quick actions to a single date shortcut (`Aujourd'hui`) and a single time shortcut (`🚀 Maintenant +3h`) and added a helper `Amplitude par défaut : 3h autour de maintenant.` message.
- Simplified options to two compact toggles (`Correspondances` and `Trains CFL`) with an `option-toggle` style and removed the inline min/max transfer number inputs for a cleaner default UI.

### Testing
- Launched a local static server with `python -m http.server` and loaded `index2.html` via a Playwright script to verify rendering and captured a screenshot at `artifacts/index2-manual-compact.png`, which completed successfully.
- Verified the page loads and the modified selectors/controls render on desktop viewport in the automated screenshot run, with no runtime JS changes to existing behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b1ef2b228832d9e04f51d0526acbd)