### PR TITLE
Embedded map, mobile tableau UX, and local caching/background refresh for GTFS/voies/compo

### DIFF
--- a/index0.html
+++ b/index0.html
@@ -47,7 +47,7 @@ body {
   left: 0;
   right: 0;
   height: var(--top-bar-height);
-  z-index: 1200;
+  z-index: 3000;
   background: linear-gradient(135deg, rgba(7, 15, 30, 0.98), rgba(12, 24, 44, 0.96));
   border-bottom: 1px solid rgba(0, 240, 255, 0.35);
   box-shadow: 0 8px 24px rgba(0, 240, 255, 0.15);
@@ -416,11 +416,12 @@ body {
 }
 
 .bottom-nav{
+  pointer-events:auto !important;
   position: fixed;
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 1200;
+  z-index: 3200;
   background: linear-gradient(135deg, rgba(7, 15, 30, 0.98), rgba(12, 24, 44, 0.96));
   border-top: 1px solid rgba(0, 240, 255, 0.35);
   box-shadow: 0 -6px 20px rgba(0, 240, 255, 0.18);
@@ -436,6 +437,7 @@ body {
 }
 
 .bottom-nav__item{
+  pointer-events:auto !important;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1723,23 +1725,24 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
 @media (max-width: 768px) {
   .table-scroll {
     overflow-x: auto;
-    overflow-y: hidden;
+    overflow-y: auto;
     -webkit-overflow-scrolling: touch; /* scroll fluide iOS */
-    height: calc(100vh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 78px) - 60px);
+    height: calc(100dvh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 78px) - var(--tableau-viewbar-h, 0px) - 10px);
     margin-top: 0;
   }
   #trainInfo table{
     height: auto; /* évite l'étirement des lignes quand il y a peu d'arrêts */
     width: 100%;
     table-layout: fixed;
-    font-size: 0.85rem;
-    line-height: 1.1;
+    font-size: var(--lb-row-font-size, 0.78rem);
+    line-height: 1.0;
   }
 
   /* Hauteur des lignes: adaptative (évite les lignes géantes quand il y a peu d'arrêts) */
   #trainInfo{ 
     --lb-row-h: 34px;          /* sera recalculé en JS */
     --lb-cell-pad-y: 6px;     /* sera recalculé en JS */
+    --lb-row-font-size: 0.78rem;
   }
   #trainInfo table tbody tr{ height: var(--lb-row-h); }
   #trainInfo table tbody td,
@@ -1749,20 +1752,20 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   }
   #trainInfo table th:first-child,
   #trainInfo table td:first-child{
-    /* Colonne gares : plus large + lisible (évite les troncatures) */
+    /* Colonne gares : compacte pour faire tenir TOUTES les gares à l'écran */
     width: var(--lb-first-col-px, 170px);
     min-width: var(--lb-first-col-px, 170px);
     max-width: var(--lb-first-col-px, 170px);
 
-    font-size: 0.72rem;
-    padding: 6px 6px;
+    font-size: 0.64rem;
+    padding: 2px 4px;
 
-    /* On autorise le retour à la ligne (2 lignes max) */
-    white-space: normal;
+    /* Mode compact: une seule ligne, pas de retour pour éviter d'agrandir les lignes */
+    white-space: nowrap;
     overflow: hidden;
-    text-overflow: clip;
-    word-break: break-word;
-    line-height: 1.15;
+    text-overflow: ellipsis;
+    word-break: normal;
+    line-height: 1.0;
 
     position: sticky;
     left: 0;
@@ -1771,6 +1774,36 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
     border-right: 1px solid rgba(0,240,255,0.14);
     box-shadow: 10px 0 18px rgba(0,0,0,0.35);
   }
+
+  /* Gare + météo sur UNE ligne (sans masquer la météo) */
+  #trainInfo table td:first-child .gare-label{
+    display: inline-block;
+    max-width: calc(100% - 40px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    letter-spacing: -0.01em;
+  }
+  #trainInfo table td:first-child .wx{
+    display: inline-flex !important;
+    align-items: center;
+    vertical-align: middle;
+    margin-left: 2px;
+    max-width: 36px;
+    font-size: 0.52rem;
+  }
+  #trainInfo table td:first-child .wx a.wx-link{
+    display: inline-flex;
+    align-items: center;
+    gap: 0.12rem;
+    padding: 0 2px;
+    border: none;
+    background: transparent;
+    line-height: 1;
+  }
+  #trainInfo table td:first-child .wx .wx-ico{ font-size: 0.62rem; }
+  #trainInfo table td:first-child .wx .wx-t{ font-size: 0.52rem; }
+
 
   /* Colonnes trains : compactées pour en afficher ~4 sur smartphone */
   #trainInfo table th:not(:first-child),
@@ -1890,6 +1923,13 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
 }
 
 #trainInfo table thead th:first-child{ z-index: 10; }
+
+#trainInfo table thead th:first-child{ z-index: 12; }
+#trainInfo table thead th:not(:first-child){ z-index: 7; }
+#trainInfo table thead th.status-head{ padding-top: 4px !important; padding-bottom: 4px !important; }
+#trainInfo table thead th .train-num{ display:block; line-height:1.05; }
+#trainInfo table thead th .train-state{ display:block; margin-top:2px; line-height:1; font-size:.86em; }
+
 
 .table-toolbar{
   display:flex;
@@ -6912,6 +6952,114 @@ html, body{ overflow-x: hidden; }
   }
 }
 
+
+/* Harmonisation espaces sur l'accueil (sans changer la hauteur des cartes) */
+@media (max-width: 768px){
+  #home.home-section{
+    gap: 12px !important;
+    margin: 18px 0 18px !important;
+  }
+  #home.home-section > .home-card,
+  #home.home-section > #favTrainsWidget,
+  #home.home-section > .home-dashboard,
+  #home.home-section > .home-fav-wrap{
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+}
+
+
+/* Carte intégrée */
+#carte .map-embed-shell{
+  border: 1px solid rgba(0, 240, 255, 0.25);
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(3, 10, 18, 0.88);
+  box-shadow: inset 0 0 12px rgba(0, 240, 255, 0.08);
+}
+#carte .map-embed-shell iframe{
+  width: 100%;
+  height: calc(100dvh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 84px) - 92px);
+  min-height: 520px;
+  border: 0;
+  display: block;
+  background: #07101b;
+}
+
+/* Mode carte plein écran sur smartphone: entre les barres fixes */
+:root{ --carte-top-offset: 72px; --carte-bottom-offset: 84px; }
+@media (max-width: 768px){
+  #carte{ margin: 0 !important; }
+
+  body.carte-fullscreen #home,
+  body.carte-fullscreen #search,
+  body.carte-fullscreen #favTrainsWidget,
+  body.carte-fullscreen #disruptionsSummary,
+  body.carte-fullscreen #trainInfo,
+  body.carte-fullscreen #refreshContainer,
+  body.carte-fullscreen #affluence,
+  body.carte-fullscreen #multimedia,
+  body.carte-fullscreen #statsConsole,
+  body.carte-fullscreen .home-card{ display:none !important; }
+
+  body.carte-fullscreen #carte,
+  #carte:target{
+    display:block !important;
+    position: fixed !important;
+    top: var(--carte-top-offset, var(--top-bar-height, 72px)) !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: var(--carte-bottom-offset, calc(max(var(--bottom-bar-height, 84px), var(--lb-bottomnav-h, 84px)) + env(safe-area-inset-bottom, 0px))) !important;
+    width: 100vw !important;
+    max-width: none !important;
+    z-index: 1000 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    border-radius: 0 !important;
+    background: #07101b;
+    pointer-events: none;
+    overflow: hidden !important;
+  }
+  body.carte-fullscreen #carte h2,
+  body.carte-fullscreen #carte p,
+  #carte:target h2,
+  #carte:target p{ display:none !important; }
+
+  body.carte-fullscreen #carte .map-embed-shell,
+  #carte:target .map-embed-shell{
+    position: absolute !important;
+    inset: 0 !important;
+    height: 100% !important;
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    pointer-events: auto;
+  }
+  body.carte-fullscreen #carte .map-embed-shell iframe,
+  #carte:target .map-embed-shell iframe{
+    height: 100% !important;
+    min-height: 100% !important;
+  }
+
+  body.carte-underlay #carte{
+    position: relative !important;
+    top: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+    left: auto !important;
+    width: auto !important;
+    height: 0 !important;
+    min-height: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    z-index: -1 !important;
+    pointer-events: none !important;
+  }
+}
+
 </style>
   <style>
 @supports (-webkit-touch-callout: none) {
@@ -6937,6 +7085,77 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
   requestAnimationFrame(step);
 }
   
+
+function initEmbeddedCarteFrame(){
+  const frame = document.querySelector('#carte iframe');
+  if (!frame || frame.dataset.embedInit === '1') return;
+  frame.dataset.embedInit = '1';
+
+  const hideInnerUi = () => {
+    try{
+      const doc = frame.contentDocument || frame.contentWindow?.document;
+      if (!doc) return;
+      const selectors = [
+        '.leaflet-top.leaflet-right',
+        '.map-title', '.map-header', '.hero', 'header', 'nav',
+        '[data-embed-hide]', '.banner', '.top-banner', '.project-support', '.support-project'
+      ];
+      selectors.forEach(sel => {
+        doc.querySelectorAll(sel).forEach(el => { el.style.display = 'none'; });
+      });
+      doc.body && (doc.body.style.marginTop = '0');
+      doc.documentElement && (doc.documentElement.style.marginTop = '0');
+    }catch(e){ /* cross-origin or selector unsupported */ }
+  };
+
+  frame.addEventListener('load', () => {
+    hideInnerUi();
+    let n = 0;
+    const t = setInterval(() => {
+      hideInnerUi();
+      n += 1;
+      if (n > 20) clearInterval(t);
+    }, 200);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initEmbeddedCarteFrame);
+
+function syncCarteFullscreenMode(){
+  const active = (location.hash || '') === '#carte';
+  const topH = Math.round(document.querySelector('.top-bar')?.getBoundingClientRect().height || parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--top-bar-height')) || 72);
+  const botH = Math.round(document.querySelector('.bottom-nav')?.getBoundingClientRect().height || parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--bottom-bar-height')) || 84);
+  document.documentElement.style.setProperty('--carte-top-offset', `${topH}px`);
+  document.documentElement.style.setProperty('--carte-bottom-offset', `calc(${botH}px + env(safe-area-inset-bottom, 0px))`);
+  document.body.classList.toggle('carte-fullscreen', active);
+  document.body.classList.toggle('carte-underlay', !active);
+
+  const frame = document.querySelector('#carte iframe');
+  if (frame) frame.style.pointerEvents = active ? 'auto' : 'none';
+
+  if (active) initEmbeddedCarteFrame();
+}
+
+window.addEventListener('hashchange', syncCarteFullscreenMode);
+window.addEventListener('resize', syncCarteFullscreenMode, { passive:true });
+
+document.addEventListener('DOMContentLoaded', () => {
+  syncCarteFullscreenMode();
+  const carteTab = document.querySelector('.bottom-nav__item[href="#carte"]');
+  carteTab?.addEventListener('click', () => setTimeout(syncCarteFullscreenMode, 0));
+
+  document.querySelectorAll('.bottom-nav__item[href]').forEach(link => {
+    link.addEventListener('click', () => {
+      if ((link.getAttribute('href') || '') !== '#carte') {
+        document.body.classList.remove('carte-fullscreen');
+        document.body.classList.add('carte-underlay');
+        const frame = document.querySelector('#carte iframe');
+        if (frame) frame.style.pointerEvents = 'none';
+      }
+    }, { passive: true });
+  });
+});
+
 </script>
 
 <style id="lb-typography">
@@ -7213,6 +7432,10 @@ html, body{
       <span class="bottom-nav__icon" aria-hidden="true">🏠</span>
       <span class="bottom-nav__label">Accueil</span>
     </a>
+    <a class="bottom-nav__item" href="#carte">
+      <span class="bottom-nav__icon" aria-hidden="true">🗺️</span>
+      <span class="bottom-nav__label">Carte</span>
+    </a>
     <a class="bottom-nav__item" href="#search">
       <span class="bottom-nav__icon" aria-hidden="true">📋</span>
       <span class="bottom-nav__label">Tableau</span>
@@ -7225,9 +7448,9 @@ html, body{
       <span class="bottom-nav__icon" aria-hidden="true">📊</span>
       <span class="bottom-nav__label">Stats</span>
     </a>
-	<a class="bottom-nav__item" href="#affluence">
-      <span class="bottom-nav__icon" aria-hidden="true">🚆</span>
-      <span class="bottom-nav__label">Affluence</span>
+	<a class="bottom-nav__item" href="#divertissement">
+      <span class="bottom-nav__icon" aria-hidden="true">🎉</span>
+      <span class="bottom-nav__label">Loisirs</span>
     </a>  
     <button class="bottom-nav__item" id="bottomAccountBtn" type="button">
       <span class="bottom-nav__icon" aria-hidden="true">👤</span>
@@ -7937,6 +8160,18 @@ html, body{
   </div>
 </div>
 
+<div id="tableauViewNav" role="tablist" aria-label="Sous-navigation Tableau" hidden>
+  <button type="button" class="tableau-view-tab" role="tab" aria-selected="false" data-tableau-view="perturbations">Détails perturbations</button>
+  <button type="button" class="tableau-view-tab" role="tab" aria-selected="true" data-tableau-view="global">Tableau global</button>
+  <button type="button" class="tableau-view-tab" role="tab" aria-selected="false" data-tableau-view="search">Nouvelle recherche</button>
+</div>
+
+<div id="loisirsViewNav" role="tablist" aria-label="Sous-navigation Loisirs" hidden>
+  <button type="button" class="tableau-view-tab" role="tab" aria-selected="true" data-loisirs-view="multimedia">🎬 Multimédia</button>
+  <button type="button" class="tableau-view-tab" role="tab" aria-selected="false" data-loisirs-view="bingo">🎲 Bingo</button>
+  <button type="button" class="tableau-view-tab" role="tab" aria-selected="false" data-loisirs-view="jeu">🎮 Jeu</button>
+</div>
+
 <!-- BLOC 1 : Perturbations + Informations -->
 <div id="disruptionsSummary" class="command-console" style="display:none;">
   <div class="disruption-header">Perturbations en cours</div>
@@ -7953,7 +8188,7 @@ html, body{
 <div class="home-card">
   <h2>Accès rapides</h2>
   <div class="quick-links">
-    <button class="quick-card" id="btnCarte" type="button"><span>🗺️</span>Carte</button>
+    <a class="quick-card" id="btnCarte" href="#carte"><span>🗺️</span>Carte</a>
     <button class="quick-card" id="btnBingo" type="button"><span>🎲</span>Bingo</button>
     <button class="quick-card" id="btnJeu" type="button"><span>🎮</span>Jeu</button>
     <a class="quick-card" href="#multimedia"><span>🎬</span>
@@ -7963,6 +8198,19 @@ html, body{
 	<a class="quick-card" href="#affluence"><span>🚆</span>Affluence</a>
   </div>
 </div>
+
+<section id="carte" class="media-section" aria-label="Carte en direct">
+  <h2>Carte en direct</h2>
+  <p>Accès complet à la carte La Bétaillère sans quitter l’application.</p>
+  <div class="map-embed-shell">
+    <iframe
+      src="https://www.labetaillere.fr/carte.html?embed=1"
+      title="Carte La Bétaillère"
+      loading="lazy"
+      referrerpolicy="strict-origin-when-cross-origin"
+      allowfullscreen></iframe>
+  </div>
+</section>
 
 <section id="affluence" class="media-section" aria-label="Affluence">
   <h2>Affluence (J0 à J+14)</h2>
@@ -8551,25 +8799,150 @@ html, body{
   #search .options-row{ gap: 10px !important; margin-top: 6px !important; }
   #search .option-toggle{ background: transparent !important; border: none !important; box-shadow: none !important; padding: 6px 6px !important; }
 
-  /* Bouton Rechercher FIXE en bas (au-dessus de la barre fixe) UNIQUEMENT sur l'écran #search */
-  #search:target{ padding-bottom: calc(env(safe-area-inset-bottom, 0px) + var(--bottomNavH) + 88px) !important; }
-  #search:target .actions-main{
+  /* Bouton Rechercher intégré à la console (non flottant) */
+  #search .actions-main{
     position: static !important;
-    margin: 0 !important;
+    margin-top: 10px !important;
     padding: 0 !important;
-    background: transparent !important;
-    border: none !important;
-    box-shadow: none !important;
-    height: 0 !important;
+    height: auto !important;
     overflow: visible !important;
   }
-  #search:target #presetBuilderSearch{
-    position: fixed !important;
-    left: 50% !important;
-    transform: translateX(-50%) !important;
-    bottom: calc(env(safe-area-inset-bottom, 0px) + var(--bottomNavH) + 10px) !important;
-    width: min(340px, calc(100vw - 28px)) !important;
-    z-index: 9999 !important;
+  #search #btnProposer{
+    position: static !important;
+    width: min(340px, calc(100vw - 36px)) !important;
+    margin: 0 auto !important;
+    transform: none !important;
+    left: auto !important;
+    bottom: auto !important;
+    z-index: auto !important;
+  }
+}
+
+/* ===== PATCH smartphone 2026-03-02: tableau full height + console plus pro ===== */
+@media (max-width: 768px){
+  #trainInfo .table-scroll{
+    height: calc(100dvh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 84px) - var(--tableau-viewbar-h, 0px) - 10px) !important;
+    max-height: calc(100dvh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 84px) - var(--tableau-viewbar-h, 0px) - 10px) !important;
+    overflow-y: auto !important;
+  }
+
+  .command-console{
+    padding: 16px;
+    border-radius: 16px;
+  }
+
+  .console-header{
+    font-size: 1rem;
+    margin-bottom: 8px;
+    letter-spacing: 0.02em;
+  }
+
+  .filters-selection{
+    border-top: 1px dashed rgba(0, 240, 255, 0.28);
+    margin-top: 10px;
+    padding-top: 10px;
+  }
+
+  #selectionInline{
+    background: linear-gradient(145deg, rgba(0, 30, 48, 0.88), rgba(0, 16, 30, 0.82));
+    border: 1px solid rgba(0, 240, 255, 0.28);
+    border-radius: 14px;
+    padding: 10px 12px;
+  }
+}
+
+/* Sous-barre Tableau (onglets) FIXE au-dessus de la barre du bas */
+:root{ --tableau-viewbar-h: 0px; }
+#tableauViewNav,
+#tableauViewNav[hidden]{ display:none !important; }
+#tableauViewNav.is-visible{
+  display:flex !important;
+  position: fixed;
+  left: 8px;
+  right: 8px;
+  bottom: calc(var(--bottom-bar-height, 84px) + env(safe-area-inset-bottom, 0px) + 4px);
+  z-index: 1290;
+  padding: 6px;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 240, 255, 0.35);
+  background: linear-gradient(135deg, rgba(7, 15, 30, 0.98), rgba(12, 24, 44, 0.96));
+  box-shadow: 0 8px 24px rgba(0, 240, 255, 0.16);
+  backdrop-filter: blur(10px);
+  gap: 6px;
+}
+#tableauViewNav .tableau-view-tab{
+  flex:1 1 0;
+  min-width:0;
+  margin:0 !important;
+  padding: 7px 6px !important;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 240, 255, 0.24);
+  background: rgba(0, 12, 24, 0.55);
+  color:#dffbff;
+  font-size: .70rem !important;
+  font-weight: 700;
+  letter-spacing: .02em;
+  line-height: 1.15;
+  max-width:none !important;
+}
+#tableauViewNav .tableau-view-tab.is-active{
+  border-color: rgba(0, 240, 255, 0.65);
+  background: linear-gradient(135deg, rgba(0,255,255,.86), rgba(0,170,255,.86));
+  color:#00111a;
+  box-shadow: 0 0 14px rgba(0,240,255,.45), inset 0 0 14px rgba(0,240,255,.35);
+}
+@media (max-width: 768px){
+  body.tableau-view-nav-visible{ --tableau-viewbar-h: 64px; }
+  #tableauViewNav.is-visible{
+    left: 0;
+    right: 0;
+    bottom: calc(var(--bottom-bar-height, 84px) + env(safe-area-inset-bottom, 0px));
+    border-left: 0;
+    border-right: 0;
+    border-radius: 14px 14px 0 0;
+    padding-left: max(8px, env(safe-area-inset-left, 0px));
+    padding-right: max(8px, env(safe-area-inset-right, 0px));
+  }
+}
+
+
+#loisirsViewNav,
+#loisirsViewNav[hidden]{ display:none !important; }
+#loisirsViewNav.is-visible{
+  display:flex !important;
+  position: fixed;
+  left: 8px;
+  right: 8px;
+  bottom: calc(var(--bottom-bar-height, 84px) + env(safe-area-inset-bottom, 0px) + 4px);
+  z-index: 1290;
+  padding: 6px;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 240, 255, 0.35);
+  background: linear-gradient(135deg, rgba(7, 15, 30, 0.98), rgba(12, 24, 44, 0.96));
+  box-shadow: 0 8px 24px rgba(0, 240, 255, 0.16);
+  backdrop-filter: blur(10px);
+  gap: 6px;
+}
+#loisirsViewNav .tableau-view-tab{
+  flex:1 1 0;
+  min-width:0;
+}
+#loisirsViewNav .tableau-view-tab.is-active{
+  border-color: rgba(0, 240, 255, 0.65);
+  background: linear-gradient(135deg, rgba(0,255,255,.86), rgba(0,170,255,.86));
+  color:#00111a;
+  box-shadow: 0 0 14px rgba(0,240,255,.45), inset 0 0 14px rgba(0,240,255,.35);
+}
+@media (max-width: 768px){
+  #loisirsViewNav.is-visible{
+    left: 0;
+    right: 0;
+    bottom: calc(var(--bottom-bar-height, 84px) + env(safe-area-inset-bottom, 0px));
+    border-left: 0;
+    border-right: 0;
+    border-radius: 14px 14px 0 0;
+    padding-left: max(8px, env(safe-area-inset-left, 0px));
+    padding-right: max(8px, env(safe-area-inset-right, 0px));
   }
 }
 
@@ -8621,6 +8994,11 @@ html, body{
       </div>
     </div>	
   </div></section>
+
+<section id="divertissement" class="media-section" aria-label="Loisirs" style="display:none;">
+  <h2>Loisirs</h2>
+  <p>Retrouve ici les sous-catégories Multimédia, Bingo et Jeu.</p>
+</section>
 
 <section id="multimedia" class="media-section" aria-label="Multimédia">
   <h2>Multimédia</h2>
@@ -9278,6 +9656,13 @@ async function loadVoiesByTrain({ forceFresh = false, onlyIfChanged = false } = 
   if (forceFresh) voiesByTrainPromise = null;
   if (voiesByTrainPromise) return voiesByTrainPromise;
 
+  if (!forceFresh && (!(window.voiesByTrainMap instanceof Map) || !window.voiesByTrainMap.size)) {
+    const cached = lbCacheRead('voiesByTrainMap', 90 * 1000);
+    if (Array.isArray(cached)) {
+      try { window.voiesByTrainMap = new Map(cached.map(([k,v]) => [k, new Map(v)])); } catch(_) {}
+    }
+  }
+
   voiesByTrainPromise = (async () => {
     try {
       const baseUrl = 'https://vps.labetaillere.fr/gtfs/voies_by_train.json';
@@ -9285,7 +9670,7 @@ async function loadVoiesByTrain({ forceFresh = false, onlyIfChanged = false } = 
 
       // On récupère le body en texte pour pouvoir comparer sans parser si identique
       const res = await fetch(url, {
-        cache: 'no-store',
+        cache: forceFresh ? 'no-store' : 'default',
         headers: (window.__voiesEtag && onlyIfChanged && !forceFresh) ? { 'If-None-Match': window.__voiesEtag } : {}
       });
 
@@ -9320,11 +9705,16 @@ async function loadVoiesByTrain({ forceFresh = false, onlyIfChanged = false } = 
       const json = JSON.parse(text);
       window.voiesByTrainMap = normalizeVoiesPayload(json);
       window.__voiesLastChanged = true;
+      try {
+        const serial = Array.from(window.voiesByTrainMap.entries()).map(([k,m]) => [k, Array.from(m.entries())]);
+        lbCacheWrite('voiesByTrainMap', serial);
+      } catch(_) {}
       return window.voiesByTrainMap;
 
     } catch (err) {
       console.warn('[Voies] Chargement échoué', err?.message || err);
       window.__voiesLastChanged = false;
+      if (window.voiesByTrainMap instanceof Map && window.voiesByTrainMap.size) return window.voiesByTrainMap;
       window.voiesByTrainMap = new Map();
       return window.voiesByTrainMap;
     }
@@ -9509,14 +9899,52 @@ function formatClockWithVoie(clock, voie){
   return `<span class="voie-info">${clock}<span class="voie-badge">${escapeHtml(label)}</span></span>`;
 }
 
-async function loadCompoData() {
+const LB_DATA_CACHE_VERSION = 'v1';
+
+function lbCacheRead(key, maxAgeMs){
+  try{
+    const raw = localStorage.getItem(`${LB_DATA_CACHE_VERSION}:${key}`);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const ts = Number(parsed.ts || 0);
+    if (!ts) return null;
+    if (Number.isFinite(maxAgeMs) && maxAgeMs > 0 && (Date.now() - ts) > maxAgeMs) return null;
+    return parsed.data ?? null;
+  }catch(_){ return null; }
+}
+
+function lbCacheWrite(key, data){
+  try{
+    localStorage.setItem(`${LB_DATA_CACHE_VERSION}:${key}`, JSON.stringify({ ts: Date.now(), data }));
+  }catch(_){ }
+}
+
+function lbRunInBackground(fn){
+  if (typeof requestIdleCallback === 'function') {
+    requestIdleCallback(() => fn(), { timeout: 1200 });
+  } else {
+    setTimeout(() => fn(), 0);
+  }
+}
+
+async function loadCompoData({ forceFresh = false, background = false } = {}) {
+  const COMPO_CACHE_MAX_AGE = 6 * 60 * 1000;
   try {
+    if (!forceFresh) {
+      const cached = lbCacheRead('compoData', COMPO_CACHE_MAX_AGE);
+      if (cached && typeof cached === 'object') {
+        window.compoData = cached;
+        updateCompoHeaderColors();
+        if (background) return cached;
+      }
+    }
+
     const COMPO_PRIMARY_URL = 'https://vps.labetaillere.fr/gtfs/Compotrains.json';
     const COMPO_FALLBACK_URL = 'https://raw.githubusercontent.com/TekMaTe-lux/Assistant-train/main/Compotrains.json';
 
-    // 1) VPS (prioritaire) → 2) GitHub (secours)
     const tryFetchJson = async (url) => {
-      const r = await fetch(url, { cache: 'no-store' });
+      const r = await fetch(url, { cache: forceFresh ? 'no-store' : 'default' });
       if (!r.ok) throw new Error('HTTP ' + r.status);
       return r.json();
     };
@@ -9529,9 +9957,12 @@ async function loadCompoData() {
       json = await tryFetchJson(COMPO_FALLBACK_URL);
     }
     window.compoData = { ...(json.NancyMetzLux||{}), ...(json.LuxMetzNancy||{}) };
+    lbCacheWrite('compoData', window.compoData);
     updateCompoHeaderColors();
+    return window.compoData;
   } catch (error) {
     console.error("Erreur lors du chargement des compositions :", error);
+    return window.compoData || null;
   }
 }
 
@@ -10063,11 +10494,8 @@ function injectTableChunkedIntoTrainInfo(html, {chunk=200} = {}){
   if (!tableSrc) { host.innerHTML = html; return; }
 
   // conteneur scrollable + horodatage
-  host.innerHTML = '<div class="table-toolbar"><button type="button" id="btnTableSnapshot" class="snapshot-btn" disabled title="Afficher une capture plein écran du tableau">🔍 Vue globale</button></div><div class="scroll-hint">← glisser →</div><div class="table-scroll"></div><div id="lastUpdated" class="last-updated" aria-live="polite"></div>';
+  host.innerHTML = '<div class="table-scroll"></div><div id="lastUpdated" class="last-updated" aria-live="polite"></div>';
   const scroller = host.querySelector('.table-scroll');
-  const snapshotBtn = host.querySelector('#btnTableSnapshot');
-  const scrollHint = host.querySelector('.scroll-hint');
-  if (scrollHint) scrollHint.style.display = 'none';
 
   // table cible
   const tableDst = document.createElement('table');
@@ -10122,24 +10550,9 @@ tableDst.style.setProperty('--lb-train-col-px', colPx + 'px');
   const dstBody = document.createElement('tbody');
   tableDst.appendChild(dstBody);
 
-  const refreshScrollHint = () => {
-    if (!scrollHint) return;
-    const hasOverflow = scroller && scroller.scrollWidth > scroller.clientWidth + 1;
-    scrollHint.style.display = hasOverflow ? 'block' : 'none';
-  };
-
-  const onResize = () => { refreshScrollHint(); adjustTrainTableRowHeights?.(); };
+  const onResize = () => { adjustTrainTableRowHeights?.(); };
   window.addEventListener('resize', onResize);
   host.__scrollHintCleanup = () => window.removeEventListener('resize', onResize);
-
-    if (snapshotBtn) {
-    snapshotBtn.addEventListener('click', () => {
-      const table = host.querySelector('.table-scroll table');
-      if (!table) return;
-      snapshotBtn.blur();
-      window.__openTrainTableSnapshot?.(table, snapshotBtn);
-    });
-  }
 
   let idx = 0;
   function pump(){
@@ -10154,8 +10567,6 @@ tableDst.style.setProperty('--lb-train-col-px', colPx + 'px');
       updateCompoHeaderColors?.();
       setLastUpdated?.();
       adjustTrainTableRowHeights?.();
-      refreshScrollHint();
-      if (snapshotBtn) snapshotBtn.disabled = false;
       // GTFS-RT (non bloquant)
       setTimeout(()=> {
         if (window.retardsGTFS && (typeof isSelectedDateToday !== 'function' || isSelectedDateToday())){
@@ -10190,18 +10601,28 @@ function adjustTrainTableRowHeights(){
 
   const thead = table.querySelector('thead');
   const headerH = thead ? Math.ceil(thead.getBoundingClientRect().height) : 0;
-
   const avail = Math.max(80, scroller.clientHeight - headerH - 6); // 6px marge
   let rowH = Math.floor(avail / n);
 
-  // bornes: on évite trop petit (illisible) et trop grand (absurde)
-  rowH = Math.max(26, Math.min(54, rowH));
+  // bornes: priorité absolue à voir tout le trajet sans scroll vertical interne
+  // (même avec beaucoup de gares), quitte à compacter fortement.
+  rowH = Math.max(7, Math.min(54, rowH));
 
-  // padding vertical cohérent avec la hauteur
-  const padY = Math.max(3, Math.min(10, Math.floor((rowH - 18) / 2)));
+  // padding ultra-compact pour les gros tableaux
+  const padY = Math.max(0, Math.min(8, Math.floor((rowH - 12) / 2)));
+
+  // typographie adaptative pour tenir toutes les lignes
+  const rowFont = rowH <= 9  ? '0.48rem'
+                : rowH <= 11 ? '0.52rem'
+                : rowH <= 13 ? '0.56rem'
+                : rowH <= 15 ? '0.60rem'
+                : rowH <= 18 ? '0.66rem'
+                : rowH <= 22 ? '0.72rem'
+                : '0.78rem';
 
   host.style.setProperty('--lb-row-h', rowH + 'px');
   host.style.setProperty('--lb-cell-pad-y', padY + 'px');
+  host.style.setProperty('--lb-row-font-size', rowFont);
 }
 
 /* Scroll vers le tableau généré pour le mettre immédiatement en vue */
@@ -14355,46 +14776,37 @@ const stopHasSchedule = (result, stopName) => {
     const favNumbers = getFavoriteNumbers();
     let html = '<table><thead><tr><th>Gare</th>';
     numbers.forEach(num => {
-  const composition = (typeof compoData !== 'undefined' && compoData) ? compoData[num] : '';
-      const compClass   = compoClassFromValue(composition); // ← force blanc si inconnu
+      const composition = (typeof compoData !== 'undefined' && compoData) ? compoData[num] : '';
+      const compClass   = compoClassFromValue(composition);
       const result = results[num];
       const isCfl = num.startsWith('CFL-');
       const cflLabel = isCfl
-        ? (result?.displayLabel
-            || TRAIN_LABEL_REGISTRY.get(num)
-            || formatTrainDisplayLabel(num, { result }))
+        ? (result?.displayLabel || TRAIN_LABEL_REGISTRY.get(num) || formatTrainDisplayLabel(num, { result }))
         : null;
       const headerLabel = isCfl ? (cflLabel || num) : num;
-      const classes = [`train-header`, compClass];
+      const classes = ['train-header', compClass, 'status-head'];
       if (isCfl) classes.push('cfl-train');
       const fallbackAttr = (!isCfl && result?.gtfsFallback) ? ' data-gtfs-fallback="1"' : '';
-	  const isFavorite = favNumbers.has(extractTrainNumber(num));
+      const isFavorite = favNumbers.has(extractTrainNumber(num));
       const favAttr = isFavorite ? ' data-favorite="1"' : '';
       const safeNumber = escapeHtml(num);
       const safeLabel = escapeHtml(headerLabel);
       TRAIN_LABEL_REGISTRY.set(num, headerLabel);
-      html += `<th class="${classes.join(' ')}" data-train-number="${safeNumber}" data-train-label="${safeLabel}"${fallbackAttr}${favAttr}>${safeLabel}</th>`;
-    });
-    html += '</tr><tr><th></th>';
 
-    /* Ligne d’icônes (statut) */
-    numbers.forEach(num => {
-      const result = results[num];
       let icon = '', title = '';
       if (!result || result.error) {
         icon = '❌'; title = result?.error || 'Erreur';
       } else if (result.gtfsFallback) {
-        icon = 'ℹ️';
-        title = result.fallbackDetails?.tooltip || 'Horaires théoriques (GTFS)';  
+        icon = 'ℹ️'; title = result.fallbackDetails?.tooltip || 'Horaires théoriques (GTFS)';
       } else {
         const disruptions = result.disruptions || [];
         const impacted = result.impacted || {};
-        const hasDelay = Object.values(impacted).some(s => {
-          const amended = s.amended_departure_time || s.amended_arrival_time;
-          const baseTime = s.base_departure_time || s.base_arrival_time;
+        const hasDelay = Object.values(impacted).some(st => {
+          const amended = st.amended_departure_time || st.amended_arrival_time;
+          const baseTime = st.base_departure_time || st.base_arrival_time;
           const hasAmendedDelay = amended && baseTime && dl(baseTime, amended) > 0;
-          const delayMinutes = (typeof s.delay_minutes !== 'undefined' && s.delay_minutes !== null)
-            ? Number(s.delay_minutes)
+          const delayMinutes = (typeof st.delay_minutes !== 'undefined' && st.delay_minutes !== null)
+            ? Number(st.delay_minutes)
             : null;
           const hasDelayFlag = Number.isFinite(delayMinutes) && delayMinutes > 0;
           return hasAmendedDelay || hasDelayFlag;
@@ -14409,18 +14821,19 @@ const stopHasSchedule = (result, stopName) => {
 
         if (isFull) {
           icon = '❌'; title = 'Train supprimé';
-          if (result.disruptionCauses?.length) title += ' : ' + result.disruptionCauses.join(', ');
         } else if (isPartial || isPartialEnd) {
           icon = '⚠️'; title = 'Suppression partielle';
-          if (result.disruptionCauses?.length) title += ' : ' + result.disruptionCauses.join(', ');
         } else if (hasDelay) {
           icon = '⏰'; title = 'Retard';
-          if (result.disruptionCauses?.length) title += ' : ' + result.disruptionCauses.join(', ');
         } else {
           icon = ''; title = 'Sans perturbation';
         }
+        if (result.disruptionCauses?.length && title !== 'Sans perturbation') {
+          title += ' : ' + result.disruptionCauses.join(', ');
+        }
       }
-      html += `<th><span class="icon" title="${title}">${icon}</span></th>`;
+
+      html += `<th class="${classes.join(' ')}" data-train-number="${safeNumber}" data-train-label="${safeLabel}"${fallbackAttr}${favAttr}><span class="train-num">${safeLabel}</span><span class="train-state icon" title="${title}">${icon}</span></th>`;
     });
 
     html += '</tr></thead><tbody>';
@@ -14581,7 +14994,10 @@ const stopHasSchedule = (result, stopName) => {
 
     // 6) Injection + hooks + liens (NOUVEL ORDRE)
     injectTableChunkedIntoTrainInfo(html, { chunk: 180 });
-    scrollTrainTableIntoView();
+    requestAnimationFrame(() => {
+      adjustTrainTableRowHeights();
+      scrollTrainTableIntoView();
+    });
 
     if (sncfFallback.used) {
       const host = document.getElementById('trainInfo');
@@ -14981,6 +15397,29 @@ const GTFS_RT_DATASETS = [
     const appendGtfsCacheBuster = (url, forceFresh) =>
   url + (url.includes('?') ? '&' : '?') + 't=' + (forceFresh ? Date.now() : 'soft');
 
+const GTFS_RT_CACHE_KEY = 'gtfsRtMerged';
+const GTFS_RT_CACHE_MAX_AGE = 90 * 1000;
+
+function hydrateGtfsRetardsFromCache(){
+  const cached = lbCacheRead(GTFS_RT_CACHE_KEY, GTFS_RT_CACHE_MAX_AGE);
+  if (!cached || typeof cached !== 'object') return false;
+  if (!cached.normalized || typeof cached.normalized !== 'object') return false;
+  window.retardsGTFS_RAW = cached.raw || null;
+  window.retardsGTFS = cached.normalized;
+  window.retardsGTFS_SOURCE = cached.source || 'cache-local';
+  tryApplyGtfsToCurrentTable();
+  return true;
+}
+
+function persistGtfsRetardsCache(){
+  if (!window.retardsGTFS || typeof window.retardsGTFS !== 'object') return;
+  lbCacheWrite(GTFS_RT_CACHE_KEY, {
+    raw: window.retardsGTFS_RAW || null,
+    normalized: window.retardsGTFS,
+    source: window.retardsGTFS_SOURCE || 'network'
+  });
+}
+
     const GTFS_NORMALIZED_STATION_MAP_KEY = '__gtfsNormalizedStationMap';
 
 function getOrInitGtfsNormalizedMap(bucket) {
@@ -15273,7 +15712,8 @@ for (const base of sources) {
   throw lastErr || new Error(`[GTFS-RT] ${label || id || 'dataset'} indisponible.`);
 }
 
-async function loadGtfsRetards({ forceFresh = false } = {}) {
+async function loadGtfsRetards({ forceFresh = false, useCachedFirst = false } = {}) {
+  if (useCachedFirst && !forceFresh) hydrateGtfsRetardsFromCache();
   const datasetResults = [];
   const rawByDataset = {};
   let lastErr = null;
@@ -15308,6 +15748,7 @@ const normalized = mergeGtfsNormalizedPayloads(datasetResults.map(r => r.normali
   window.retardsGTFS_RAW = rawPayload;
   window.retardsGTFS = normalized;
   window.retardsGTFS_SOURCE = sourceLabel;
+  persistGtfsRetardsCache();
 
   if (normalized && Object.keys(normalized).length === 0) {
     console.warn('[GTFS-RT] Données chargées mais aucun arrêt exploitable trouvé.');
@@ -15326,13 +15767,50 @@ const normalized = mergeGtfsNormalizedPayloads(datasetResults.map(r => r.normali
   tryApplyGtfsToCurrentTable();
 }
 
-// 1er chargement au load (frais)
+// 1er chargement + rafraîchissement intelligent en arrière-plan
+const LB_BG_REFRESH_STATE = { timer: null, inFlight: false };
+
+async function refreshLiveDataInBackground({ forceFresh = false } = {}){
+  if (!navigator.onLine) return;
+  if (LB_BG_REFRESH_STATE.inFlight) return;
+  LB_BG_REFRESH_STATE.inFlight = true;
+  try {
+    await Promise.allSettled([
+      loadCompoData({ forceFresh, background: true }),
+      loadVoiesByTrain({ forceFresh, onlyIfChanged: true }),
+      (typeof loadCflVoiesByTrain === 'function' ? loadCflVoiesByTrain({ forceFresh, onlyIfChanged: true }) : Promise.resolve()),
+      loadGtfsRetards({ forceFresh, useCachedFirst: !forceFresh })
+    ]);
+  } finally {
+    LB_BG_REFRESH_STATE.inFlight = false;
+  }
+}
+
+function scheduleBackgroundRefresh(immediate = false){
+  if (LB_BG_REFRESH_STATE.timer) clearTimeout(LB_BG_REFRESH_STATE.timer);
+  const hidden = document.visibilityState === 'hidden';
+  const delay = immediate ? 1500 : (hidden ? 4 * 60 * 1000 : 75 * 1000);
+  LB_BG_REFRESH_STATE.timer = setTimeout(async () => {
+    await refreshLiveDataInBackground({ forceFresh: false });
+    scheduleBackgroundRefresh(false);
+  }, delay);
+}
+
 window.addEventListener('load', () => {
-  loadCompoData(); // ← optionnel : charge Compotrains.json au démarrage
-  loadVoiesByTrain().catch(err => console.warn('[Voies] Préchargement échoué', err?.message || err));
-  loadGtfsRetards({ forceFresh: true })
-    .catch(err => console.error("Erreur GTFS-RT au load:", err));
+  // Affiche rapidement du cache local puis met à jour en fond (stale-while-revalidate).
+  loadCompoData({ forceFresh: false, background: false });
+  loadVoiesByTrain({ forceFresh: false, onlyIfChanged: false }).catch(err => console.warn('[Voies] Préchargement échoué', err?.message || err));
+  loadGtfsRetards({ forceFresh: false, useCachedFirst: true })
+    .catch(err => console.warn("GTFS-RT temporairement indisponible:", err));
+
+  lbRunInBackground(() => {
+    refreshLiveDataInBackground({ forceFresh: true });
+    scheduleBackgroundRefresh(false);
+  });
 });
+
+window.addEventListener('online', () => scheduleBackgroundRefresh(true));
+document.addEventListener('visibilitychange', () => scheduleBackgroundRefresh(true));
 
 // applique si tableau présent + date = aujourd’hui
 function tryApplyGtfsToCurrentTable() {
@@ -15891,9 +16369,6 @@ document.getElementById("btnJeu").addEventListener("click", function() {
 </script>
 <script>
  // Gestion du bouton Carte
-document.getElementById("btnCarte").addEventListener("click", function() {
-  window.location.href = "https://www.labetaillere.fr/carte.html";
-});
 </script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
@@ -20474,39 +20949,49 @@ function lbRenderHomeFavPreview(){
 
   // clic / clavier -> ouvre le bon favori (Matin / Soir)
   const jumpToFav = (k) => {
-    // 1) va à la section favoris
     location.hash = '#favTrainsWidget';
 
-    // 2) puis scroll sur la carte précise + highlight (avec offset top-bar)
     const getTopOffset = () => {
       try{
         const topBar = document.querySelector('.top-bar');
-        if (topBar) return Math.round(topBar.getBoundingClientRect().height) + 10;
+        if (topBar) return Math.round(topBar.getBoundingClientRect().height) + 8;
         const css = getComputedStyle(document.documentElement).getPropertyValue('--top-bar-height').trim();
-        if (css && css.endsWith('px')) return (parseFloat(css) || 0) + 10;
+        if (css && css.endsWith('px')) return (parseFloat(css) || 0) + 8;
       }catch(e){}
-      return 72; // fallback safe
+      return 72;
+    };
+    const getBottomOffset = () => {
+      try{
+        const bottom = document.querySelector('.bottom-nav');
+        if (bottom) return Math.round(bottom.getBoundingClientRect().height) + 8;
+        const css = getComputedStyle(document.documentElement).getPropertyValue('--bottom-bar-height').trim();
+        if (css && css.endsWith('px')) return (parseFloat(css) || 0) + 8;
+      }catch(e){}
+      return 84;
     };
 
     window.setTimeout(() => {
       const id = (k === 'PM') ? 'favCardPM' : 'favCardAM';
       const card = document.getElementById(id);
       if (!card) return;
-      try{ card.scrollIntoView({ behavior: 'smooth', block: 'start' }); }catch(e){ card.scrollIntoView(true); }
 
-      // compensation: top-bar fixe -> évite de “couper” le haut de la carte (numéro de train)
-      window.setTimeout(() => {
-        const off = getTopOffset();
-        try{ window.scrollBy({ top: -off, left: 0, behavior: 'auto' }); }catch(e){ window.scrollBy(0, -off); }
-      }, 90);
-      window.setTimeout(() => {
-        const off = getTopOffset();
-        try{ window.scrollBy({ top: -off, left: 0, behavior: 'auto' }); }catch(e){ window.scrollBy(0, -off); }
-      }, 220);
+      const topOff = getTopOffset();
+      const botOff = getBottomOffset();
+      const vh = window.innerHeight || document.documentElement.clientHeight || 800;
+      const visibleH = Math.max(120, vh - topOff - botOff);
+      const rect = card.getBoundingClientRect();
+      const absTop = rect.top + (window.pageYOffset || document.documentElement.scrollTop || 0);
+      const targetY = absTop - topOff - Math.max(0, (visibleH - rect.height) / 2);
+
+      try{
+        window.scrollTo({ top: Math.max(0, Math.round(targetY)), behavior: 'smooth' });
+      }catch(e){
+        window.scrollTo(0, Math.max(0, Math.round(targetY)));
+      }
 
       card.classList.add('home-jump-highlight');
       window.setTimeout(()=>card.classList.remove('home-jump-highlight'), 1300);
-    }, 60);
+    }, 80);
   };
 
   slot.querySelectorAll('.home-fav-row').forEach(row=>{
@@ -21359,6 +21844,194 @@ async function loadAffluenceDate(dateStr){
     openTrain: lbOpenAffluenceTrain
   };
   window.lbOpenAffluenceTrain = lbOpenAffluenceTrain;
+})();
+
+(function(){
+  const nav = document.getElementById('tableauViewNav');
+  const search = document.getElementById('search');
+  const disruptions = document.getElementById('disruptionsSummary');
+  const trainInfo = document.getElementById('trainInfo');
+  if (!nav || !search || !disruptions || !trainInfo) return;
+
+  const tabs = Array.from(nav.querySelectorAll('[data-tableau-view]'));
+  let currentView = 'global';
+
+  const hasGeneratedTable = () => !!trainInfo.querySelector('table');
+  const onTableTab = () => (location.hash || '#home') === '#search';
+
+  function activateButton(view){
+    tabs.forEach(tab => { const active = tab.dataset.tableauView === view; tab.classList.toggle('is-active', active); tab.setAttribute('aria-selected', active ? 'true' : 'false'); });
+  }
+
+  function applyView(view, opts = {}){
+    const hasTable = hasGeneratedTable();
+    if (!hasTable){
+      search.style.display = '';
+      disruptions.style.display = 'none';
+      trainInfo.style.display = '';
+      nav.hidden = true;
+      nav.classList.remove('is-visible');
+      document.body.classList.remove('tableau-view-nav-visible');
+      return;
+    }
+
+    currentView = view;
+    activateButton(view);
+    search.style.display = (view === 'search') ? '' : 'none';
+    disruptions.style.display = (view === 'perturbations') ? 'flex' : 'none';
+    trainInfo.style.display = (view === 'global') ? '' : 'none';
+
+    const showNav = hasTable && onTableTab() && view !== 'search';
+    nav.hidden = !showNav;
+    nav.classList.toggle('is-visible', showNav);
+    document.body.classList.toggle('tableau-view-nav-visible', showNav);
+
+    if (opts.scroll !== false){
+      const target = view === 'search' ? search : (view === 'perturbations' ? disruptions : trainInfo);
+      requestAnimationFrame(() => target.scrollIntoView({ behavior: 'smooth', block: 'start' }));
+    }
+  }
+
+  function refreshNav(opts = {}){
+    const hasTable = hasGeneratedTable();
+    const showNav = hasTable && onTableTab() && currentView !== 'search';
+    nav.hidden = !showNav;
+    nav.classList.toggle('is-visible', showNav);
+    document.body.classList.toggle('tableau-view-nav-visible', showNav);
+    if (!showNav){
+      if (onTableTab()){
+        search.style.display = '';
+        if (!opts.keepCurrentPanels){
+          disruptions.style.display = disruptions.style.display || 'none';
+          trainInfo.style.display = '';
+        }
+      }
+      return;
+    }
+    applyView(currentView || 'global', { scroll: false });
+  }
+
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      const view = tab.dataset.tableauView;
+      applyView(view);
+      if (view === 'global'){
+        const table = document.querySelector('#trainInfo .table-scroll table');
+        if (table){
+          window.__openTrainTableSnapshot?.(table, tab);
+        }
+      }
+    });
+  });
+
+  window.addEventListener('hashchange', () => refreshNav({ keepCurrentPanels: true }));
+
+  document.querySelectorAll('.bottom-nav__item[href]').forEach(link => {
+    link.addEventListener('click', () => {
+      const href = link.getAttribute('href') || '';
+      if (href !== '#search'){
+        nav.hidden = true;
+        nav.classList.remove('is-visible');
+        document.body.classList.remove('tableau-view-nav-visible');
+      }
+    }, { passive: true });
+  });
+
+  const tableNavLink = document.querySelector('.bottom-nav__item[href="#search"]');
+  if (tableNavLink){
+    tableNavLink.addEventListener('click', (e) => {
+      if (!hasGeneratedTable()) return;
+      e.preventDefault();
+      if ((location.hash || '') !== '#search') location.hash = 'search';
+      currentView = 'global';
+      refreshNav();
+      applyView('global');
+    });
+  }
+
+  const mo = new MutationObserver(() => {
+    if (hasGeneratedTable()){
+      currentView = 'global';
+      if (onTableTab()){
+        refreshNav();
+        applyView('global');
+      }
+    } else {
+      refreshNav();
+    }
+  });
+  mo.observe(trainInfo, { childList: true, subtree: true });
+
+  document.addEventListener('DOMContentLoaded', () => refreshNav());
+  refreshNav();
+})();
+
+
+(function(){
+  const nav = document.getElementById('loisirsViewNav');
+  const loisirsLink = document.querySelector('.bottom-nav__item[href="#divertissement"]');
+  const multimediaSection = document.getElementById('multimedia');
+  const bingoBtn = document.getElementById('btnBingo');
+  const jeuBtn = document.getElementById('btnJeu');
+  if (!nav || !loisirsLink || !multimediaSection) return;
+
+  const tabs = Array.from(nav.querySelectorAll('[data-loisirs-view]'));
+  const onLoisirsTab = () => ['#divertissement', '#multimedia'].includes(location.hash || '');
+
+  function activate(view){
+    tabs.forEach(tab => {
+      const active = tab.dataset.loisirsView === view;
+      tab.classList.toggle('is-active', active);
+      tab.setAttribute('aria-selected', active ? 'true' : 'false');
+    });
+  }
+
+  function openView(view, opts = {}){
+    activate(view);
+    if (view === 'multimedia'){
+      if ((location.hash || '') !== '#multimedia') location.hash = 'multimedia';
+      if (opts.scroll !== false) requestAnimationFrame(() => multimediaSection.scrollIntoView({ behavior: 'smooth', block: 'start' }));
+      return;
+    }
+    if (view === 'bingo') bingoBtn?.click();
+    if (view === 'jeu') jeuBtn?.click();
+  }
+
+  function refresh(){
+    const show = onLoisirsTab();
+    nav.hidden = !show;
+    nav.classList.toggle('is-visible', show);
+    document.body.classList.toggle('loisirs-view-nav-visible', show);
+    if (show){
+      const current = (location.hash || '') === '#multimedia' ? 'multimedia' : (tabs.find(t => t.classList.contains('is-active'))?.dataset.loisirsView || 'multimedia');
+      activate(current);
+    }
+  }
+
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => openView(tab.dataset.loisirsView));
+  });
+
+  loisirsLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    if ((location.hash || '') !== '#divertissement') location.hash = 'divertissement';
+    refresh();
+    openView('multimedia', { scroll: true });
+  });
+
+  document.querySelectorAll('.bottom-nav__item[href]').forEach(link => {
+    link.addEventListener('click', () => {
+      if ((link.getAttribute('href') || '') !== '#divertissement') {
+        nav.hidden = true;
+        nav.classList.remove('is-visible');
+        document.body.classList.remove('loisirs-view-nav-visible');
+      }
+    }, { passive: true });
+  });
+
+  window.addEventListener('hashchange', refresh);
+  document.addEventListener('DOMContentLoaded', refresh);
+  refresh();
 })();
 </script>
 


### PR DESCRIPTION
### Motivation
- Improve mobile usability by providing an embedded fullscreen map, a compact/scrollable train table and a lightweight sub-navigation for the tableau and leisure sections.
- Reduce network load and make live data more resilient by caching GTFS, voies and composition payloads and supporting stale-while-revalidate background refresh.
- Fix layering/interaction issues for fixed bars and bottom navigation and surface richer train header/status info for better UX.

### Description
- Add an embedded map section `#carte` with an iframe and initialization logic in `initEmbeddedCarteFrame`, plus `syncCarteFullscreenMode` to handle fullscreen/underlay behavior and pointer-events toggling; include CSS for fullscreen map layout between fixed top/bottom bars.
- Implement mobile/tableau UI improvements: compact row sizing via `adjustTrainTableRowHeights`, CSS variable tuning for mobile (`--lb-row-h`, `--lb-row-font-size`), and new sub-navigation panels `#tableauViewNav` and `#loisirsViewNav` with JS controllers to switch views and show/hide relevant panels.
- Add simple localStorage cache helpers `lbCacheRead`/`lbCacheWrite` and `lbRunInBackground`, persist `voiesByTrainMap`, `compoData` and merged GTFS-RT payloads, and hydrate from cache on startup to speed initial render.
- Change data-loading functions to be more robust and background-friendly: `loadCompoData`, `loadVoiesByTrain` and `loadGtfsRetards` now use cache/fallbacks, conditional fetch caching, lightweight signatures to avoid reparse, and new helpers `hydrateGtfsRetardsFromCache`/`persistGtfsRetardsCache` plus `refreshLiveDataInBackground` and `scheduleBackgroundRefresh` to periodically refresh data.
- Miscellaneous UI tweaks: increase z-index for top/bottom bars, enable `pointer-events` for bottom nav items, adjust favorite jump scrolling offsets, add train status spans and `status-head` class in headers, and swap/rename bottom-nav items to expose the map and a "Loisirs" category.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a53f242038832d9c99cbbd581e3030)