### PR TITLE
Add internal Train detail panel with affluence chart, reliability and internal linking

### DIFF
--- a/index02.html
+++ b/index02.html
@@ -1598,6 +1598,77 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   cursor: pointer;           /* Indique que c'est cliquable */
 }
 
+.train-detail-panel{
+  margin: 12px 0 16px;
+  border: 1px solid rgba(0, 240, 255, 0.32);
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(7, 15, 30, 0.96), rgba(11, 23, 42, 0.94));
+  box-shadow: 0 10px 30px rgba(0, 240, 255, 0.10);
+  padding: 14px;
+}
+.train-detail-panel[hidden]{ display:none !important; }
+.train-detail-top{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:10px;
+  margin-bottom:10px;
+}
+.train-detail-top h3{
+  margin:0;
+  color:#7ef7ff;
+  letter-spacing:.04em;
+}
+.train-detail-close{
+  border:1px solid rgba(0,240,255,.45);
+  border-radius:999px;
+  background:rgba(0,16,28,.5);
+  color:#dffbff;
+  cursor:pointer;
+  padding:6px 10px;
+}
+.train-detail-grid{
+  display:grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap:10px;
+}
+.train-detail-card{
+  border:1px solid rgba(0, 240, 255, 0.2);
+  border-radius:10px;
+  padding:10px;
+  background:rgba(0, 10, 20, 0.42);
+}
+.train-detail-card .k{ opacity:.78; font-size:.78rem; text-transform:uppercase; letter-spacing:.07em; }
+.train-detail-card .v{ margin-top:4px; font-weight:700; color:#dffbff; }
+.train-detail-route{
+  margin-top:10px;
+  border:1px solid rgba(0, 240, 255, 0.2);
+  border-radius:10px;
+  background:rgba(0,10,20,.35);
+  max-height:260px;
+  overflow:auto;
+}
+.train-detail-stop{ display:flex; justify-content:space-between; gap:10px; padding:8px 10px; border-bottom:1px solid rgba(0,240,255,.08); }
+.train-detail-stop:last-child{ border-bottom:none; }
+.train-detail-actions{ margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
+.train-detail-btn{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  border:1px solid rgba(0,240,255,.4);
+  border-radius:999px;
+  color:#dffbff;
+  text-decoration:none;
+  padding:6px 12px;
+  background:rgba(0,16,28,.5);
+}
+
+.train-detail-minirow{ display:flex; justify-content:space-between; gap:10px; padding:6px 0; border-bottom:1px dashed rgba(0,240,255,.12); }
+.train-detail-minirow:last-child{ border-bottom:none; }
+.train-detail-minirow .right{ text-align:right; }
+.train-detail-reliability-badges{ display:flex; gap:8px; flex-wrap:wrap; margin-top:6px; }
+.train-detail-reliability-badges span{ font-size:.82rem; }
+
 /* Pastille météo (lien) – intégrée, sans bleu ni souligné */
 #trainInfo .wx a.wx-link{
   color: inherit;                 /* hérite la couleur du texte du tableau */
@@ -8180,6 +8251,35 @@ html, body{
 
 <!-- BLOC 2 : Infos trains -->
 <div id="trainInfo"></div>
+<section id="trainDetailPanel" class="train-detail-panel" hidden aria-live="polite">
+  <div class="train-detail-top">
+    <div>
+      <h3 id="trainDetailTitle">Train —</h3>
+      <div id="trainDetailSubtitle" style="opacity:.82; font-size:.9rem">Détails internes</div>
+    </div>
+    <button id="trainDetailClose" class="train-detail-close" type="button" aria-label="Fermer le détail">✕</button>
+  </div>
+  <div class="train-detail-grid">
+    <div class="train-detail-card"><div class="k">Statut du jour / prochain train</div><div class="v" id="trainDetailNext">—</div></div>
+    <div class="train-detail-card"><div class="k">Fiabilité sur un mois</div><div class="v" id="trainDetailReliability">—</div></div>
+    <div class="train-detail-card"><div class="k">Affluence prévue (max)</div><div class="v" id="trainDetailAffluence">—</div></div>
+    <div class="train-detail-card"><div class="k">Composition prévue</div><div class="v" id="trainDetailCompo">—</div></div>
+    <div class="train-detail-card" style="grid-column:1/-1"><div class="k">Parcours</div><div class="v" id="trainDetailPath">—</div></div>
+  </div>
+  <div class="train-detail-card" style="margin-top:10px">
+    <div class="k">Détails fiabilité</div>
+    <div id="trainDetailReliabilityDetails" style="margin-top:6px">—</div>
+  </div>
+  <div class="train-detail-card" style="margin-top:10px">
+    <div class="k">Affluence par gare</div>
+    <div class="aff-chart" style="margin-top:8px"><canvas id="trainDetailAffluenceChart" height="140"></canvas></div>
+  </div>
+  <div class="train-detail-route" id="trainDetailStops"></div>
+  <div class="train-detail-actions">
+    <a id="trainDetailAffBtn" class="train-detail-btn" href="#affluence">🚆 Ouvrir dans Affluence</a>
+    <a id="trainDetailStatsBtn" class="train-detail-btn" href="#statsConsole">📊 Voir schéma stats du train</a>
+  </div>
+</section>
 
 <div id="refreshContainer" style="display:none; text-align:center; margin:8px 0 6px;">
   <button id="refreshButton" class="refresh-btn">Actualiser les données</button>
@@ -15088,9 +15188,18 @@ function linkifyGaresAndTrains(root){
       return;
     }
     const already = th.querySelector('a.train-link');
-    const url = `https://www.sncf-voyageurs.com/fr/voyagez-avec-nous/horaires-et-itineraires/recherche-de-train/detail-train/?numeroCirculation=${numero}&dateCirculation=${dateCirculation}`;
-    if (already) { already.href = url; already.textContent = numero; }
-    else { th.innerHTML = `<a href="${url}" target="_blank" rel="noopener" class="train-link">${numero}</a>`; }
+    const internalHref = `#train-detail-${numero}`;
+    if (already) {
+      already.href = internalHref;
+      already.textContent = numero;
+      already.removeAttribute('target');
+      already.removeAttribute('rel');
+      already.dataset.trainNumber = numero;
+      already.dataset.trainDate = dateCirculation || '';
+    }
+    else {
+      th.innerHTML = `<a href="${internalHref}" class="train-link" data-train-number="${numero}" data-train-date="${dateCirculation || ''}">${numero}</a>`;
+    }
 	applyFavStar(th);
     if (th.dataset.gtfsFallback === '1' && !th.querySelector('.fallback-pill')) {
       const pill = document.createElement('span');
@@ -20358,6 +20467,13 @@ if (statsEl){
         return;
       }
 
+      const gtfsRetard = cell.querySelector('.gtfs-retard');
+      if (gtfsRetard) {
+        const gtfsBase = gtfsRetard.querySelector('.gtfs-retard-base');
+        if (gtfsBase) gtfsBase.innerHTML = baseWithVoie;
+        return;
+      }
+
       const strong = cell.querySelector('strong');
       if (strong) {
         strong.innerHTML = baseWithVoie;
@@ -20375,7 +20491,7 @@ if (statsEl){
         return;
       }
 
-      if (!cell.querySelector('.delayed')) {
+      if (!cell.querySelector('.delayed') && !cell.querySelector('.gtfs-retard')) {
         cell.innerHTML = baseWithVoie;
       }
     };
@@ -21920,7 +22036,296 @@ async function loadAffluenceDate(dateStr){
     summary: lbGetAffluenceSummary,
     openTrain: lbOpenAffluenceTrain
   };
+
   window.lbOpenAffluenceTrain = lbOpenAffluenceTrain;
+})();
+
+(function(){
+  const luxTodayYMD = () => new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Luxembourg' });
+  const esc = (v) => String(v ?? '').replace(/[&<>"']/g, (ch) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch] || ch));
+  const fmtDateFr = (iso) => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(String(iso||''))) return 'date inconnue';
+    const d = new Date(`${iso}T00:00:00`);
+    return d.toLocaleDateString('fr-FR', { day:'numeric', month:'long', year:'numeric' });
+  };
+  const hhmmToMin = (raw) => {
+    const digits = String(raw||'').replace(/\D/g, '');
+    if (digits.length < 4) return null;
+    const hh = Number(digits.slice(0,2));
+    const mm = Number(digits.slice(2,4));
+    if (!Number.isFinite(hh) || !Number.isFinite(mm) || mm > 59) return null;
+    return hh * 60 + mm;
+  };
+  const minToClock = (m) => Number.isFinite(m) ? `${String(Math.floor(m/60)).padStart(2,'0')}:${String(m%60).padStart(2,'0')}` : '—';
+  const luxNowMin = () => {
+    const parts = new Intl.DateTimeFormat('fr-FR', { timeZone:'Europe/Luxembourg', hour:'2-digit', minute:'2-digit', hourCycle:'h23' }).formatToParts(new Date());
+    const hh = Number(parts.find(p => p.type === 'hour')?.value || 0);
+    const mm = Number(parts.find(p => p.type === 'minute')?.value || 0);
+    return hh * 60 + mm;
+  };
+
+  const state = { affChart: null };
+  const affColor = (pct) => {
+    const p = Number(pct);
+    if (!Number.isFinite(p)) return '#9aa7b6';
+    if (p < 50) return '#24c25a';
+    if (p < 70) return '#ffd166';
+    if (p < 85) return '#ff8a1a';
+    if (p < 95) return '#ff3131';
+    return '#111';
+  };
+  function destroyAffChart(){
+    if (state.affChart){
+      try{ state.affChart.destroy(); }catch(_){ }
+      state.affChart = null;
+    }
+  }
+
+  async function getReliabilityData(trainNumber){
+    try{
+      const stats = window.__lbStats || {};
+      if (typeof stats.getLastDaysRange !== 'function' || typeof stats.getRawRange !== 'function' || typeof stats.computeTrainSeriesFromRawDays !== 'function') return null;
+      const r = stats.getLastDaysRange(30);
+      if (!r?.from || !r?.to) return null;
+      const rawDays = await stats.getRawRange(r.from, r.to);
+      const range = stats.computeTrainSeriesFromRawDays(rawDays || [], r.from, r.to, String(trainNumber), null);
+      const s = Array.isArray(range?.series) ? range.series : [];
+      if (!s.length) return null;
+
+      let onTime = 0, delayed = 0, canceled = 0, partial = 0;
+      for (const d of s){
+        const b = String(d?.bucket || '');
+        if (!b) continue;
+        if (b === 'ON_TIME') onTime += 1;
+        else if (b === 'DELAYED') delayed += 1;
+        else if (b === 'CANCELED') canceled += 1;
+        else if (b === 'PARTIAL') partial += 1;
+      }
+      const total = onTime + delayed + canceled + partial;
+      if (!total) return null;
+      const delayValues = s
+        .filter(d => String(d?.bucket || '') === 'DELAYED' && Number.isFinite(Number(d?.value)))
+        .map(d => Number(d.value));
+      const avgDelay = delayValues.length ? Math.round(delayValues.reduce((a,b)=>a+b,0) / delayValues.length) : 0;
+      const maxDelay = delayValues.length ? Math.max(...delayValues) : 0;
+      return {
+        pct: Math.round((onTime / total) * 100),
+        onTime, delayed, canceled, partial,
+        avgDelay, maxDelay
+      };
+    }catch(_){ return null; }
+  }
+
+  function firstDepartureFromStopTimes(stopTimes){
+    if (!Array.isArray(stopTimes) || !stopTimes.length) return null;
+    return hhmmToMin(stopTimes[0]?.departure_time || stopTimes[0]?.arrival_time);
+  }
+
+  async function computeNextDepartureLabelEnhanced(trainNumber, dateIso, stopTimes){
+    const depMin = firstDepartureFromStopTimes(stopTimes);
+    const arrMin = hhmmToMin(stopTimes?.[stopTimes.length - 1]?.arrival_time || stopTimes?.[stopTimes.length - 1]?.departure_time);
+    if (!Number.isFinite(depMin)) return 'Non disponible';
+    const today = luxTodayYMD();
+    if (dateIso === today){
+      const now = luxNowMin();
+      if (Number.isFinite(arrMin) && now > arrMin){
+        const td = new Date(`${today}T00:00:00`); td.setDate(td.getDate()+1);
+        const tomorrow = td.toISOString().slice(0,10);
+        try{
+          const fb = await buildGtfsFallbackResult(String(trainNumber||''), { ymd: tomorrow.replace(/-/g,'') });
+          const tDep = firstDepartureFromStopTimes(fb?.train?.stop_times || []);
+          if (Number.isFinite(tDep)) return `Terminé aujourd’hui • prochain train demain à ${minToClock(tDep)}`;
+        }catch(_){ }
+        return `Terminé aujourd'hui (arrivé vers ${minToClock(arrMin)})`;
+      }
+      if (now >= depMin) return `En cours (départ ${minToClock(depMin)})`;
+      return `Aujourd'hui à ${minToClock(depMin)} (dans ${depMin - now} min)`;
+    }
+    const tomorrow = (()=>{ const d=new Date(`${today}T00:00:00`); d.setDate(d.getDate()+1); return d.toISOString().slice(0,10); })();
+    if (dateIso === tomorrow) return `Demain à ${minToClock(depMin)}`;
+    return `Le ${fmtDateFr(dateIso)} à ${minToClock(depMin)}`;
+  }
+
+  function renderAffluenceChartFromInfo(info){
+    const cvs = document.getElementById('trainDetailAffluenceChart');
+    if (!cvs || !window.Chart) return;
+    const stops = Array.isArray(info?.stops) ? info.stops : [];
+    const labels = stops.map(s => String(s?.station || s?.name || '—'));
+    const values = stops.map(s => {
+      const p = Number(s?.globalPct ?? Math.round((Number(s?.globalOcc)||0)*100));
+      return Number.isFinite(p) ? Math.max(0, Math.min(100, Math.round(p))) : null;
+    });
+    destroyAffChart();
+    if (!labels.length) return;
+    state.affChart = new Chart(cvs, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          data: values,
+          borderColor: 'rgba(0,240,255,.85)',
+          backgroundColor: 'rgba(0,240,255,.12)',
+          tension: .25,
+          fill: false,
+          pointRadius: 5,
+          pointBackgroundColor: values.map(v => affColor(v)),
+          pointBorderColor: 'rgba(255,255,255,.8)',
+          pointBorderWidth: 1.5
+        }]
+      },
+      options: {
+        animation: false,
+        plugins: { legend: { display:false } },
+        scales: {
+          y: { min:0, max:100, ticks:{ color:'rgba(210,250,255,.9)', callback:v=>`${v}%` }, grid:{ color:'rgba(0,255,255,.12)' } },
+          x: { ticks:{ color:'rgba(210,250,255,.9)' }, grid:{ color:'rgba(0,255,255,.08)' } }
+        }
+      }
+    });
+  }
+
+  async function renderAffluenceBlock(trainNumber, selectedDate){
+    const affEl = document.getElementById('trainDetailAffluence');
+    if (typeof window.lbAff?.loadDate === 'function') {
+      try { await window.lbAff.loadDate(selectedDate); } catch(_) {}
+    }
+    const info = (typeof window.getAffluenceTrainInfo === 'function') ? window.getAffluenceTrainInfo(String(trainNumber)) : null;
+    if (!info){
+      affEl.textContent = 'Non disponible';
+      destroyAffChart();
+      return null;
+    }
+    const maxPct = Array.isArray(info.stops)
+      ? info.stops.reduce((mx,s)=>{
+          const p = Number(s?.globalPct ?? Math.round((Number(s?.globalOcc)||0)*100));
+          return Number.isFinite(p) ? Math.max(mx, Math.round(p)) : mx;
+        }, 0)
+      : (Number.isFinite(Number(info.depPct)) ? Math.round(Number(info.depPct)) : null);
+    affEl.textContent = Number.isFinite(maxPct) ? `${maxPct}%` : 'Non disponible';
+    renderAffluenceChartFromInfo(info);
+    return info;
+  }
+
+  async function openInternalTrainPanel(trainNumber, dateIso){
+    const panel = document.getElementById('trainDetailPanel');
+    if (!panel) return;
+    const selectedDate = /^\d{4}-\d{2}-\d{2}$/.test(String(dateIso||'')) ? String(dateIso) : (document.getElementById('trainDate')?.value || luxTodayYMD());
+    const ymd = selectedDate.replace(/-/g, '');
+
+    const titleEl = document.getElementById('trainDetailTitle');
+    const subtitleEl = document.getElementById('trainDetailSubtitle');
+    const nextEl = document.getElementById('trainDetailNext');
+    const relEl = document.getElementById('trainDetailReliability');
+    const relDetailsEl = document.getElementById('trainDetailReliabilityDetails');
+    const pathEl = document.getElementById('trainDetailPath');
+    const stopsEl = document.getElementById('trainDetailStops');
+    const affBtn = document.getElementById('trainDetailAffBtn');
+    const statsBtn = document.getElementById('trainDetailStatsBtn');
+
+    panel.hidden = false;
+    titleEl.textContent = `Train ${trainNumber}`;
+    subtitleEl.textContent = `Vue interne avancée • ${fmtDateFr(selectedDate)}`;
+    nextEl.textContent = 'Chargement…';
+    relEl.textContent = 'Chargement…';
+    relDetailsEl.textContent = 'Chargement…';
+    pathEl.textContent = 'Chargement…';
+    stopsEl.innerHTML = '<div class="train-detail-stop"><span>Récupération du parcours…</span></div>';
+
+    if (typeof loadCompoData === 'function') {
+      try { await loadCompoData({ forceFresh: false, background: true }); } catch(_) {}
+    }
+
+    let fallback = null;
+    try { fallback = await buildGtfsFallbackResult(trainNumber, { ymd }); } catch(_) {}
+    const stopTimes = fallback?.train?.stop_times || [];
+    const first = stopTimes[0] || null;
+    const last = stopTimes[stopTimes.length - 1] || null;
+
+    if (stopTimes.length){
+      const origin = first?.stop_point?.name || '—';
+      const dest = last?.stop_point?.name || '—';
+      pathEl.textContent = `${origin} → ${dest} (${stopTimes.length} arrêts)`;
+      nextEl.textContent = await computeNextDepartureLabelEnhanced(trainNumber, selectedDate, stopTimes);
+
+      const affInfoInline = (typeof window.getAffluenceTrainInfo === 'function') ? window.getAffluenceTrainInfo(String(trainNumber)) : null;
+      const affStops = Array.isArray(affInfoInline?.stops) ? affInfoInline.stops : [];
+      const normStation = (nm) => { try{ return normalizeStationName ? normalizeStationName(nm||'') : String(nm||'').toLowerCase(); }catch(_){ return String(nm||'').toLowerCase(); } };
+      stopsEl.innerHTML = stopTimes.map((st, idx) => {
+        const arr = (st?.arrival_time || '').replace(/(\d{2})(\d{2}).*/, '$1:$2');
+        const dep = (st?.departure_time || '').replace(/(\d{2})(\d{2}).*/, '$1:$2');
+        const stopNameRaw = st?.stop_point?.name || '—';
+        const stopName = esc(stopNameRaw);
+        const t = dep || arr || '—';
+        const side = idx === 0 ? 'Départ' : (idx === stopTimes.length-1 ? 'Arrivée' : 'Passage');
+        const hit = affStops.find(a => normStation(a?.station || a?.name || '') === normStation(stopNameRaw));
+        const p = Number(hit?.globalPct ?? Math.round((Number(hit?.globalOcc)||0)*100));
+        const pct = Number.isFinite(p) ? `${Math.round(p)}%` : '—';
+        return `<div class="train-detail-stop"><span>${stopName}</span><span>${pct} • ${t} • ${side}</span></div>`;
+      }).join('');
+    } else {
+      pathEl.textContent = 'Parcours indisponible pour cette date';
+      nextEl.textContent = 'Non disponible';
+      stopsEl.innerHTML = '<div class="train-detail-stop"><span>Aucun arrêt GTFS trouvé pour ce train et cette date.</span></div>';
+    }
+
+    const rel = await getReliabilityData(trainNumber);
+    if (rel){
+      relEl.textContent = `Fiabilité sur un mois : ${rel.pct}%`;
+      relDetailsEl.innerHTML = `
+        <div>✅ ${rel.onTime} à l'heure ⏰ ${rel.delayed} retard ❌ ${rel.canceled} supprimé 🟠 ${rel.partial} partiel</div>
+        <div style="margin-top:4px">Retard moyen : ${rel.avgDelay} min</div>
+        <div>Retard max : ${rel.maxDelay} min</div>`;
+    } else {
+      relEl.textContent = 'Fiabilité sur un mois : —';
+      relDetailsEl.textContent = 'Données indisponibles.';
+    }
+
+    const affInfo = await renderAffluenceBlock(trainNumber, selectedDate);
+    const compoEl = document.getElementById('trainDetailCompo');
+    if (typeof window.buildFavTrainTypeBadge === 'function') {
+      const badge = window.buildFavTrainTypeBadge(String(trainNumber), affInfo?.trainType || '');
+      compoEl.innerHTML = badge || 'Inconnue';
+    } else {
+      compoEl.textContent = affInfo?.trainType || 'Inconnue';
+    }
+
+    if (affBtn){
+      affBtn.onclick = (e) => {
+        e.preventDefault();
+        if (typeof window.lbOpenAffluenceTrain === 'function') window.lbOpenAffluenceTrain(trainNumber, selectedDate);
+        else location.hash = '#affluence';
+      };
+    }
+
+    if (statsBtn){
+      statsBtn.onclick = (e) => {
+        e.preventDefault();
+        const input = document.getElementById('statsTrainId');
+        if (input) input.value = String(trainNumber);
+        document.getElementById('statsTabTrainBtn')?.click();
+        document.getElementById('statsBtnTrainRun')?.click();
+        location.hash = '#statsConsole';
+      };
+    }
+
+    panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  document.addEventListener('click', (e) => {
+    const a = e.target.closest && e.target.closest('#trainInfo a.train-link');
+    if (!a) return;
+    const trainNumber = a.dataset.trainNumber || (a.textContent || '').trim();
+    if (!/\d{5,6}/.test(trainNumber || '')) return;
+    e.preventDefault();
+    const dateIso = a.dataset.trainDate || document.getElementById('trainDate')?.value || luxTodayYMD();
+    openInternalTrainPanel((trainNumber.match(/\d{5,6}/)||[])[0], dateIso);
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const closeBtn = document.getElementById('trainDetailClose');
+    const panel = document.getElementById('trainDetailPanel');
+    if (closeBtn && panel) closeBtn.addEventListener('click', () => { panel.hidden = true; destroyAffChart(); });
+  });
 })();
 
 (function(){


### PR DESCRIPTION
### Motivation
- Provide an in-app, richer detail view for individual trains (affluence, reliability, composition, stops) without navigating off-site. 
- Surface GTFS fallback schedules and improve time rendering for GTFS-based delays. 
- Integrate existing affluence and stats subsystems into a single interactive panel for operators/advanced users.

### Description
- Added styles for a new `.train-detail-panel` and related components to the main stylesheet to render the detail UI.
- Injected a new HTML section `#trainDetailPanel` that contains header, summary cards, a stop list, an affluence chart canvas, and action buttons.
- Changed train header links in `linkifyGaresAndTrains` to create internal anchors (hash links) with `data-train-number` and `data-train-date` instead of always pointing to the external SNCF detail page, while preserving existing CFL special-case handling and favorite-star logic via `applyFavStar`.
- Updated timetable cell rendering logic to respect `.gtfs-retard` elements so GTFS fallback delay blocks are updated correctly when base times change.
- Added a self-contained JS module that provides utilities and UI behavior including: date/time helpers, reliability data retrieval via the `__lbStats` helper, affluence chart rendering using `Chart` (with `destroy`/recreate), GTFS fallback fetch via `buildGtfsFallbackResult`, `openInternalTrainPanel` to populate the panel, and click/close event handlers to open the panel when a train link is clicked and to close/destroy the chart.
- Hooked action buttons to open the affluence view and populate the stats console for the selected train using existing global helpers like `lbOpenAffluenceTrain` and stats controls when available.

### Testing
- Ran the project linter with `npm run lint` and corrected issues; lint completed without errors.
- Performed a build with `npm run build`; the build succeeded with no errors.
- Executed the automated test suite with `npm test`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69e41dfdc832d9164ef79f035e64b)