### PR TITLE
Mobile: full-height timetable, compact rows, inline weather and console integration

### DIFF
--- a/index0.html
+++ b/index0.html
@@ -1725,21 +1725,22 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
     overflow-x: auto;
     overflow-y: hidden;
     -webkit-overflow-scrolling: touch; /* scroll fluide iOS */
-    height: calc(100vh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 78px) - 60px);
+    height: calc(100dvh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 78px) - 18px);
     margin-top: 0;
   }
   #trainInfo table{
     height: auto; /* évite l'étirement des lignes quand il y a peu d'arrêts */
     width: 100%;
     table-layout: fixed;
-    font-size: 0.85rem;
-    line-height: 1.1;
+    font-size: var(--lb-row-font-size, 0.78rem);
+    line-height: 1.0;
   }
 
   /* Hauteur des lignes: adaptative (évite les lignes géantes quand il y a peu d'arrêts) */
   #trainInfo{ 
     --lb-row-h: 34px;          /* sera recalculé en JS */
     --lb-cell-pad-y: 6px;     /* sera recalculé en JS */
+    --lb-row-font-size: 0.78rem;
   }
   #trainInfo table tbody tr{ height: var(--lb-row-h); }
   #trainInfo table tbody td,
@@ -1749,20 +1750,20 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   }
   #trainInfo table th:first-child,
   #trainInfo table td:first-child{
-    /* Colonne gares : plus large + lisible (évite les troncatures) */
+    /* Colonne gares : compacte pour faire tenir TOUTES les gares à l'écran */
     width: var(--lb-first-col-px, 170px);
     min-width: var(--lb-first-col-px, 170px);
     max-width: var(--lb-first-col-px, 170px);
 
-    font-size: 0.72rem;
-    padding: 6px 6px;
+    font-size: 0.66rem;
+    padding: 2px 4px;
 
-    /* On autorise le retour à la ligne (2 lignes max) */
-    white-space: normal;
+    /* Mode compact: une seule ligne, pas de retour pour éviter d'agrandir les lignes */
+    white-space: nowrap;
     overflow: hidden;
-    text-overflow: clip;
-    word-break: break-word;
-    line-height: 1.15;
+    text-overflow: ellipsis;
+    word-break: normal;
+    line-height: 1.0;
 
     position: sticky;
     left: 0;
@@ -1771,6 +1772,36 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
     border-right: 1px solid rgba(0,240,255,0.14);
     box-shadow: 10px 0 18px rgba(0,0,0,0.35);
   }
+
+  /* Gare + météo sur UNE ligne (sans masquer la météo) */
+  #trainInfo table td:first-child .gare-label{
+    display: inline-block;
+    max-width: calc(100% - 40px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    letter-spacing: -0.01em;
+  }
+  #trainInfo table td:first-child .wx{
+    display: inline-flex !important;
+    align-items: center;
+    vertical-align: middle;
+    margin-left: 2px;
+    max-width: 36px;
+    font-size: 0.52rem;
+  }
+  #trainInfo table td:first-child .wx a.wx-link{
+    display: inline-flex;
+    align-items: center;
+    gap: 0.12rem;
+    padding: 0 2px;
+    border: none;
+    background: transparent;
+    line-height: 1;
+  }
+  #trainInfo table td:first-child .wx .wx-ico{ font-size: 0.62rem; }
+  #trainInfo table td:first-child .wx .wx-t{ font-size: 0.52rem; }
+
 
   /* Colonnes trains : compactées pour en afficher ~4 sur smartphone */
   #trainInfo table th:not(:first-child),
@@ -8551,25 +8582,55 @@ html, body{
   #search .options-row{ gap: 10px !important; margin-top: 6px !important; }
   #search .option-toggle{ background: transparent !important; border: none !important; box-shadow: none !important; padding: 6px 6px !important; }
 
-  /* Bouton Rechercher FIXE en bas (au-dessus de la barre fixe) UNIQUEMENT sur l'écran #search */
-  #search:target{ padding-bottom: calc(env(safe-area-inset-bottom, 0px) + var(--bottomNavH) + 88px) !important; }
-  #search:target .actions-main{
+  /* Bouton Rechercher intégré à la console (non flottant) */
+  #search .actions-main{
     position: static !important;
-    margin: 0 !important;
+    margin-top: 10px !important;
     padding: 0 !important;
-    background: transparent !important;
-    border: none !important;
-    box-shadow: none !important;
-    height: 0 !important;
+    height: auto !important;
     overflow: visible !important;
   }
-  #search:target #presetBuilderSearch{
-    position: fixed !important;
-    left: 50% !important;
-    transform: translateX(-50%) !important;
-    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--bottomNavH) + 10px) !important;
-    width: min(340px, calc(100vw - 28px)) !important;
-    z-index: 9999 !important;
+  #search #btnProposer{
+    position: static !important;
+    width: min(340px, calc(100vw - 36px)) !important;
+    margin: 0 auto !important;
+    transform: none !important;
+    left: auto !important;
+    bottom: auto !important;
+    z-index: auto !important;
+  }
+}
+
+/* ===== PATCH smartphone 2026-03-02: tableau full height + console plus pro ===== */
+@media (max-width: 768px){
+  #trainInfo .table-scroll{
+    height: calc(100dvh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 84px) - 18px) !important;
+    max-height: calc(100dvh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 84px) - 18px) !important;
+    overflow-y: hidden !important;
+  }
+
+  .command-console{
+    padding: 16px;
+    border-radius: 16px;
+  }
+
+  .console-header{
+    font-size: 1rem;
+    margin-bottom: 8px;
+    letter-spacing: 0.02em;
+  }
+
+  .filters-selection{
+    border-top: 1px dashed rgba(0, 240, 255, 0.28);
+    margin-top: 10px;
+    padding-top: 10px;
+  }
+
+  #selectionInline{
+    background: linear-gradient(145deg, rgba(0, 30, 48, 0.88), rgba(0, 16, 30, 0.82));
+    border: 1px solid rgba(0, 240, 255, 0.28);
+    border-radius: 14px;
+    padding: 10px 12px;
   }
 }
 
@@ -10194,14 +10255,25 @@ function adjustTrainTableRowHeights(){
   const avail = Math.max(80, scroller.clientHeight - headerH - 6); // 6px marge
   let rowH = Math.floor(avail / n);
 
-  // bornes: on évite trop petit (illisible) et trop grand (absurde)
-  rowH = Math.max(26, Math.min(54, rowH));
+  // bornes: priorité absolue à voir tout le trajet sans scroll vertical interne
+  // (même avec beaucoup de gares), quitte à compacter fortement.
+  rowH = Math.max(8, Math.min(54, rowH));
 
-  // padding vertical cohérent avec la hauteur
-  const padY = Math.max(3, Math.min(10, Math.floor((rowH - 18) / 2)));
+  // padding ultra-compact pour les gros tableaux
+  const padY = Math.max(0, Math.min(8, Math.floor((rowH - 12) / 2)));
+
+  // typographie adaptative pour tenir toutes les lignes
+  const rowFont = rowH <= 9  ? '0.48rem'
+                : rowH <= 11 ? '0.52rem'
+                : rowH <= 13 ? '0.56rem'
+                : rowH <= 15 ? '0.60rem'
+                : rowH <= 18 ? '0.66rem'
+                : rowH <= 22 ? '0.72rem'
+                : '0.78rem';
 
   host.style.setProperty('--lb-row-h', rowH + 'px');
   host.style.setProperty('--lb-cell-pad-y', padY + 'px');
+  host.style.setProperty('--lb-row-font-size', rowFont);
 }
 
 /* Scroll vers le tableau généré pour le mettre immédiatement en vue */
@@ -14581,7 +14653,10 @@ const stopHasSchedule = (result, stopName) => {
 
     // 6) Injection + hooks + liens (NOUVEL ORDRE)
     injectTableChunkedIntoTrainInfo(html, { chunk: 180 });
-    scrollTrainTableIntoView();
+    requestAnimationFrame(() => {
+      adjustTrainTableRowHeights();
+      scrollTrainTableIntoView();
+    });
 
     if (sncfFallback.used) {
       const host = document.getElementById('trainInfo');


### PR DESCRIPTION
### Motivation
- Make the timetable usable on narrow screens by fitting the table to the full viewport height and preventing internal vertical scrolling from hiding stops. 
- Allow very long itineraries to remain readable on mobile by compacting row heights and typography so all stops can be displayed. 
- Improve the mobile search/console UX by integrating the search button into the console and removing the floating/pinned behavior.
- Keep station name and weather UI visible while saving horizontal space on small screens.

### Description
- CSS: switched `100vh` to `100dvh` for mobile scroller height calculations and adjusted several `calc()` offsets to expand the table to full device height. 
- CSS: introduced compact styles for mobile `#trainInfo` including a new `--lb-row-font-size` variable, smaller font sizes, single-line station column with `text-overflow: ellipsis`, inline weather (`.wx`) and tightened paddings and column widths for train columns. 
- CSS: added a smartphone patch block (dated `2026-03-02`) that forces the `.table-scroll` max-height/height and applies improved `command-console`, `.console-header`, `.filters-selection` and `#selectionInline` visuals. 
- JS: updated `adjustTrainTableRowHeights()` to prioritize showing the full itinerary by lowering the minimum row height, using a tighter padding scheme, and computing an adaptive `rowFont` set on `--lb-row-font-size`. 
- JS: after injecting the generated table the code now calls `adjustTrainTableRowHeights()` and then `scrollTrainTableIntoView()` inside a `requestAnimationFrame` to ensure sizes are computed before scrolling. 
- Search/console behavior: removed floating/pinned search action layout and made `#search .actions-main` and `#search #btnProposer` static and integrated into the console layout for small screens. 

### Testing
- Ran the existing automated frontend test suite including linting and unit tests; all tests passed. 
- Executed headless visual regression checks for mobile breakpoints to validate the compact table layout and console changes with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a53f242038832d9c99cbbd581e3030)