### PR TITLE
Improve mobile table fit and polish selection console in index9.html

### DIFF
--- a/index9.html
+++ b/index9.html
@@ -1955,6 +1955,23 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
     touch-action: pan-x;
   }
 
+  /* Forcer l'affichage de toutes les gares dans l'espace entre barres fixes */
+  body.lb-table-mode #trainInfo table{
+    font-size: var(--lb-table-font-size, .75rem);
+    line-height: var(--lb-table-line-height, 1.0);
+  }
+  body.lb-table-mode #trainInfo table tbody tr{ height: var(--lb-row-h, 22px); }
+  body.lb-table-mode #trainInfo table tbody td,
+  body.lb-table-mode #trainInfo table thead th{
+    padding-top: var(--lb-cell-pad-y, 2px) !important;
+    padding-bottom: var(--lb-cell-pad-y, 2px) !important;
+  }
+  body.lb-table-mode #trainInfo table th:first-child,
+  body.lb-table-mode #trainInfo table td:first-child{
+    font-size: var(--lb-station-font-size, .62rem);
+    line-height: var(--lb-station-line-height, 1.05);
+  }
+
   /* Le conteneur scrollable ne doit jamais accepter du pan-y sur mobile */
   .table-scroll{ touch-action: pan-x; }
 
@@ -2519,7 +2536,7 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   appearance:none;
   border:1px solid rgba(0, 240, 255, 0.35);
   background:rgba(0, 240, 255, 0.10);
-  color:#9ffcff;
+  color:#bafcff;
   border-radius:999px;
   width:34px;
   height:34px;
@@ -2909,15 +2926,15 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
 
 /* ===== Sélecteur manuel compact (input + Ajouter + Vider sur la même ligne) ===== */
 #selectionBlock .selection-manual-card{
-  margin:8px 0 10px;
-  padding:10px 12px;
-  border-radius:12px;
-  border:1px solid rgba(0,255,255,0.2);
-  background:linear-gradient(180deg, rgba(0,18,30,0.65), rgba(0,12,20,0.45));
-  box-shadow: inset 0 0 12px rgba(0,255,255,0.08);
+  margin:10px 0 12px;
+  padding:12px 13px;
+  border-radius:14px;
+  border:1px solid rgba(0,255,255,0.32);
+  background:linear-gradient(165deg, rgba(1,33,52,0.72), rgba(1,18,30,0.54));
+  box-shadow: inset 0 0 14px rgba(0,255,255,0.10), 0 6px 20px rgba(0,0,0,0.24);
 }
 #selectionBlock .selection-manual-card__title{
-  font-size:0.85rem;
+  font-size:0.82rem;
   font-weight:700;
   color:#9ffcff;
   text-transform:uppercase;
@@ -2943,14 +2960,18 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
 #selectionBlock .chips-manual input{
   flex:1 1 auto;
   min-width:0;
-  padding:7px 10px;
-  border-radius:10px;
+  padding:9px 12px;
+  border-radius:11px;
   background:#0b1325;
   color:#00f0ff;
   border:1px solid #00f0ff55;
-  box-shadow:0 0 6px #00f0ff44 inset;
+  box-shadow:0 0 8px #00f0ff55 inset;
   font-family:'Orbitron', sans-serif;
-  font-size:0.95rem;
+  font-size:0.92rem;
+  letter-spacing:0.02em;
+}
+#selectionBlock .chips-manual input::placeholder{
+  color: rgba(186, 252, 255, 0.62);
 }
 
 /* (optionnel) wrapper si tu l’utilises dans le HTML */
@@ -2967,11 +2988,13 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   max-width:none !important;
   width:auto !important;
   margin:0 !important;
-  padding:6px 10px !important;
-  font-size:.95rem !important;
+  padding:8px 12px !important;
+  font-size:.84rem !important;
+  letter-spacing:.06em !important;
   line-height:1.1 !important;
   box-shadow:0 0 10px #00f0ff66, inset 0 0 14px #00f0ff55;
-  border-radius:8px;
+  border-radius:10px;
+  text-transform:uppercase;
 }
 /* variante fantôme pour "Vider" (moins flashy) */
 #selectionBlock .btn.btn-compact.ghost{
@@ -7869,7 +7892,7 @@ html, body{
 
 <!-- Console de Commande -->
 <div class="command-console" id="search">
-  <div class="console-header"> Console de Commande – Sélection des Bétaillères</div>
+  <div class="console-header"> Console de pilotage — Sélection des bétaillères</div>
 
   <!-- 1) GÉNÉRATION PERSONNALISÉE -->
   <details class="console-section">
@@ -8036,7 +8059,7 @@ html, body{
         </div>
         
         <div class="selection-manual-card">
-          <div class="selection-manual-card__title">🐮 Saisie rapide</div>
+          <div class="selection-manual-card__title">🐮 Ajout manuel</div>
           <div class="chips-manual">
             <input id="manualTrainInput" type="text" inputmode="numeric" pattern="\d{5,6}" placeholder="N° train (5-6 chiffres)">
             <div class="manual-actions">
@@ -8044,7 +8067,7 @@ html, body{
               <button id="btnClearSelection" class="btn btn-compact ghost" type="button" title="Vider la sélection">🧹 Vider</button>
             </div>
           </div>
-          <div class="selection-manual-card__hint">Astuce : ajoute plusieurs trains en les saisissant un par un.</div>
+          <div class="selection-manual-card__hint">Format conseillé : 5 à 6 chiffres. Ajoute les trains un par un pour une sélection propre.</div>
         </div>
         
         <div id="selectionChips" aria-live="polite"></div>
@@ -10343,17 +10366,26 @@ function adjustTrainTableRowHeights(){
   const thead = table.querySelector('thead');
   const headerH = thead ? Math.ceil(thead.getBoundingClientRect().height) : 0;
 
-  const avail = Math.max(80, scroller.clientHeight - headerH - 6); // 6px marge
+  const avail = Math.max(70, scroller.clientHeight - headerH - 4);
   let rowH = Math.floor(avail / n);
 
-  // bornes: on évite trop petit (illisible) et trop grand (absurde)
-  rowH = Math.max(26, Math.min(54, rowH));
+  // Priorité: afficher toutes les gares entre les barres fixes, même si la vue est dense.
+  rowH = Math.max(12, Math.min(44, rowH));
 
-  // padding vertical cohérent avec la hauteur
-  const padY = Math.max(3, Math.min(10, Math.floor((rowH - 18) / 2)));
+  // Typo adaptive pour conserver la lisibilité quand la densité augmente
+  const compactRatio = Math.max(0, Math.min(1, (22 - rowH) / 10));
+  const tableFont = (0.76 - compactRatio * 0.14).toFixed(3);
+  const stationFont = (0.66 - compactRatio * 0.12).toFixed(3);
+  const lineH = (1.06 - compactRatio * 0.14).toFixed(3);
+
+  const padY = Math.max(1, Math.min(8, Math.floor((rowH - 12) / 2)));
 
   host.style.setProperty('--lb-row-h', rowH + 'px');
   host.style.setProperty('--lb-cell-pad-y', padY + 'px');
+  host.style.setProperty('--lb-table-font-size', tableFont + 'rem');
+  host.style.setProperty('--lb-station-font-size', stationFont + 'rem');
+  host.style.setProperty('--lb-table-line-height', lineH);
+  host.style.setProperty('--lb-station-line-height', Math.max(0.9, Number(lineH) - 0.02).toFixed(3));
 }
 
 /* Scroll vers le tableau généré pour le mettre immédiatement en vue */


### PR DESCRIPTION
### Motivation
- The train table must display all stations between the fixed top and bottom bars on smartphones even for routes with many stops. 
- The manual selection UI for choosen trains ("bétaillères") needed visual and UX polishing to look professional and compact on small screens. 

### Description
- Modified `index9.html` to add mobile-specific CSS under `body.lb-table-mode` that exposes variables for row height, cell padding and font sizes so the table can be densified without breaking the fixed bars. 
- Enhanced the JS `adjustTrainTableRowHeights` function to prioritise showing all stations on mobile by computing a compact row height and adaptive typography and then applying CSS variables (`--lb-row-h`, `--lb-cell-pad-y`, `--lb-table-font-size`, `--lb-station-font-size`, `--lb-table-line-height`, `--lb-station-line-height`). 
- Polished selection modal styles for the manual-entry card (`#selectionBlock .selection-manual-card`) including spacing, input padding, button sizing, placeholder color and small typographic tweaks for clearer, more professional presentation. 
- Updated copy strings for the console header and manual selection title to a more professional tone (e.g. "Console de pilotage — Sélection des bétaillères", "🐮 Ajout manuel", and an improved hint text). 

### Testing
- Ran `git diff --check` to verify there are no trivial whitespace or diff issues and it passed. 
- Tried `xmllint --html --noout index9.html` but the tool is not available in the environment (command not found). 
- Attempted an automated mobile viewport screenshot using Playwright: a local HTTP server was launched and Playwright was run, but Chromium crashed (SIGSEGV) in this environment so no screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a53e56e2b8832d83a9b509cc18d799)