### PR TITLE
Add in-app page navigation, train-detail & alert modals, traffic UI and GTFS silent preload

### DIFF
--- a/index02.html
+++ b/index02.html
@@ -363,7 +363,7 @@ body {
 }
 
 .ber-context{
-  padding: 10px 12px;
+  padding: 8px 10px;
   border-radius: 14px;
   border: 1px solid rgba(255, 255, 255, 0.10);
   background: rgba(255, 255, 255, 0.05);
@@ -374,7 +374,7 @@ body {
   align-items:center;
   justify-content: space-between;
   gap: 10px;
-  padding: 10px 12px;
+  padding: 8px 10px;
   border-radius: 14px;
   border: 1px solid rgba(0, 240, 255, 0.22);
   background: rgba(0, 12, 22, 0.35);
@@ -382,24 +382,24 @@ body {
 }
 
 .ber-metric .value{
-  font-size: 1.15rem;
+  font-size: 1.02rem;
   color: #e8fbff;
 }
 
 .home-stats-panel{
   display:flex;
   flex-direction:column;
-  gap:10px;
-  margin-top: 10px;
+  gap:8px;
+  margin-top: 8px;
 }
 .home-stats-item{
-  padding:10px 12px;
+  padding:8px 10px;
   border-radius:12px;
   border:1px solid rgba(0, 240, 255, 0.18);
   background: rgba(0, 12, 22, 0.3);
 }
 .home-stats-item .title{
-  font-size:0.85rem;
+  font-size:0.8rem;
   color:#7ef7ff;
   margin-bottom:4px;
 }
@@ -482,9 +482,9 @@ body {
 
 
 .home-section{
-  margin: 26px 0 28px;
+  margin: 18px 0 20px;
   display: grid;
-  gap: 18px;
+  gap: 12px;
 }
 
 .home-grid{
@@ -497,14 +497,14 @@ body {
   background: rgba(0, 12, 26, 0.72);
   border: 1px solid rgba(0, 240, 255, 0.25);
   border-radius: 18px;
-  padding: 18px;
+  padding: 14px;
   box-shadow: inset 0 0 16px rgba(0, 240, 255, 0.12), 0 10px 22px rgba(0, 0, 0, 0.25);
 }
 
 .home-card h2{
-  margin: 0 0 8px;
+  margin: 0 0 6px;
   color: #7ef7ff;
-  font-size: 1.1rem;
+  font-size: 1.04rem;
 }
 .home-card[aria-label="Mes Bétaillères favorites"] h2{
   font-size: 1.0rem;
@@ -536,6 +536,16 @@ body {
   border-color: rgba(0, 240, 255, 0.85);
 }
 
+
+.traffic-split{ display:grid; gap:8px; }
+.traffic-split-row{ display:flex; align-items:center; justify-content:space-between; gap:10px; padding:8px 10px; border:1px solid rgba(0,240,255,.18); border-radius:12px; background:rgba(0,0,0,.18); }
+.traffic-split-line{ font-weight:700; color:#dffbff; }
+.traffic-pill{ display:inline-flex; align-items:center; border-radius:999px; padding:5px 10px; font-size:.78rem; font-weight:800; border:1px solid transparent; }
+.traffic-pill--green{ background:rgba(36,194,90,.16); border-color:rgba(36,194,90,.45); color:#7df2a4; }
+.traffic-pill--yellow{ background:rgba(255,209,102,.14); border-color:rgba(255,209,102,.42); color:#ffe08f; }
+.traffic-pill--orange{ background:rgba(255,138,26,.14); border-color:rgba(255,138,26,.45); color:#ffba74; }
+.traffic-pill--red{ background:rgba(255,49,49,.14); border-color:rgba(255,49,49,.45); color:#ff8d8d; }
+.traffic-pill--loading{ background:rgba(0,240,255,.12); border-color:rgba(0,240,255,.35); color:#8ff9ff; }
 .quick-links{
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -1598,6 +1608,86 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   cursor: pointer;           /* Indique que c'est cliquable */
 }
 
+.train-detail-panel{
+  margin: 12px 0 16px;
+  border: 1px solid rgba(0, 240, 255, 0.32);
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(7, 15, 30, 0.96), rgba(11, 23, 42, 0.94));
+  box-shadow: 0 10px 30px rgba(0, 240, 255, 0.10);
+  padding: 14px;
+}
+.train-detail-panel[hidden]{ display:none !important; }
+.train-detail-top{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:10px;
+  margin-bottom:10px;
+}
+.train-detail-top h3{
+  margin:0;
+  color:#7ef7ff;
+  letter-spacing:.04em;
+}
+.train-detail-close{
+  border:1px solid rgba(0,240,255,.45);
+  border-radius:999px;
+  background:rgba(0,16,28,.5);
+  color:#dffbff;
+  cursor:pointer;
+  padding:6px 10px;
+}
+.train-detail-grid{
+  display:grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap:10px;
+}
+.train-detail-card{
+  border:1px solid rgba(0, 240, 255, 0.2);
+  border-radius:10px;
+  padding:10px;
+  background:rgba(0, 10, 20, 0.42);
+}
+.train-detail-card .k{ opacity:.78; font-size:.78rem; text-transform:uppercase; letter-spacing:.07em; }
+.train-detail-card .v{ margin-top:4px; font-weight:700; color:#dffbff; }
+.train-detail-route{
+  margin-top:10px;
+  border:1px solid rgba(0, 240, 255, 0.2);
+  border-radius:10px;
+  background:rgba(0,10,20,.35);
+  max-height:260px;
+  overflow:auto;
+}
+.train-detail-stop{ display:flex; justify-content:space-between; gap:10px; padding:8px 10px; border-bottom:1px solid rgba(0,240,255,.08); }
+.train-detail-stop:last-child{ border-bottom:none; }
+.train-detail-stop .left{ display:flex; align-items:center; gap:10px; min-width:0; }
+.train-detail-stop .time{ min-width:50px; color:#8ff9ff; font-weight:700; font-variant-numeric:tabular-nums; }
+.train-detail-stop .name{ overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.train-detail-stop .right{ display:flex; align-items:center; gap:8px; }
+#trainDetailPanel .aff-chart{ padding:8px 10px; }
+#trainDetailPanel #trainDetailAffluenceChart{ height:92px !important; max-height:92px; }
+@media (max-width: 900px){
+  #trainDetailPanel #trainDetailAffluenceChart{ height:130px !important; max-height:130px; }
+}
+.train-detail-actions{ margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
+.train-detail-btn{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  border:1px solid rgba(0,240,255,.4);
+  border-radius:999px;
+  color:#dffbff;
+  text-decoration:none;
+  padding:6px 12px;
+  background:rgba(0,16,28,.5);
+}
+
+.train-detail-minirow{ display:flex; justify-content:space-between; gap:10px; padding:6px 0; border-bottom:1px dashed rgba(0,240,255,.12); }
+.train-detail-minirow:last-child{ border-bottom:none; }
+.train-detail-minirow .right{ text-align:right; }
+.train-detail-reliability-badges{ display:flex; gap:8px; flex-wrap:wrap; margin-top:6px; }
+.train-detail-reliability-badges span{ font-size:.82rem; }
+
 /* Pastille météo (lien) – intégrée, sans bleu ni souligné */
 #trainInfo .wx a.wx-link{
   color: inherit;                 /* hérite la couleur du texte du tableau */
@@ -2082,6 +2172,12 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
 .disruption-box.orange:hover {
   box-shadow: 0 0 14px #ffb74d, inset 0 0 8px #ffb74d55;
 }
+.disruption-box.info {
+  border-color: #00f0ff;
+  color: #7ff6ff;
+  box-shadow: inset 0 0 4px #00f0ff33;
+}
+.disruption-description{ margin-top:8px; line-height:1.35; opacity:.92; }
 
 /* Icône clignotante style console */
 .disruption-icon {
@@ -2116,6 +2212,12 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   gap: 14px;
   margin-top: 16px;
 }
+.disruption-title-row{ display:flex; align-items:center; gap:8px; font-weight:800; font-size:1rem; }
+.disruption-title-text{ letter-spacing:.01em; }
+.disruption-cause{ margin-top:6px; opacity:.9; font-style:italic; }
+.disruption-trains{ margin-top:10px; display:flex; flex-wrap:wrap; gap:6px; }
+.disruption-train-pill{ padding:3px 8px; border-radius:999px; border:1px solid currentColor; font-weight:700; font-size:.75rem; }
+.disruption-empty{ margin-top:10px; opacity:.75; font-size:.78rem; }
     @media (max-width: 768px) {
   #disruptionsSummary {
     overflow: hidden; /* Empêche les débordements visuels sur mobile */
@@ -2142,7 +2244,28 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
     box-shadow: 0 0 8px currentColor, inset 0 0 6px currentColor;
   }
 }
-  .gtfs-retard {
+  
+
+/* Modal détail perturbation (clic icône tableau) */
+#alertDetailModal.lb-auth-modal{ z-index:3800; }
+#alertDetailModal.is-open{ display:flex !important; }
+#alertDetailModal .alert-detail-panel.lb-auth-card{
+  width:min(680px, 94vw);
+  max-height:min(86vh, 760px);
+  overflow:auto;
+  padding:16px;
+}
+#alertDetailModal .alert-detail-head{ display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:10px; padding-right:28px; }
+#alertDetailModal .alert-detail-title{ color:#9ffcff; font-weight:800; font-size:1rem; }
+#alertDetailModal .alert-detail-body{ display:flex; flex-direction:column; gap:10px; }
+#alertDetailModal .alert-detail-card{ border:1px solid rgba(0,240,255,.24); border-radius:12px; background:rgba(0,14,24,.6); padding:10px; }
+#alertDetailModal .alert-detail-card.red{ border-color:#ff3355; color:#ff8d9f; }
+#alertDetailModal .alert-detail-card.orange{ border-color:#ffb74d; color:#ffd08f; }
+#alertDetailModal .alert-detail-card.info{ border-color:#00f0ff; color:#7ff6ff; }
+#alertDetailModal .alert-detail-row{ display:flex; align-items:center; gap:8px; font-weight:800; }
+#alertDetailModal .alert-detail-desc{ margin-top:6px; line-height:1.35; opacity:.92; color:#d7ecff; }
+
+.gtfs-retard {
   display: inline-block;
   margin-top: 2px;
   padding: 0;
@@ -6584,14 +6707,17 @@ body{
 .home-card[forwarding="ber"] .ber-context,
 .home-card[forwarding="ber"] .home-stats-panel,
 .home-card[forwarding="ber"] .home-stats-item{ display:none !important; }
-.home-card[forwarding="ber"] .ber-lines{ padding-top: 2px; }
+.home-card[forwarding="ber"]{ padding-top: 8px !important; padding-bottom: 8px !important; }
 .home-card[forwarding="ber"] .ber-metric{
   margin-top: 0 !important;
-  padding: 8px 10px !important;
-  border-radius: 12px;
+  padding: 2px 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
 }
 .home-card[forwarding="ber"] .ber-metric .value{
-  font-size: 1.00rem !important;
+  font-size: .96rem !important;
 }
 
 /* Mobile: tout tient mieux sur l'écran d'accueil */
@@ -7060,6 +7186,18 @@ html, body{ overflow-x: hidden; }
   }
 }
 
+
+/* === Navigation pages (1 onglet = 1 page) === */
+.app-page{ display:none; }
+.app-page.is-page-active{ display:block; }
+body.page-home #home{ display:flex; }
+body.page-favoris #favTrainsWidget{ display:block !important; }
+body.page-search #search,
+body.page-carte #carte,
+body.page-carte #affluence,
+body.page-loisirs #divertissement,
+body.page-loisirs #multimedia,
+body.page-stats #stats{ display:block; }
 </style>
   <style>
 @supports (-webkit-touch-callout: none) {
@@ -7326,10 +7464,10 @@ html, body{
 
 /* Compact the "Ponctualité hier" row so it stays visible */
 .ber-metric{
-  padding: 12px 14px;
+  padding: 8px 10px;
 }
 .ber-metric .value{
-  font-size: clamp(1.1rem, 4.6vw, 1.4rem);
+  font-size: clamp(0.98rem, 3.9vw, 1.12rem);
 }
 
 /* Favorites preview: keep it short and readable */
@@ -7440,15 +7578,15 @@ html, body{
       <span class="bottom-nav__icon" aria-hidden="true">📋</span>
       <span class="bottom-nav__label">Tableau</span>
     </a>
-    <a class="bottom-nav__item" href="#favTrainsWidget">
+    <a class="bottom-nav__item" href="#favoris">
       <span class="bottom-nav__icon" aria-hidden="true">⭐</span>
       <span class="bottom-nav__label">Favoris</span>
     </a>
-    <a class="bottom-nav__item" href="#statsConsole">
+    <a class="bottom-nav__item" href="#stats">
       <span class="bottom-nav__icon" aria-hidden="true">📊</span>
       <span class="bottom-nav__label">Stats</span>
     </a>
-	<a class="bottom-nav__item" href="#divertissement">
+	<a class="bottom-nav__item" href="#loisirs">
       <span class="bottom-nav__icon" aria-hidden="true">🎉</span>
       <span class="bottom-nav__label">Loisirs</span>
     </a>  
@@ -7561,19 +7699,21 @@ html, body{
 </div>
 
   </div>
-  <section id="home" class="home-section" aria-label="Accueil">
+  <section id="home" class="home-section app-page" data-page="home" aria-label="Accueil">
   <div class="home-dashboard">
     <div class="home-welcome-line">Bienvenue 🐮 dans votre bétaillère Nancy–Metz–Lux 👋</div>
 
     <!-- État du trafic (accueil) -->
-    <article class="home-card home-traffic-card traffic-level--loading" aria-label="État du trafic">
-      <div class="traffic-inner">
-<div class="traffic-dot" aria-hidden="true"></div>
-        <div class="traffic-text">
-          <div class="traffic-title" id="homeTrafficTitle">TRAFIC —</div>
-          <div class="traffic-sub" id="homeTrafficSub">Chargement…</div>
-          <div class="traffic-quote">“Puisse le sort vous être favorable”</div>
-          <div class="traffic-hash">#BER</div>
+    <article class="home-card" aria-label="Info trafic">
+      <h2>Info trafic</h2>
+      <div class="traffic-split" id="homeTrafficRows">
+        <div class="traffic-split-row">
+          <span class="traffic-split-line" id="homeTrafficLineNorth">Metz - Luxembourg</span>
+          <span class="traffic-pill traffic-pill--loading" id="homeTrafficBadgeNorth">Chargement…</span>
+        </div>
+        <div class="traffic-split-row">
+          <span class="traffic-split-line" id="homeTrafficLineSouth">Nancy - Metz</span>
+          <span class="traffic-pill traffic-pill--loading" id="homeTrafficBadgeSouth">Chargement…</span>
         </div>
       </div>
     </article>
@@ -7600,14 +7740,13 @@ html, body{
 
     <article class="home-card" forwarding="ber" aria-label="Info ou pas de votre Bétaillère">
       <h2>🦄🐄 Info ou pas de votre Bétaillère</h2>
-      <div class="ber-lines">
-        <div class="ber-line1" id="homeBerLine1">—</div>
-        <div class="ber-context" id="homeBerContext" style="display:none;">—</div>
-        <div class="ber-metric">
-          <div>📊 Ponctualité hier</div>
-          <div class="value" id="homeBerPunctuality">—</div>
-        </div>
-       <div class="home-stats-panel">
+      <div class="ber-line1" id="homeBerLine1">—</div>
+      <div class="ber-context" id="homeBerContext" style="display:none;">—</div>
+      <div class="ber-metric">
+        <div>📊 Ponctualité hier</div>
+        <div class="value" id="homeBerPunctuality">—</div>
+      </div>
+      <div class="home-stats-panel">
           <div class="home-stats-item">
             <div class="title">Train le moins fiable (7j)</div>
             <div class="value" id="homeWorstTrain">—</div>
@@ -7618,8 +7757,7 @@ html, body{
             <div class="value" id="homeMostDelayTrain">—</div>
             <div class="meta" id="homeMostDelayWhy">—</div>
           </div>		   
-        </div>
-      </div>
+       </div>
     </article>
   </div>
 
@@ -7924,7 +8062,7 @@ html, body{
   </div>
 
 <!-- Widget Favoris Matin / Soir (visible si connecté) -->
-<section id="favTrainsWidget" class="fav-widget" style="display:none; position:relative; z-index:2;">
+<section id="favTrainsWidget" class="fav-widget app-page" data-page="favoris" style="display:none; position:relative; z-index:2;">
   <div class="fav-head">
     <div class="fav-title">⭐ Mes bétaillères favorites</div>
     <button id="favOpenPrefs" class="fav-btn" type="button">Modifier</button>
@@ -7968,7 +8106,7 @@ html, body{
 </section>
 
 <!-- Console de Commande -->
-<div class="command-console" id="search">
+<div class="command-console app-page" id="search" data-page="search">
   <div class="console-header"> Console de Commande – Sélection des Bétaillères</div>
 
   <!-- 1) GÉNÉRATION PERSONNALISÉE -->
@@ -8161,9 +8299,9 @@ html, body{
 </div>
 
 <div id="tableauViewNav" role="tablist" aria-label="Sous-navigation Tableau" hidden>
-  <button type="button" class="tableau-view-tab" role="tab" aria-selected="false" data-tableau-view="perturbations">Détails perturbations</button>
-  <button type="button" class="tableau-view-tab" role="tab" aria-selected="true" data-tableau-view="global">Tableau global</button>
-  <button type="button" class="tableau-view-tab" role="tab" aria-selected="false" data-tableau-view="search">Nouvelle recherche</button>
+  <button type="button" class="tableau-view-tab" role="tab" aria-selected="false" data-tableau-view="perturbations">Perturbations</button>
+  <button type="button" class="tableau-view-tab tableau-view-tab--search" role="tab" aria-selected="false" data-tableau-view="search">Nouvelle recherche</button>
+  <button type="button" class="tableau-view-tab" role="tab" aria-selected="true" data-tableau-view="global">Image tableau</button>
 </div>
 
 <div id="loisirsViewNav" role="tablist" aria-label="Sous-navigation Loisirs" hidden>
@@ -8178,28 +8316,52 @@ html, body{
   <div id="disruptionsContent"></div>
 </div>
 
+<div id="alertDetailModal" class="lb-auth-modal" aria-hidden="true">
+  <div class="alert-detail-panel lb-auth-card" role="dialog" aria-modal="true" aria-labelledby="alertDetailTitle">
+    <button type="button" class="lb-auth-close tron-close-button" id="alertDetailClose" aria-label="Fermer"></button>
+    <div class="alert-detail-head">
+      <div id="alertDetailTitle" class="alert-detail-title">Détail perturbation</div>
+    </div>
+    <div class="alert-detail-body" id="alertDetailBody"></div>
+  </div>
+</div>
+
 <!-- BLOC 2 : Infos trains -->
 <div id="trainInfo"></div>
+<section id="trainDetailPanel" class="train-detail-panel" hidden aria-live="polite">
+  <div class="train-detail-top">
+    <div>
+      <h3 id="trainDetailTitle">Train —</h3>
+    </div>
+    <button id="trainDetailClose" class="train-detail-close" type="button" aria-label="Fermer le détail">✕</button>
+  </div>
+  <div class="train-detail-grid">
+    <div class="train-detail-card"><div class="k">Statut du jour / prochain train</div><div class="v" id="trainDetailNext">—</div></div>
+    <div class="train-detail-card"><div class="k">Fiabilité sur un mois</div><div class="v" id="trainDetailReliability">—</div></div>
+    <div class="train-detail-card"><div class="k">Affluence prévue (max)</div><div class="v" id="trainDetailAffluence">—</div></div>
+    <div class="train-detail-card"><div class="k">Composition prévue</div><div class="v" id="trainDetailCompo">—</div></div>
+    <div class="train-detail-card" style="grid-column:1/-1"><div class="k">Parcours</div><div class="v" id="trainDetailPath">—</div></div>
+  </div>
+  <div class="train-detail-card" style="margin-top:10px">
+    <div class="k">Détails fiabilité</div>
+    <div id="trainDetailReliabilityDetails" style="margin-top:6px">—</div>
+  </div>
+  <div class="train-detail-card" style="margin-top:10px">
+    <div class="k">Affluence par gare</div>
+    <div class="aff-chart" style="margin-top:8px"><canvas id="trainDetailAffluenceChart" height="92"></canvas></div>
+  </div>
+  <div class="train-detail-route" id="trainDetailStops"></div>
+  <div class="train-detail-actions">
+    <a id="trainDetailAffBtn" class="train-detail-btn" href="#affluence">🚆 Ouvrir dans Affluence</a>
+    <a id="trainDetailStatsBtn" class="train-detail-btn" href="#stats">📊 Voir schéma stats du train</a>
+  </div>
+</section>
 
 <div id="refreshContainer" style="display:none; text-align:center; margin:8px 0 6px;">
   <button id="refreshButton" class="refresh-btn">Actualiser les données</button>
 </div>
 
-<div class="home-card">
-  <h2>Accès rapides</h2>
-  <div class="quick-links">
-    <a class="quick-card" id="btnCarte" href="#carte"><span>🗺️</span>Carte</a>
-    <button class="quick-card" id="btnBingo" type="button"><span>🎲</span>Bingo</button>
-    <button class="quick-card" id="btnJeu" type="button"><span>🎮</span>Jeu</button>
-    <a class="quick-card" href="#multimedia"><span>🎬</span>
-    <span class="bottom-nav__label">Multimédia</span>
-  </a>
-    <a class="quick-card" href="#statsConsole"><span>📊</span>Stats</a>
-	<a class="quick-card" href="#affluence"><span>🚆</span>Affluence</a>
-  </div>
-</div>
-
-<section id="carte" class="media-section" aria-label="Carte en direct">
+<section id="carte" class="media-section app-page" data-page="carte" aria-label="Carte en direct">
   <h2>Carte en direct</h2>
   <p>Accès complet à la carte La Bétaillère sans quitter l’application.</p>
   <div class="map-embed-shell">
@@ -8212,7 +8374,7 @@ html, body{
   </div>
 </section>
 
-<section id="affluence" class="media-section" aria-label="Affluence">
+<section id="affluence" class="media-section app-page" data-page="carte" aria-label="Affluence">
   <h2>Affluence (J0 à J+14)</h2>
   <p>Choisis une date, puis clique sur un train pour voir tous les arrêts + la courbe d’affluence. (Les filtres avancés sont optionnels.)</p>
   <style>
@@ -8432,8 +8594,8 @@ html, body {
 
 /* === PATCH v17: nav icons + home spacing === */
 :root{
-  --home-gap: 10px;
-  --home-card-pad: 14px;
+  --home-gap: 7px;
+  --home-card-pad: 10px;
 }
 
 /* Home: make spacing consistent & a bit tighter so everything fits */
@@ -8891,6 +9053,10 @@ html, body{
   color:#00111a;
   box-shadow: 0 0 14px rgba(0,240,255,.45), inset 0 0 14px rgba(0,240,255,.35);
 }
+#tableauViewNav .tableau-view-tab--search{
+  font-weight: 800;
+  letter-spacing: .03em;
+}
 @media (max-width: 768px){
   body.tableau-view-nav-visible{ --tableau-viewbar-h: 64px; }
   #tableauViewNav.is-visible{
@@ -8995,12 +9161,12 @@ html, body{
     </div>	
   </div></section>
 
-<section id="divertissement" class="media-section" aria-label="Loisirs" style="display:none;">
+<section id="divertissement" class="media-section app-page" data-page="loisirs" aria-label="Loisirs" style="display:none;">
   <h2>Loisirs</h2>
   <p>Retrouve ici les sous-catégories Multimédia, Bingo et Jeu.</p>
 </section>
 
-<section id="multimedia" class="media-section" aria-label="Multimédia">
+<section id="multimedia" class="media-section app-page" data-page="loisirs" aria-label="Multimédia">
   <h2>Multimédia</h2>
   <p>Retrouve ici les vidéos de La Bétaillère, accessibles en un clic comme les raccourcis Bingo/Jeu.</p>
   <div class="media-grid">
@@ -9023,7 +9189,7 @@ html, body{
 </section>
 
 <!-- Console Statistiques -->
-<div class="command-console" id="stats">
+<div class="command-console app-page" id="stats" data-page="stats">
   <div class="console-header">Console de Commande – Statistiques</div>
   <details id="statsConsole" class="console-section">
     <summary class="section-summary">
@@ -9152,7 +9318,7 @@ html, body{
               <div class="stats-kpi"><div class="t">Total trains</div><div class="v" id="statsKpiTotal">—</div></div>
               <div class="stats-kpi"><div class="t">Retardés</div><div class="v" id="statsKpiDelayed">—</div></div>
               <div class="stats-kpi"><div class="t">Supprimés</div><div class="v" id="statsKpiCanceled">—</div></div>
-              <div class="stats-kpi"><div class="t">Partiellement supprimés</div><div class="v" id="statsKpiPartial">—</div></div>
+              <div class="stats-kpi"><div class="t">Suppr. partielles</div><div class="v" id="statsKpiPartial">—</div></div>
               <div class="stats-kpi"><div class="t">Pas à l’heure</div><div class="v" id="statsKpiNotOnTime">—</div></div>
               <div class="stats-kpi"><div class="t">Ponctualité</div><div class="v" id="statsKpiPct">—</div></div>
             </div>
@@ -9180,7 +9346,7 @@ html, body{
               <div class="stats-card" data-chart-key="volumes" style="grid-column:span 3">
                 <div class="head">
                   <div class="title">Trains perturbés (par jour)</div>
-                  <div class="meta">Retardés / Partiels / Supprimés</div>
+                  <div class="meta">Retardés / Suppr. partielles / Supprimés</div>
                 </div>
                 <div class="stats-canvas"><canvas id="statsChVolumes"></canvas></div>
               </div>
@@ -9233,7 +9399,7 @@ html, body{
                 <div class="stats-pills" id="statsLcancel"></div>
               </div>
               <div class="stats-listbox" style="grid-column:span 2">
-                <div class="h"><div class="name">Suppressions partielles</div><div class="count" id="statsCpartial">—</div></div>
+                <div class="h"><div class="name">Suppr. partielles</div><div class="count" id="statsCpartial">—</div></div>
                 <div class="stats-pills" id="statsLpartial"></div>
               </div>
             </div>
@@ -9270,7 +9436,7 @@ html, body{
               <div class="stats-card" style="grid-column:span 2">
                 <div class="head">
                   <div class="title">Répartition (période)</div>
-                  <div class="meta">À l’heure / Retard / Partiel / Supprimé</div>
+                  <div class="meta">À l’heure / Retard / Suppr. partielle / Supprimé</div>
                 </div>
                 <div class="stats-canvas"><canvas id="statsChTrainDonut"></canvas></div>
               </div>
@@ -9320,7 +9486,7 @@ html, body{
               <div class="stats-card" style="grid-column:span 3">
                 <div class="head">
                   <div class="title">Perturbations à l’arrêt (par jour)</div>
-                  <div class="meta">retards / supprimés / partiels</div>
+                  <div class="meta">retards / supprimés / suppr. partielles</div>
                 </div>
                 <div class="stats-canvas"><canvas id="statsChStopVolumes"></canvas></div>
               </div>
@@ -9347,7 +9513,7 @@ html, body{
                       <th class="num">Trains</th>
                       <th class="num">Retards</th>
                       <th class="num">Supprimés</th>
-                      <th class="num">Partiels</th>
+                      <th class="num">Suppr. partielles</th>
                       <th class="num">Pas à l’heure</th>
                       <th class="num">Ponctualité</th>
                     </tr>
@@ -12465,6 +12631,7 @@ let GTFS = {
 };
     
 let GTFS_LOADING_PROMISE = null;
+let GTFS_LOADED_ONCE = false;
 
 const __yieldToBrowser = () => (typeof setTimeout === 'function')
   ? new Promise(resolve => setTimeout(resolve, 0))
@@ -12718,7 +12885,7 @@ async function fetchAndParseCSV(filename, opt = {}){
   throw lastErr || new Error('Impossible de charger '+filename);
 }
 
-async function ensureGTFSLoaded(){
+async function ensureGTFSLoaded({ silent = false } = {}){
   if (GTFS.stops && GTFS.stopTimes && GTFS.trips && GTFS.tripById && GTFS.stopNameToId && GTFS.allowedByDate) return;
     if (GTFS_LOADING_PROMISE) {
     try {
@@ -12729,7 +12896,8 @@ async function ensureGTFSLoaded(){
     if (GTFS.stops && GTFS.stopTimes && GTFS.trips && GTFS.tripById && GTFS.stopNameToId && GTFS.allowedByDate) return;
   }
  GTFS_LOADING_PROMISE = (async () => {
-    GTFSLoadingUI.show('Chargement des arrêts SNCF…');
+    const showOverlay = !silent && !GTFS_LOADED_ONCE;
+    if (showOverlay) GTFSLoadingUI.show('Chargement des arrêts SNCF…');
     try {
       await __yieldToBrowser();
 
@@ -12740,7 +12908,7 @@ async function ensureGTFSLoaded(){
       stops = stops.filter(s => relevantStopIds.has(s.stop_id));
       await __yieldToBrowser();
 
-      GTFSLoadingUI.message('Chargement des horaires détaillés…');
+      if (showOverlay) GTFSLoadingUI.message('Chargement des horaires détaillés…');
       const relevantTripIds = new Set();
       const stopTimes = await fetchAndParseCSV('stop_times.txt', {
         keepColumns: ['trip_id','arrival_time','departure_time','stop_id','stop_sequence'],
@@ -12752,7 +12920,7 @@ async function ensureGTFSLoaded(){
       });
       await __yieldToBrowser();
 
-      GTFSLoadingUI.message('Chargement des trajets…');
+      if (showOverlay) GTFSLoadingUI.message('Chargement des trajets…');
       const relevantServiceIds = new Set();
       const trips = await fetchAndParseCSV('trips.txt', {
         keepColumns: ['trip_id','service_id','route_id','trip_short_name','trip_headsign'],
@@ -12764,14 +12932,14 @@ async function ensureGTFSLoaded(){
       });
       await __yieldToBrowser();
 
-      GTFSLoadingUI.message('Chargement du calendrier…');
+      if (showOverlay) GTFSLoadingUI.message('Chargement du calendrier…');
       const calendarDates = await fetchAndParseCSV('calendar_dates.txt', {
         keepColumns: ['service_id','date','exception_type'],
         filterRow: row => !row.service_id || relevantServiceIds.has(row.service_id)
       });
       await __yieldToBrowser();
 
-      GTFSLoadingUI.message('Organisation des données…');
+      if (showOverlay) GTFSLoadingUI.message('Organisation des données…');
       await __yieldToBrowser();
 
       const stopNameToId = new Map();
@@ -12812,8 +12980,9 @@ async function ensureGTFSLoaded(){
         relevantTripIds,
         relevantServiceIds
       };
+      GTFS_LOADED_ONCE = true;
     } finally {
-      GTFSLoadingUI.hide();
+      if (showOverlay) GTFSLoadingUI.hide();
       }
   })();
   
@@ -12971,7 +13140,7 @@ async function buildGtfsFallbackResult(number, { ymd } = {}){
   if (!normalized) return null;
   const targetYmd = (ymd && /^\d{8}$/.test(ymd)) ? ymd : null;
   try {
-    await ensureGTFSLoaded();
+    await ensureGTFSLoaded({ silent: true });
   } catch (err) {
     console.error('[GTFS] Impossible de charger les données statiques pour le fallback', err);
     return null;
@@ -13314,7 +13483,7 @@ async function computeItineraryProposals({
 
   const targetYMD = ymd || dateInputToYMD($('#trainDate').val()) || todayYMDLux().replace(/-/g,'');
 
-  await ensureGTFSLoaded();
+  await ensureGTFSLoaded({ silent: true });
   buildStationGroups();
 
   const originIds = getIdsForName(start);
@@ -14117,7 +14286,7 @@ async function applyRapidPreset(kind, options = {}){
   }
 
   const numbers = fallback.slice();
-  if (config){
+  if (config && !opts.auto){
     try {
       const $start = $('#startStation');
       const $end = $('#endStation');
@@ -15077,21 +15246,41 @@ function linkifyGaresAndTrains(root){
       const label = th.dataset.trainLabel || formatTrainDisplayLabel(numero);
       const safeLabel = escapeHtml(label);
       const href = 'https://www.cfl.lu/fr-fr';
-      const existing = th.querySelector('.train-link-cfl');
-      if (existing) {
-        existing.textContent = label;
-        existing.setAttribute('href', href);
+      const numWrap = th.querySelector('.train-num');
+      if (numWrap) {
+        const existingLink = numWrap.querySelector('.train-link-cfl');
+        if (existingLink) {
+          existingLink.textContent = label;
+          existingLink.setAttribute('href', href);
+        } else {
+          numWrap.innerHTML = `<a href="${href}" target="_blank" rel="noopener" class="train-link train-link-cfl">${safeLabel}</a>`;
+        }
       } else {
-        th.innerHTML = `<a href="${href}" target="_blank" rel="noopener" class="train-link train-link-cfl">${safeLabel}</a>`;
+        th.innerHTML = `<span class="train-num"><a href="${href}" target="_blank" rel="noopener" class="train-link train-link-cfl">${safeLabel}</a></span><span class="train-state icon">🚉</span>`;
       }
-	  applyFavStar(th);
+      applyFavStar(th);
       return;
     }
-    const already = th.querySelector('a.train-link');
-    const url = `https://www.sncf-voyageurs.com/fr/voyagez-avec-nous/horaires-et-itineraires/recherche-de-train/detail-train/?numeroCirculation=${numero}&dateCirculation=${dateCirculation}`;
-    if (already) { already.href = url; already.textContent = numero; }
-    else { th.innerHTML = `<a href="${url}" target="_blank" rel="noopener" class="train-link">${numero}</a>`; }
-	applyFavStar(th);
+
+    const internalHref = `#train-detail-${numero}`;
+    const numWrap = th.querySelector('.train-num');
+    if (numWrap) {
+      const current = numWrap.querySelector('a.train-link');
+      if (current) {
+        current.href = internalHref;
+        current.textContent = numero;
+        current.removeAttribute('target');
+        current.removeAttribute('rel');
+        current.dataset.trainNumber = numero;
+        current.dataset.trainDate = dateCirculation || '';
+      } else {
+        numWrap.innerHTML = `<a href="${internalHref}" class="train-link" data-train-number="${numero}" data-train-date="${dateCirculation || ''}">${numero}</a>`;
+      }
+    } else {
+      th.innerHTML = `<span class="train-num"><a href="${internalHref}" class="train-link" data-train-number="${numero}" data-train-date="${dateCirculation || ''}">${numero}</a></span><span class="train-state icon">🚉</span>`;
+    }
+
+    applyFavStar(th);
     if (th.dataset.gtfsFallback === '1' && !th.querySelector('.fallback-pill')) {
       const pill = document.createElement('span');
       pill.className = 'fallback-pill';
@@ -15168,6 +15357,7 @@ scheduleWeatherAfterTableSettled();
     }
 
     let groupedDisruptions = {};
+    LB_TABLE_DISRUPTIONS_BY_TRAIN.clear();
     numbers.forEach(num => {
       const result = results[num];
       if (result && result.disruptions && result.disruptions.length > 0) {
@@ -15244,22 +15434,36 @@ scheduleWeatherAfterTableSettled();
       });
       sortedGroups.forEach(disr => {
         const trainsList = Array.from(disr.trains).sort((a,b) => a.localeCompare(b));
+        const detailEntry = {
+          key: `d_${++LB_ALERT_SEQ}`,
+          level: disr.box === 'red' ? 'red' : (disr.box === 'orange' ? 'orange' : 'info'),
+          icon: disr.icon || 'ℹ️',
+          title: disr.txt || 'Perturbation',
+          description: disr.cause || 'Cause non précisée',
+          trains: trainsList.slice()
+        };
+        LB_ALERTS_BY_KEY.set(detailEntry.key, detailEntry);
+
+        trainsList.forEach((tn) => {
+          const key = String((tn || '').replace(/^CFL-/, '')).trim();
+          if (!key) return;
+          if (!LB_TABLE_DISRUPTIONS_BY_TRAIN.has(key)) LB_TABLE_DISRUPTIONS_BY_TRAIN.set(key, []);
+          LB_TABLE_DISRUPTIONS_BY_TRAIN.get(key).push(detailEntry);
+          const header = Array.from(document.querySelectorAll('th[data-train-number]')).find(th => extractTrainNumber(th.dataset.trainNumber || '') === extractTrainNumber(key));
+          if (header && !header.dataset.alertKeyMain) header.dataset.alertKeyMain = detailEntry.key;
+        });
+
         const trainsHtml = trainsList.length
-          ? '<ul>' + trainsList.map(t => `<li>${t}</li>`).join('') + '</ul>'
-          : '<p>Aucun train impacté listé</p>';
-        const color = disr.box === 'red' ? '#ff4c4c' : '#ff8a00';
+          ? `<div class="disruption-trains">${trainsList.map(t => `<span class="disruption-train-pill">${t}</span>`).join('')}</div>`
+          : '<div class="disruption-empty">Aucun train impacté listé</div>';
         disruptionsHtml += `
           <div class="disruption-box ${disr.box}">
-            <div style="display:flex;align-items:center;gap:8px;color:${color};font-weight:700;font-size:1.2rem;">
+            <div class="disruption-title-row">
               <div class="disruption-icon ${disr.blink ? 'icon-blink' : ''}">${disr.icon}</div>
-              <div>${disr.txt}</div>
+              <div class="disruption-title-text">${disr.txt}</div>
             </div>
-            <div style="color:${color};margin-top:6px;font-style:italic;">
-              ${disr.cause}
-            </div>
-            <div style="color:${color};margin-top:8px;">
-              ${trainsHtml}
-            </div>
+            <div class="disruption-cause">${disr.cause || 'Cause non précisée'}</div>
+            ${trainsHtml}
           </div>
         `;
       });
@@ -15817,6 +16021,15 @@ window.addEventListener('load', () => {
 window.addEventListener('online', () => scheduleBackgroundRefresh(true));
 document.addEventListener('visibilitychange', () => scheduleBackgroundRefresh(true));
 
+window.addEventListener('load', () => {
+  // Précharge les données statiques SNCF en silence pour éviter les modales au 1er usage.
+  if (typeof lbRunInBackground === 'function') {
+    lbRunInBackground(() => ensureGTFSLoaded({ silent: true }).catch(() => {}));
+  } else {
+    setTimeout(() => { ensureGTFSLoaded({ silent: true }).catch(() => {}); }, 0);
+  }
+});
+
 // applique si tableau présent + date = aujourd’hui
 function tryApplyGtfsToCurrentTable() {
   if (typeof isSelectedDateToday === 'function' && !isSelectedDateToday()) return;
@@ -16025,6 +16238,10 @@ function resetGtfsRetards(scope) {
 }
 /* ---------- ALERTES ---------- */
 const urlAlertes = 'https://vps.labetaillere.fr/gtfs/alertes_sillon_lorrain.json';
+const LB_ALERTS_BY_TRAIN = new Map();
+const LB_ALERTS_BY_KEY = new Map();
+const LB_TABLE_DISRUPTIONS_BY_TRAIN = new Map();
+let LB_ALERT_SEQ = 0;
 const motsCles = Array.from(new Set([
   ...garesParLigne.map(g => g.nom),
   'CFL','Moselle','Meurthe-et-Moselle','Luxembourg','Lorraine'
@@ -16142,6 +16359,9 @@ async function chargerEtAfficherAlertes() {
   const container = document.getElementById('disruptionsContent');
   if (!container) return;
 
+  LB_ALERTS_BY_TRAIN.clear();
+  LB_ALERTS_BY_KEY.clear();
+
   const selectedDateInput = document.getElementById('trainDate');
   let selectedDate = new Date();
   if (selectedDateInput && selectedDateInput.value) {
@@ -16154,7 +16374,7 @@ async function chargerEtAfficherAlertes() {
 
   const ymd = `${selectedDate.getFullYear()}${String(selectedDate.getMonth()+1).padStart(2,'0')}${String(selectedDate.getDate()).padStart(2,'0')}`;
 
-  try { await ensureGTFSLoaded(); } catch(e){ console.warn('GTFS non chargé pour alertes:', e); }
+  try { await ensureGTFSLoaded({ silent: true }); } catch(e){ console.warn('GTFS non chargé pour alertes:', e); }
   ensureTransferIndexesBuilt();   // accélère getStopsForTripQuick
   buildStationGroups();
 
@@ -16256,6 +16476,21 @@ async function chargerEtAfficherAlertes() {
         }
 
         const trainsCibles = Array.from(new Set([...trainsFromEntities, ...trainsFromText]));
+        const detailEntry = {
+          key: `a_${++LB_ALERT_SEQ}`,
+          level: (styleMeta.prio === 1) ? 'red' : ((styleMeta.prio === 2 || styleMeta.prio === 3 || isReducedSeats) ? 'orange' : 'info'),
+          icon: styleMeta.icone || 'ℹ️',
+          title: titre || styleMeta.label || 'Information',
+          description: description || '',
+          trains: trainsCibles.slice()
+        };
+        LB_ALERTS_BY_KEY.set(detailEntry.key, detailEntry);
+        trainsCibles.forEach((tn) => {
+          const key = String(tn || '').trim();
+          if (!key) return;
+          if (!LB_ALERTS_BY_TRAIN.has(key)) LB_ALERTS_BY_TRAIN.set(key, []);
+          LB_ALERTS_BY_TRAIN.get(key).push(detailEntry);
+        });
 
         // hint visuel “US” si effect=2 et si train affiché
         const targetsDisplayed = trainsCibles.filter(n => sets.displayedNums.has(n));
@@ -16270,6 +16505,7 @@ async function chargerEtAfficherAlertes() {
             const header = findHeaderByNumber(numeroTrain);
             if (header) {
               header.classList.add('reduced-seats');
+              if (!header.dataset.alertKeyMain) header.dataset.alertKeyMain = detailEntry.key;
         try{ if(window.lbReducedSeats) window.lbReducedSeats.add(String(trainNum)); }catch(e){}
               header.title = "Service réduit : réduction du nombre de places (UM ➜ US)";
               const headRow = header.parentElement;
@@ -16281,44 +16517,36 @@ async function chargerEtAfficherAlertes() {
                 iconSpan.className = 'icon reduced-seat-icon';
                 iconSpan.textContent = styleMeta.icone || '⚠️';
                 iconSpan.title = "Service réduit : réduction du nombre de places";
+                iconSpan.dataset.alertKey = detailEntry.key;
                 iconCell.appendChild(iconSpan);
               }
             }
           });
         }
 
-        let classeCouleur = 'alerte-box';
-        if (styleMeta.prio === 1) classeCouleur += ' red';
-        else if (styleMeta.prio === 2 || styleMeta.prio === 3) classeCouleur += ' orange';
+        let classeCouleur = 'disruption-box info';
+        if (styleMeta.prio === 1) classeCouleur = 'disruption-box red';
+        else if (styleMeta.prio === 2 || styleMeta.prio === 3 || isReducedSeats) classeCouleur = 'disruption-box orange';
+
+        targetsDisplayed.forEach(numeroTrain => {
+          const header = findHeaderByNumber(numeroTrain);
+          if (header && !header.dataset.alertKeyMain) header.dataset.alertKeyMain = detailEntry.key;
+        });
+
+        const trainsHtml = trainsCibles.length
+          ? `<div class="disruption-trains">${trainsCibles.map(t => `<span class="disruption-train-pill">${t}</span>`).join('')}</div>`
+          : '<div class="disruption-empty">Aucun train impacté listé</div>';
 
         const div = document.createElement('div');
         div.className = classeCouleur;
-
-        const headerDiv = document.createElement('div');
-        headerDiv.style.display = "flex";
-        headerDiv.style.alignItems = "center";
-        headerDiv.style.fontWeight = "600";
-
-        const iconeSpan = document.createElement('span');
-        iconeSpan.textContent = styleMeta.icone;
-        iconeSpan.className = 'alerte-icon';
-
-        headerDiv.appendChild(iconeSpan);
-        headerDiv.appendChild(document.createTextNode(titre));
-
-        const detailDiv = document.createElement('div');
-        detailDiv.className = 'alerte-content';
-        detailDiv.innerHTML = `
-          ${description ? `<p>${description}</p>` : ''}
-          ${trainsCibles.length ? `<p style="opacity:.9;">Trains concernés : <strong>${trainsCibles.join(', ')}</strong></p>` : ''}
+        div.innerHTML = `
+          <div class="disruption-title-row">
+            <span class="disruption-icon">${styleMeta.icone || 'ℹ️'}</span>
+            <span class="disruption-title-text">${titre}</span>
+          </div>
+          ${description ? `<div class="disruption-description">${description}</div>` : ''}
+          ${trainsHtml}
         `;
-
-        headerDiv.addEventListener('click', () => {
-          div.classList.toggle('expanded');
-        });
-
-        div.appendChild(headerDiv);
-        div.appendChild(detailDiv);
         infoWrapper.appendChild(div);
       });
 	  updateDisruptionsSummaryVisibility();
@@ -16368,9 +16596,12 @@ window.addEventListener('load', () => {
 </script>
   <script>
 // Gestion du bouton Jeu
-document.getElementById("btnJeu").addEventListener("click", function() {
-  window.location.href = "https://tekmate-lux.github.io/Assistant-train/jeuBETA.html";
-});
+const btnJeu = document.getElementById("btnJeu");
+if (btnJeu){
+  btnJeu.addEventListener("click", function() {
+    window.location.href = "https://tekmate-lux.github.io/Assistant-train/jeuBETA.html";
+  });
+}
 </script>
 <script>
  // Gestion du bouton Carte
@@ -16654,7 +16885,7 @@ document.addEventListener('DOMContentLoaded', () => {
       chDonutYesterday = new Chart($("statsDonutYesterday"), {
         type: "doughnut",
         data: {
-          labels: ["À l’heure","Retardés","Partiels","Supprimés"],
+          labels: ["À l’heure","Retardés","Suppr. partielles","Supprimés"],
           datasets:[{ data:[0,0,0,0], backgroundColor:[
             statsPalette.onTime,
             statsPalette.delayed,
@@ -16693,7 +16924,7 @@ document.addEventListener('DOMContentLoaded', () => {
         type: "bar",
         data: { labels: [], datasets: [
           { label:"Retardés", data: [], backgroundColor: statsPalette.delayed },
-          { label:"Partiels", data: [], backgroundColor: statsPalette.partial },
+          { label:"Suppr. partielles", data: [], backgroundColor: statsPalette.partial },
           { label:"Supprimés", data: [], backgroundColor: statsPalette.canceled },
         ]},
         options: {
@@ -16807,7 +17038,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!chTrainDonut){
       chTrainDonut = new Chart($("statsChTrainDonut"), {
         type: "doughnut",
-        data: { labels: ["À l’heure","Retard","Partiel","Supprimé"], datasets:[{ data:[0,0,0,0], backgroundColor:[
+        data: { labels: ["À l’heure","Retard","Suppr. partielle","Supprimé"], datasets:[{ data:[0,0,0,0], backgroundColor:[
           statsPalette.onTime,
           statsPalette.delayed,
           statsPalette.partial,
@@ -16837,7 +17068,7 @@ document.addEventListener('DOMContentLoaded', () => {
         data: { labels: [], datasets: [
           { label:"Retards à l’arrêt", data: [], backgroundColor: statsPalette.delayed },
           { label:"Supprimés", data: [], backgroundColor: statsPalette.canceled },
-          { label:"Partiels", data: [], backgroundColor: statsPalette.partial },
+          { label:"Suppr. partielles", data: [], backgroundColor: statsPalette.partial },
         ]},
         options: {
           responsive:true,
@@ -17174,7 +17405,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (!GTFS.tripById || !Array.isArray(GTFS.stopTimes)){
       try {
-        await ensureGTFSLoaded();
+        await ensureGTFSLoaded({ silent: true });
       } catch (err){
         chByHour.data.labels = [];
         chByHour.data.datasets[0].data = [];
@@ -17426,7 +17657,7 @@ document.addEventListener('DOMContentLoaded', () => {
       legend.innerHTML = [
         { label:"À l’heure", color: statsPalette.onTime },
         { label:"En retard", color: statsPalette.delayed },
-        { label:"Partiels", color: statsPalette.partial },
+        { label:"Suppr. partielles", color: statsPalette.partial },
         { label:"Supprimés", color: statsPalette.canceled }
       ].map(it => `
         <div class="item">
@@ -17468,25 +17699,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
     $("statsWorstTrain").textContent = worst ? `TER ${worst.trainNo}` : "—";
     $("statsWorstTrainWhy").textContent = worst
-      ? `${worst.cancelled7} supp. · ${worst.partial7} partiels · ${fmtDelayWithPlus(worst.delayMin7)}`
+      ? `${worst.cancelled7} supp. · ${worst.partial7} suppr. partielles · ${fmtDelayWithPlus(worst.delayMin7)}`
       : "—";
 
     $("statsMostDelayTrain").textContent = mostDelay ? `TER ${mostDelay.trainNo}` : "—";
     $("statsMostDelayWhy").textContent = mostDelay
-      ? `${fmtDelayWithPlus(mostDelay.delayMin7)} · ${mostDelay.cancelled7} supp. · ${mostDelay.partial7} partiels`
+      ? `${fmtDelayWithPlus(mostDelay.delayMin7)} · ${mostDelay.cancelled7} supp. · ${mostDelay.partial7} suppr. partielles`
       : "—";
 
 	const homeWorstTrain = document.getElementById("homeWorstTrain");
     if (homeWorstTrain) homeWorstTrain.textContent = worst ? `TER ${worst.trainNo}` : "—";
     const homeWorstWhy = document.getElementById("homeWorstTrainWhy");
     if (homeWorstWhy) homeWorstWhy.textContent = worst
-      ? `${worst.cancelled7} supp. · ${worst.partial7} partiels · ${fmtDelayWithPlus(worst.delayMin7)}`
+      ? `${worst.cancelled7} supp. · ${worst.partial7} suppr. partielles · ${fmtDelayWithPlus(worst.delayMin7)}`
       : "—";
     const homeMostDelayTrain = document.getElementById("homeMostDelayTrain");
     if (homeMostDelayTrain) homeMostDelayTrain.textContent = mostDelay ? `TER ${mostDelay.trainNo}` : "—";
     const homeMostDelayWhy = document.getElementById("homeMostDelayWhy");
     if (homeMostDelayWhy) homeMostDelayWhy.textContent = mostDelay
-      ? `${fmtDelayWithPlus(mostDelay.delayMin7)} · ${mostDelay.cancelled7} supp. · ${mostDelay.partial7} partiels`
+      ? `${fmtDelayWithPlus(mostDelay.delayMin7)} · ${mostDelay.cancelled7} supp. · ${mostDelay.partial7} suppr. partielles`
       : "—";
   }
 
@@ -17581,7 +17812,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const statusMap = {
       ON_TIME: { label: "À l’heure", className: "stats-status-on-time" },
       DELAYED: { label: "Retard", className: "stats-status-delayed" },
-      PARTIAL: { label: "Partiel *", className: "stats-status-partial" },
+      PARTIAL: { label: "Suppr. partielle *", className: "stats-status-partial" },
       CANCELED: { label: "Supprimé", className: "stats-status-canceled" }
     };
     for (const r of s){
@@ -18451,7 +18682,7 @@ function scheduleWeatherAfterTableSettled(){
       else if (b === 'PARTIAL') partial += 1;
     }
 
-    // Fiabilite = (a l'heure) / (a l'heure + retards + suppr. + partiel)
+    // Fiabilite = (a l'heure) / (a l'heure + retards + suppr. + suppr. partielle)
     const total = onTime + delayed + canceled + partial;
     const pctOnTime = total ? Math.round((onTime / total) * 100) : 0;
 
@@ -18494,7 +18725,7 @@ function scheduleWeatherAfterTableSettled(){
         <span class="stats-status-on-time">✅ ${data.onTime} a l'heure</span>
         <span class="stats-status-delayed">⏰ ${data.delayed} retard</span>
         <span class="stats-status-canceled">❌ ${data.canceled} suppr.</span>
-        <span class="stats-status-partial">🟠 ${data.partial} partiel</span>
+        <span class="stats-status-partial">🟠 ${data.partial} suppr. partielle</span>
       </div>
       <div class="fav-note">Base: uniquement les jours trouves dans tes stats (week-end sans circulation = non penalise).</div>
     `;
@@ -20320,7 +20551,7 @@ if (statsEl){
 
   function canLiveRetards(){
     if (!canLiveBase()) return false;
-    if (typeof isSelectedDateToday === 'function' && !isSelectedDateToday()) return false;
+    // Le trafic Home doit rester live même si la date tableau n'est pas "aujourd'hui".
     return true;
   }
 
@@ -20358,6 +20589,13 @@ if (statsEl){
         return;
       }
 
+      const gtfsRetard = cell.querySelector('.gtfs-retard');
+      if (gtfsRetard) {
+        const gtfsBase = gtfsRetard.querySelector('.gtfs-retard-base');
+        if (gtfsBase) gtfsBase.innerHTML = baseWithVoie;
+        return;
+      }
+
       const strong = cell.querySelector('strong');
       if (strong) {
         strong.innerHTML = baseWithVoie;
@@ -20375,7 +20613,7 @@ if (statsEl){
         return;
       }
 
-      if (!cell.querySelector('.delayed')) {
+      if (!cell.querySelector('.delayed') && !cell.querySelector('.gtfs-retard')) {
         cell.innerHTML = baseWithVoie;
       }
     };
@@ -20450,6 +20688,17 @@ if (statsEl){
         // Force un fetch live à intervalle court, sans attendre un refresh manuel.
         await loadGtfsRetards({ forceFresh: false, useCachedFirst: true });
       }
+
+      // Sécurité: met à jour explicitement le trafic Home même si l'event custom est raté.
+      try {
+        if (typeof __lbUpdateHomeTrafficUI === 'function' && window.retardsGTFS_RAW) {
+          __lbUpdateHomeTrafficUI({
+            rawByDataset: window.retardsGTFS_RAW?.['sncf-nml'] ? window.retardsGTFS_RAW : null,
+            raw: window.retardsGTFS_RAW
+          });
+        }
+      } catch(_){}
+
       scheduleLiveApply();
     } catch(e){}
   }
@@ -20680,98 +20929,129 @@ async function updateHomeWeather(fromCfg, toCfg){
    Source: GTFS-RT retards_nancymetzlux.json (proxy VPS)
    Affichage: uniquement un état (FLUIDE / DENSE / BLOQUÉ) + une phrase courte.
 */
-function __lbPickTrafficLevel({ maxDelayMin, delayed, total }){
-  const d = Math.max(0, Number(delayed||0));
-  const t = Math.max(0, Number(total||0));
-  const mx = Math.max(0, Number(maxDelayMin||0));
-  if (!t) return { level:'loading', title:'TRAFIC —', sub:'Données indisponibles' };
+function __lbPickTrafficLevel({ maxDelayMin, delayed, total, partialCount, canceledStopsInSegment }){
+  const d = Math.max(0, Number(delayed || 0));
+  const t = Math.max(0, Number(total || 0));
+  const mx = Math.max(0, Number(maxDelayMin || 0));
+  const partial = Math.max(0, Number(partialCount || 0));
+  const canceledStops = Math.max(0, Number(canceledStopsInSegment || 0));
 
-  // Échelles ferroviaires (simple, lisible)
-  // Vert   : aucun retard significatif
-  // Jaune  : quelques retards (≤ 5 min)
-  // Orange : trafic perturbé
-  // Rouge  : trafic très perturbé
+  if (!t) return { level: 'loading', label: 'Données indisponibles' };
+
   const pct = t ? (d / t) : 0;
 
-  if (mx <= 0) return { level:'green',  title:'TRAFIC FLUIDE', sub:'RAS (pour une fois)' };
-  if (mx <= 5) return { level:'yellow', title:'QUELQUES RETARDS', sub:'≤ 5 min' };
+  // Suppression partielle: impact immédiat sur le segment concerné,
+  // même si les minutes de retard restent faibles.
+  if (partial > 0) {
+    if (partial >= 2 || canceledStops >= 4) return { level: 'red', label: 'Trafic très perturbé' };
+    return { level: 'orange', label: 'Trafic perturbé' };
+  }
 
-  // Au-delà de 5 min : on distingue perturbé / très perturbé
-  // On combine intensité (retard max) + volume (part de trains impactés)
-  const severe = (mx >= 20) || (pct >= 0.25) || (d >= 6);
-  if (severe) return { level:'red', title:'TRAFIC TRÈS PERTURBÉ', sub:'Retards importants' };
+  if (mx <= 0 || d <= 0) return { level: 'green', label: 'Trafic fluide' };
 
-  return { level:'orange', title:'TRAFIC PERTURBÉ', sub:'Retards en cours' };
+  // Retards légers (<= 5 min) = trafic ralenti, même s'il y a plusieurs trains.
+  if (mx <= 5) return { level: 'yellow', label: 'Trafic ralenti' };
+
+  // Prend en compte la gravité minute + volume de trains retardés.
+  const severeMinutes = mx >= 20;
+  const highShare = pct >= 0.5;
+  const manyDelayed = d >= 6;
+  if (severeMinutes && (highShare || d >= 4)) return { level: 'red', label: 'Trafic très perturbé' };
+  if (highShare && manyDelayed) return { level: 'red', label: 'Trafic très perturbé' };
+
+  if (mx >= 12 || pct >= 0.25 || d >= 3) return { level: 'orange', label: 'Trafic perturbé' };
+  return { level: 'orange', label: 'Trafic perturbé' };
+}
+
+function __lbBuildTrafficSegmentStats(raw, segmentStationNames){
+  const trainsObj = raw?.trains || raw?.normalized?.trains || raw?.['sncf-nml']?.trains || null;
+  if (!trainsObj || typeof trainsObj !== 'object') {
+    return { maxDelayMin: 0, delayed: 0, total: 0, partialCount: 0, canceledStopsInSegment: 0 };
+  }
+
+  const norm = (x) => {
+    try { return normalizeStationName ? normalizeStationName(x || '') : String(x || '').toLowerCase().trim(); }
+    catch(_) { return String(x || '').toLowerCase().trim(); }
+  };
+
+  const stationSet = new Set((segmentStationNames || []).map(norm).filter(Boolean));
+  let total = 0;
+  let delayed = 0;
+  let maxDelayMin = 0;
+  let partialCount = 0;
+  let canceledStopsInSegment = 0;
+
+  for (const tr of Object.values(trainsObj)) {
+    const stops = tr?.stops || {};
+    const canceledStops = Array.isArray(tr?.canceled_stops) ? tr.canceled_stops : (Array.isArray(tr?.canceledStops) ? tr.canceledStops : []);
+    const statusRaw = String(tr?.status || '').toUpperCase();
+
+    let touchesSegment = false;
+    let trSegMax = 0;
+    let canceledHits = 0;
+
+    for (const [stopName, delayVal] of Object.entries(stops)) {
+      const stopNorm = norm(stopName);
+      if (!stationSet.has(stopNorm)) continue;
+      touchesSegment = true;
+      const n = Number(delayVal);
+      if (Number.isFinite(n) && n > trSegMax) trSegMax = n;
+    }
+
+    for (const stopName of canceledStops) {
+      if (!stationSet.has(norm(stopName))) continue;
+      touchesSegment = true;
+      canceledHits += 1;
+    }
+
+    if (!touchesSegment) continue;
+
+    total += 1;
+    if (trSegMax > 0) delayed += 1;
+    if (trSegMax > maxDelayMin) maxDelayMin = trSegMax;
+
+    const isPartial = statusRaw.includes('PARTIAL');
+    // N'impacte le segment que si des arrêts de CE segment sont réellement supprimés.
+    // Si la source ne fournit pas canceled_stops, on garde un fallback prudent.
+    const hasCanceledList = canceledStops.length > 0;
+    if (isPartial && (canceledHits > 0 || !hasCanceledList)) {
+      partialCount += 1;
+      canceledStopsInSegment += canceledHits;
+    }
+  }
+
+  return { maxDelayMin, delayed, total, partialCount, canceledStopsInSegment };
+}
+
+function __lbSetTrafficBadge(el, status){
+  if (!el) return;
+  el.classList.remove('traffic-pill--loading', 'traffic-pill--green', 'traffic-pill--yellow', 'traffic-pill--orange', 'traffic-pill--red');
+  el.classList.add(`traffic-pill--${status.level || 'loading'}`);
+  el.textContent = status.label || 'Données indisponibles';
 }
 
 function __lbUpdateHomeTrafficUI(payload){
-  const card = document.querySelector('.home-traffic-card');
-  const titleEl = document.getElementById('homeTrafficTitle');
-  const subEl = document.getElementById('homeTrafficSub');
-  if (!card || !titleEl || !subEl) return;
+  const lineNorth = document.getElementById('homeTrafficLineNorth');
+  const lineSouth = document.getElementById('homeTrafficLineSouth');
+  const badgeNorth = document.getElementById('homeTrafficBadgeNorth');
+  const badgeSouth = document.getElementById('homeTrafficBadgeSouth');
+  if (!lineNorth || !lineSouth || !badgeNorth || !badgeSouth) return;
 
-  // Reset classes
-  card.classList.remove(
-    'traffic-level--loading',
-    'traffic-level--green',
-    'traffic-level--yellow',
-    'traffic-level--orange',
-    'traffic-level--red'
-  );
+  lineNorth.textContent = 'Metz - Luxembourg';
+  lineSouth.textContent = 'Nancy - Metz';
 
-  let delayed = null, total = null, maxDelayMin = 0;
-
-  // payload peut être rawByDataset si plusieurs datasets
   const raw = payload?.rawByDataset?.['sncf-nml'] || payload?.rawByDataset?.sncfNml || payload?.raw || payload;
 
-  // compteurs
-  if (raw && raw.counters){
-    delayed = raw.counters.DELAYED;
-    total = raw.count;
-  } else if (raw && raw.normalized && raw.normalized.counters){
-    delayed = raw.normalized.counters.DELAYED;
-    total = raw.normalized.count;
-  } else if (raw && raw['sncf-nml']){
-    delayed = raw['sncf-nml']?.counters?.DELAYED;
-    total = raw['sncf-nml']?.count;
-  }
+  // Metz est volontairement EXCLU des 2 segments pour éviter le chevauchement
+  // des retards sur la gare frontière quand un train traverse les 2 zones.
+  const segNorth = __lbBuildTrafficSegmentStats(raw, ['Hagondange', 'Uckange', 'Thionville', 'Hettange-Grande', 'Bettembourg', 'Luxembourg']);
+  const segSouth = __lbBuildTrafficSegmentStats(raw, ['Nancy', 'Frouard', 'Pompey', 'Belleville', 'Dieulouard', 'Pont-à-Mousson', 'Vandières', 'Pagny-sur-Moselle', 'Novéant-sur-Moselle', 'Ancy-sur-Moselle', 'Ars-sur-Moselle']);
 
-  // retard max (si trains/stops dispo)
-  const trainsObj = raw?.trains || raw?.normalized?.trains || raw?.['sncf-nml']?.trains || null;
-  if (trainsObj && typeof trainsObj === 'object'){
-    for (const tr of Object.values(trainsObj)){
-      const stops = tr?.stops || {};
-      let trMax = 0;
-      for (const v of Object.values(stops)){
-        const n = Number(v);
-        if (Number.isFinite(n) && n > trMax) trMax = n;
-      }
-      if (trMax > maxDelayMin) maxDelayMin = trMax;
-    }
-    // fallback compteurs si absents
-    if (delayed == null){
-      let d = 0;
-      for (const tr of Object.values(trainsObj)){
-        const stops = tr?.stops || {};
-        let trMax = 0;
-        for (const v of Object.values(stops)){
-          const n = Number(v);
-          if (Number.isFinite(n) && n > trMax) trMax = n;
-        }
-        if (trMax > 0) d++;
-      }
-      delayed = d;
-    }
-    if (total == null) total = Object.keys(trainsObj).length;
-  }
+  const n = __lbPickTrafficLevel(segNorth);
+  const s = __lbPickTrafficLevel(segSouth);
 
-  const s = __lbPickTrafficLevel({ maxDelayMin, delayed, total });
-
-  const cls = `traffic-level--${s.level}`;
-  card.classList.add(cls);
-
-  titleEl.textContent = s.title;
-  subEl.textContent = s.sub;
+  __lbSetTrafficBadge(badgeNorth, n);
+  __lbSetTrafficBadge(badgeSouth, s);
 }
 
 async function updateHomeTrafficStatus(){
@@ -20793,12 +21073,14 @@ async function updateHomeTrafficStatus(){
     const result = await fetchGtfsDataset(dataset, { forceFresh: true });
     __lbUpdateHomeTrafficUI({ raw: result?.raw, normalized: result?.normalized });
   }catch(e){
-    const titleEl = document.getElementById('homeTrafficTitle');
-    const subEl = document.getElementById('homeTrafficSub');
-    const card = document.querySelector('.home-traffic-card');
-    if (card) card.classList.add('traffic-level--loading');
-    if (titleEl) titleEl.textContent = 'TRAFIC —';
-    if (subEl) subEl.textContent = 'Données indisponibles';
+    const lineNorth = document.getElementById('homeTrafficLineNorth');
+    const lineSouth = document.getElementById('homeTrafficLineSouth');
+    const badgeNorth = document.getElementById('homeTrafficBadgeNorth');
+    const badgeSouth = document.getElementById('homeTrafficBadgeSouth');
+    if (lineNorth) lineNorth.textContent = 'Metz - Luxembourg';
+    if (lineSouth) lineSouth.textContent = 'Nancy - Metz';
+    __lbSetTrafficBadge(badgeNorth, { level:'loading', label:'Données indisponibles' });
+    __lbSetTrafficBadge(badgeSouth, { level:'loading', label:'Données indisponibles' });
   }
 }
 
@@ -21920,7 +22202,360 @@ async function loadAffluenceDate(dateStr){
     summary: lbGetAffluenceSummary,
     openTrain: lbOpenAffluenceTrain
   };
+
   window.lbOpenAffluenceTrain = lbOpenAffluenceTrain;
+})();
+
+(function(){
+  const luxTodayYMD = () => new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/Luxembourg' });
+  const esc = (v) => String(v ?? '').replace(/[&<>"']/g, (ch) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch] || ch));
+  const fmtDateFr = (iso) => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(String(iso||''))) return 'date inconnue';
+    const d = new Date(`${iso}T00:00:00`);
+    return d.toLocaleDateString('fr-FR', { day:'numeric', month:'long', year:'numeric' });
+  };
+  const hhmmToMin = (raw) => {
+    const digits = String(raw||'').replace(/\D/g, '');
+    if (digits.length < 4) return null;
+    const hh = Number(digits.slice(0,2));
+    const mm = Number(digits.slice(2,4));
+    if (!Number.isFinite(hh) || !Number.isFinite(mm) || mm > 59) return null;
+    return hh * 60 + mm;
+  };
+  const minToClock = (m) => Number.isFinite(m) ? `${String(Math.floor(m/60)).padStart(2,'0')}:${String(m%60).padStart(2,'0')}` : '—';
+  const luxNowMin = () => {
+    const parts = new Intl.DateTimeFormat('fr-FR', { timeZone:'Europe/Luxembourg', hour:'2-digit', minute:'2-digit', hourCycle:'h23' }).formatToParts(new Date());
+    const hh = Number(parts.find(p => p.type === 'hour')?.value || 0);
+    const mm = Number(parts.find(p => p.type === 'minute')?.value || 0);
+    return hh * 60 + mm;
+  };
+
+  const state = { affChart: null };
+  const affColor = (pct) => {
+    const p = Number(pct);
+    if (!Number.isFinite(p)) return '#9aa7b6';
+    if (p < 50) return '#24c25a';
+    if (p < 70) return '#ffd166';
+    if (p < 85) return '#ff8a1a';
+    if (p < 95) return '#ff3131';
+    return '#111';
+  };
+  function destroyAffChart(){
+    if (state.affChart){
+      try{ state.affChart.destroy(); }catch(_){ }
+      state.affChart = null;
+    }
+  }
+
+  async function getReliabilityData(trainNumber){
+    try{
+      const stats = window.__lbStats || {};
+      if (typeof stats.getLastDaysRange !== 'function' || typeof stats.getRawRange !== 'function' || typeof stats.computeTrainSeriesFromRawDays !== 'function') return null;
+      const r = stats.getLastDaysRange(30);
+      if (!r?.from || !r?.to) return null;
+      const rawDays = await stats.getRawRange(r.from, r.to);
+      const range = stats.computeTrainSeriesFromRawDays(rawDays || [], r.from, r.to, String(trainNumber), null);
+      const s = Array.isArray(range?.series) ? range.series : [];
+      if (!s.length) return null;
+
+      let onTime = 0, delayed = 0, canceled = 0, partial = 0;
+      for (const d of s){
+        const b = String(d?.bucket || '');
+        if (!b) continue;
+        if (b === 'ON_TIME') onTime += 1;
+        else if (b === 'DELAYED') delayed += 1;
+        else if (b === 'CANCELED') canceled += 1;
+        else if (b === 'PARTIAL') partial += 1;
+      }
+      const total = onTime + delayed + canceled + partial;
+      if (!total) return null;
+      const delayValues = s
+        .filter(d => String(d?.bucket || '') === 'DELAYED' && Number.isFinite(Number(d?.value)))
+        .map(d => Number(d.value));
+      const avgDelay = delayValues.length ? Math.round(delayValues.reduce((a,b)=>a+b,0) / delayValues.length) : 0;
+      const maxDelay = delayValues.length ? Math.max(...delayValues) : 0;
+      return {
+        pct: Math.round((onTime / total) * 100),
+        onTime, delayed, canceled, partial,
+        avgDelay, maxDelay
+      };
+    }catch(_){ return null; }
+  }
+
+  function firstDepartureFromStopTimes(stopTimes){
+    if (!Array.isArray(stopTimes) || !stopTimes.length) return null;
+    return hhmmToMin(stopTimes[0]?.departure_time || stopTimes[0]?.arrival_time);
+  }
+
+  async function computeNextDepartureLabelEnhanced(trainNumber, dateIso, stopTimes){
+    const depMin = firstDepartureFromStopTimes(stopTimes);
+    const arrMin = hhmmToMin(stopTimes?.[stopTimes.length - 1]?.arrival_time || stopTimes?.[stopTimes.length - 1]?.departure_time);
+    if (!Number.isFinite(depMin)) return 'Non disponible';
+    const today = luxTodayYMD();
+    if (dateIso === today){
+      const now = luxNowMin();
+      if (Number.isFinite(arrMin) && now > arrMin){
+        const td = new Date(`${today}T00:00:00`); td.setDate(td.getDate()+1);
+        const tomorrow = td.toISOString().slice(0,10);
+        try{
+          const fb = await buildGtfsFallbackResult(String(trainNumber||''), { ymd: tomorrow.replace(/-/g,'') });
+          const tDep = firstDepartureFromStopTimes(fb?.train?.stop_times || []);
+          if (Number.isFinite(tDep)) return `Terminé aujourd’hui • prochain train demain à ${minToClock(tDep)}`;
+        }catch(_){ }
+        return `Terminé aujourd'hui (arrivé vers ${minToClock(arrMin)})`;
+      }
+      if (now >= depMin) return `En cours (départ ${minToClock(depMin)})`;
+      return `Aujourd'hui à ${minToClock(depMin)} (dans ${depMin - now} min)`;
+    }
+    const tomorrow = (()=>{ const d=new Date(`${today}T00:00:00`); d.setDate(d.getDate()+1); return d.toISOString().slice(0,10); })();
+    if (dateIso === tomorrow) return `Demain à ${minToClock(depMin)}`;
+    return `Le ${fmtDateFr(dateIso)} à ${minToClock(depMin)}`;
+  }
+
+  function renderAffluenceChartFromInfo(info){
+    const cvs = document.getElementById('trainDetailAffluenceChart');
+    if (!cvs || !window.Chart) return;
+    const stops = Array.isArray(info?.stops) ? info.stops : [];
+    const labels = stops.map(s => String(s?.station || s?.name || '—'));
+    const values = stops.map(s => {
+      const p = Number(s?.globalPct ?? Math.round((Number(s?.globalOcc)||0)*100));
+      return Number.isFinite(p) ? Math.max(0, Math.min(100, Math.round(p))) : null;
+    });
+    destroyAffChart();
+    if (!labels.length) return;
+    state.affChart = new Chart(cvs, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          data: values,
+          borderColor: 'rgba(0,240,255,.85)',
+          backgroundColor: 'rgba(0,240,255,.12)',
+          tension: .25,
+          fill: false,
+          pointRadius: 5,
+          pointBackgroundColor: values.map(v => affColor(v)),
+          pointBorderColor: 'rgba(255,255,255,.8)',
+          pointBorderWidth: 1.5
+        }]
+      },
+      options: {
+        animation: false,
+        plugins: { legend: { display:false } },
+        scales: {
+          y: { min:0, max:100, ticks:{ color:'rgba(210,250,255,.9)', callback:v=>`${v}%` }, grid:{ color:'rgba(0,255,255,.12)' } },
+          x: { ticks:{ color:'rgba(210,250,255,.9)' }, grid:{ color:'rgba(0,255,255,.08)' } }
+        }
+      }
+    });
+  }
+
+  async function renderAffluenceBlock(trainNumber, selectedDate){
+    const affEl = document.getElementById('trainDetailAffluence');
+    if (typeof window.lbAff?.loadDate === 'function') {
+      try { await window.lbAff.loadDate(selectedDate); } catch(_) {}
+    }
+    const info = (typeof window.getAffluenceTrainInfo === 'function') ? window.getAffluenceTrainInfo(String(trainNumber)) : null;
+    if (!info){
+      affEl.textContent = 'Non disponible';
+      destroyAffChart();
+      return null;
+    }
+    const maxPct = Array.isArray(info.stops)
+      ? info.stops.reduce((mx,s)=>{
+          const p = Number(s?.globalPct ?? Math.round((Number(s?.globalOcc)||0)*100));
+          return Number.isFinite(p) ? Math.max(mx, Math.round(p)) : mx;
+        }, 0)
+      : (Number.isFinite(Number(info.depPct)) ? Math.round(Number(info.depPct)) : null);
+    affEl.textContent = Number.isFinite(maxPct) ? `${maxPct}%` : 'Non disponible';
+    renderAffluenceChartFromInfo(info);
+    return info;
+  }
+
+  async function openInternalTrainPanel(trainNumber, dateIso){
+    const panel = document.getElementById('trainDetailPanel');
+    if (!panel) return;
+    const selectedDate = /^\d{4}-\d{2}-\d{2}$/.test(String(dateIso||'')) ? String(dateIso) : (document.getElementById('trainDate')?.value || luxTodayYMD());
+    const ymd = selectedDate.replace(/-/g, '');
+
+    const titleEl = document.getElementById('trainDetailTitle');
+    const nextEl = document.getElementById('trainDetailNext');
+    const relEl = document.getElementById('trainDetailReliability');
+    const relDetailsEl = document.getElementById('trainDetailReliabilityDetails');
+    const pathEl = document.getElementById('trainDetailPath');
+    const stopsEl = document.getElementById('trainDetailStops');
+    const affBtn = document.getElementById('trainDetailAffBtn');
+    const statsBtn = document.getElementById('trainDetailStatsBtn');
+
+    panel.hidden = false;
+    titleEl.textContent = `Train ${trainNumber}`;
+    nextEl.textContent = 'Chargement…';
+    relEl.textContent = 'Chargement…';
+    relDetailsEl.textContent = 'Chargement…';
+    pathEl.textContent = 'Chargement…';
+    stopsEl.innerHTML = '<div class="train-detail-stop"><span>Récupération du parcours…</span></div>';
+
+    if (typeof loadCompoData === 'function') {
+      try { await loadCompoData({ forceFresh: false, background: true }); } catch(_) {}
+    }
+
+    let fallback = null;
+    try { fallback = await buildGtfsFallbackResult(trainNumber, { ymd }); } catch(_) {}
+    const stopTimes = fallback?.train?.stop_times || [];
+    const first = stopTimes[0] || null;
+    const last = stopTimes[stopTimes.length - 1] || null;
+
+    if (stopTimes.length){
+      const origin = first?.stop_point?.name || '—';
+      const dest = last?.stop_point?.name || '—';
+      pathEl.textContent = `${origin} → ${dest} (${stopTimes.length} arrêts)`;
+      nextEl.textContent = await computeNextDepartureLabelEnhanced(trainNumber, selectedDate, stopTimes);
+
+      const affInfoInline = (typeof window.getAffluenceTrainInfo === 'function') ? window.getAffluenceTrainInfo(String(trainNumber)) : null;
+      const affStops = Array.isArray(affInfoInline?.stops) ? affInfoInline.stops : [];
+      const normStation = (nm) => { try{ return normalizeStationName ? normalizeStationName(nm||'') : String(nm||'').toLowerCase(); }catch(_){ return String(nm||'').toLowerCase(); } };
+      stopsEl.innerHTML = stopTimes.map((st) => {
+        const arr = (st?.arrival_time || '').replace(/(\d{2})(\d{2}).*/, '$1:$2');
+        const dep = (st?.departure_time || '').replace(/(\d{2})(\d{2}).*/, '$1:$2');
+        const stopNameRaw = st?.stop_point?.name || '—';
+        const stopName = esc(stopNameRaw);
+        const t = dep || arr || '—';
+        const hit = affStops.find(a => normStation(a?.station || a?.name || '') === normStation(stopNameRaw));
+        const p = Number(hit?.globalPct ?? Math.round((Number(hit?.globalOcc)||0)*100));
+        const pctVal = Number.isFinite(p) ? Math.round(p) : null;
+        const pctTxt = Number.isFinite(pctVal) ? `${pctVal}%` : '—';
+        const pctColor = Number.isFinite(pctVal) ? affColor(pctVal) : '#9aa7b6';
+        const schema = (hit && typeof window.wagonSchemaHtml === 'function') ? window.wagonSchemaHtml(hit, affInfoInline?.trainType) : '';
+        return `<div class="train-detail-stop"><span class="left"><span class="time">${t}</span><span class="name">${stopName}</span></span><span class="right"><span style="color:${pctColor};font-weight:800">${pctTxt}</span>${schema}</span></div>`;
+      }).join('');
+    } else {
+      pathEl.textContent = 'Parcours indisponible pour cette date';
+      nextEl.textContent = 'Non disponible';
+      stopsEl.innerHTML = '<div class="train-detail-stop"><span>Aucun arrêt GTFS trouvé pour ce train et cette date.</span></div>';
+    }
+
+    const rel = await getReliabilityData(trainNumber);
+    if (rel){
+      relEl.textContent = `${rel.pct}%`;
+      relDetailsEl.innerHTML = `
+        <div>✅ ${rel.onTime} à l'heure ⏰ ${rel.delayed} retard ❌ ${rel.canceled} supprimé 🟠 ${rel.partial} suppr. partielle</div>
+        <div style="margin-top:4px">Retard moyen : ${rel.avgDelay} min</div>
+        <div>Retard max : ${rel.maxDelay} min</div>`;
+    } else {
+      relEl.textContent = '—';
+      relDetailsEl.textContent = 'Données indisponibles.';
+    }
+
+    const affInfo = await renderAffluenceBlock(trainNumber, selectedDate);
+    const compoEl = document.getElementById('trainDetailCompo');
+    if (typeof window.buildFavTrainTypeBadge === 'function') {
+      const badge = window.buildFavTrainTypeBadge(String(trainNumber), affInfo?.trainType || '');
+      compoEl.innerHTML = badge || 'Inconnue';
+    } else {
+      compoEl.textContent = affInfo?.trainType || 'Inconnue';
+    }
+
+    if (affBtn){
+      affBtn.onclick = (e) => {
+        e.preventDefault();
+        if (typeof window.lbOpenAffluenceTrain === 'function') window.lbOpenAffluenceTrain(trainNumber, selectedDate);
+        else location.hash = '#affluence';
+      };
+    }
+
+    if (statsBtn){
+      statsBtn.onclick = (e) => {
+        e.preventDefault();
+        const input = document.getElementById('statsTrainId');
+        if (input) input.value = String(trainNumber);
+        document.getElementById('statsTabTrainBtn')?.click();
+        document.getElementById('statsBtnTrainRun')?.click();
+        location.hash = '#statsConsole';
+      };
+    }
+
+    panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  document.addEventListener('click', (e) => {
+    const a = e.target.closest && e.target.closest('#trainInfo a.train-link');
+    if (!a) return;
+    const trainNumber = a.dataset.trainNumber || (a.textContent || '').trim();
+    if (!/\d{5,6}/.test(trainNumber || '')) return;
+    e.preventDefault();
+    const dateIso = a.dataset.trainDate || document.getElementById('trainDate')?.value || luxTodayYMD();
+    openInternalTrainPanel((trainNumber.match(/\d{5,6}/)||[])[0], dateIso);
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const closeBtn = document.getElementById('trainDetailClose');
+    const panel = document.getElementById('trainDetailPanel');
+    if (closeBtn && panel) closeBtn.addEventListener('click', () => { panel.hidden = true; destroyAffChart(); });
+  });
+})();
+
+(function(){
+  const PAGE_HASH_ALIASES = {
+    '#home': 'home',
+    '#search': 'search',
+    '#carte': 'carte',
+    '#affluence': 'carte',
+    '#favoris': 'favoris',
+    '#favtrainswidget': 'favoris',
+    '#stats': 'stats',
+    '#statsconsole': 'stats',
+    '#loisirs': 'loisirs',
+    '#divertissement': 'loisirs',
+    '#multimedia': 'loisirs'
+  };
+
+  const navItems = Array.from(document.querySelectorAll('.bottom-nav__item[href]'));
+  const pages = Array.from(document.querySelectorAll('.app-page[data-page]'));
+
+  function pageFromHash(hash){
+    return PAGE_HASH_ALIASES[String(hash || '').toLowerCase()] || 'home';
+  }
+
+  function syncActiveNav(page){
+    navItems.forEach((item) => {
+      const targetPage = pageFromHash(item.getAttribute('href') || '');
+      const active = targetPage === page;
+      item.classList.toggle('active', active);
+      item.setAttribute('aria-current', active ? 'page' : 'false');
+    });
+  }
+
+  function syncPages(){
+    const hash = location.hash || '#home';
+    const page = pageFromHash(hash);
+
+    document.body.classList.remove('page-home','page-search','page-carte','page-favoris','page-stats','page-loisirs');
+    document.body.classList.add(`page-${page}`);
+
+    pages.forEach((node) => {
+      const active = node.dataset.page === page;
+      node.classList.toggle('is-page-active', active);
+      if (node.id === 'favTrainsWidget' && !active){
+        node.style.display = 'none';
+      }
+    });
+
+    if (page === 'favoris'){
+      const fav = document.getElementById('favTrainsWidget');
+      if (fav) fav.style.display = 'block';
+    }
+
+    syncActiveNav(page);
+
+    if (hash && /^#[A-Za-z][\w:-]*$/.test(hash)){
+      const target = document.querySelector(hash);
+      if (target) requestAnimationFrame(() => target.scrollIntoView({ behavior:'smooth', block:'start' }));
+    }
+  }
+
+  window.addEventListener('hashchange', syncPages);
+  document.addEventListener('DOMContentLoaded', syncPages);
+  syncPages();
 })();
 
 (function(){
@@ -22046,14 +22681,14 @@ async function loadAffluenceDate(dateStr){
 
 (function(){
   const nav = document.getElementById('loisirsViewNav');
-  const loisirsLink = document.querySelector('.bottom-nav__item[href="#divertissement"]');
+  const loisirsLink = document.querySelector('.bottom-nav__item[href="#loisirs"]');
   const multimediaSection = document.getElementById('multimedia');
   const bingoBtn = document.getElementById('btnBingo');
   const jeuBtn = document.getElementById('btnJeu');
   if (!nav || !loisirsLink || !multimediaSection) return;
 
   const tabs = Array.from(nav.querySelectorAll('[data-loisirs-view]'));
-  const onLoisirsTab = () => ['#divertissement', '#multimedia'].includes(location.hash || '');
+  const onLoisirsTab = () => ['#loisirs', '#divertissement', '#multimedia'].includes(location.hash || '');
 
   function activate(view){
     tabs.forEach(tab => {
@@ -22091,14 +22726,14 @@ async function loadAffluenceDate(dateStr){
 
   loisirsLink.addEventListener('click', (e) => {
     e.preventDefault();
-    if ((location.hash || '') !== '#divertissement') location.hash = 'divertissement';
+    if ((location.hash || '') !== '#loisirs') location.hash = 'loisirs';
     refresh();
     openView('multimedia', { scroll: true });
   });
 
   document.querySelectorAll('.bottom-nav__item[href]').forEach(link => {
     link.addEventListener('click', () => {
-      if ((link.getAttribute('href') || '') !== '#divertissement') {
+      if ((link.getAttribute('href') || '') !== '#loisirs') {
         nav.hidden = true;
         nav.classList.remove('is-visible');
         document.body.classList.remove('loisirs-view-nav-visible');
@@ -22110,6 +22745,83 @@ async function loadAffluenceDate(dateStr){
   document.addEventListener('DOMContentLoaded', refresh);
   refresh();
 })();
+
+(function(){
+  const modal = document.getElementById('alertDetailModal');
+  const body = document.getElementById('alertDetailBody');
+  const title = document.getElementById('alertDetailTitle');
+  const closeBtn = document.getElementById('alertDetailClose');
+  if (!modal || !body || !title) return;
+
+  const esc = (v) => String(v || '').replace(/[&<>"']/g, (m) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+
+  function openDetails(detailItems, trainNo, fallbackTitle){
+    const key = String(trainNo || '').trim();
+    const list = Array.isArray(detailItems) ? detailItems : [];
+    if (!list.length) {
+      const t = fallbackTitle || 'Aucun détail disponible';
+      title.textContent = `Train ${key || '—'}`;
+      body.innerHTML = `<div class="alert-detail-card info"><div class="alert-detail-row">ℹ️ ${esc(t)}</div></div>`;
+    } else {
+      title.textContent = `Train ${key} — détail perturbation`;
+      body.innerHTML = list.map((it) => `
+        <div class="alert-detail-card ${esc(it.level)}">
+          <div class="alert-detail-row"><span>${esc(it.icon)}</span><span>${esc(it.title)}</span></div>
+          ${it.description ? `<div class="alert-detail-desc">${esc(it.description)}</div>` : ''}
+          ${Array.isArray(it.trains) && it.trains.length ? `<div class="disruption-trains">${it.trains.map(t => `<span class="disruption-train-pill">${esc(t)}</span>`).join('')}</div>` : ''}
+        </div>`).join('');
+    }
+    modal.classList.add('is-open');
+    modal.setAttribute('aria-hidden', 'false');
+  }
+
+  function openForKey(alertKey, trainNo, fallbackTitle){
+    const item = alertKey ? LB_ALERTS_BY_KEY.get(String(alertKey)) : null;
+    if (item) return openDetails([item], trainNo, fallbackTitle);
+    const trainKey = String(trainNo || '').trim();
+    const disr = LB_TABLE_DISRUPTIONS_BY_TRAIN.get(trainKey) || [];
+    if (disr.length) return openDetails(disr, trainNo, fallbackTitle);
+    const list = LB_ALERTS_BY_TRAIN.get(trainKey) || [];
+    return openDetails(list, trainNo, fallbackTitle);
+  }
+
+  function closeModal(){
+    modal.classList.remove('is-open');
+    modal.setAttribute('aria-hidden', 'true');
+  }
+
+  closeBtn?.addEventListener('click', closeModal);
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) closeModal();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && modal.classList.contains('is-open')) closeModal();
+  });
+
+  document.addEventListener('click', (e) => {
+    const icon = e.target.closest && e.target.closest('#trainInfo thead .icon, #trainInfo th .train-state');
+    if (!icon) return;
+
+    let th = icon.closest('th[data-train-number]');
+    if (!th) {
+      const td = icon.closest('td,th');
+      const row = td?.parentElement;
+      const idx = (td && row) ? Array.from(row.children).indexOf(td) : -1;
+      const firstHead = icon.closest('thead')?.querySelector('tr:first-child');
+      th = (firstHead && idx >= 0) ? firstHead.children[idx] : null;
+      if (!(th && th.matches && th.matches('th[data-train-number]'))) th = null;
+    }
+
+    if (!th) return;
+    const trainNo = (th.dataset.trainNumber || '').replace(/^CFL-/, '');
+    const fallback = icon.getAttribute('title') || th.getAttribute('title') || '';
+    const alertKey = icon.dataset.alertKey || th.dataset.alertKeyMain || '';
+    if (!trainNo) return;
+    e.preventDefault();
+    openForKey(alertKey, trainNo, fallback);
+  });
+})();
+
 </script>
 
 </body>


### PR DESCRIPTION
### Motivation
- Make the single-file app more app-like with per-page navigation and tighter home UI spacing. 
- Improve user workflow for disruptions and trains by adding train-detail and alert-detail panels and richer disruption-to-train mapping. 
- Reduce intrusive GTFS load modal by allowing silent/preload loading and avoid showing the overlay repeatedly.

### Description
- Introduced app page system: added `app-page` + `data-page` attributes, body page classes and hash-based routing to show/hide pages and sync bottom nav items. 
- Reworked Home traffic card into per-segment badges (`traffic-split`, `traffic-pill`), added CSS for new UI components, and implemented new traffic scoring (`__lbBuildTrafficSegmentStats`, extended `__lbPickTrafficLevel`) to consider partial suppressions and canceled stops. 
- Added a train detail panel (`#trainDetailPanel`) with reliability, affluence chart, route/stops listing and actions, plus click-to-open handling for internal train links. 
- Added alert detail modal (`#alertDetailModal`) and reworked alert/disruption rendering to build keyed alert objects and index them by train (`LB_ALERTS_BY_KEY`, `LB_ALERTS_BY_TRAIN`, `LB_TABLE_DISRUPTIONS_BY_TRAIN`) for per-train inspection. 
- Made GTFS loader less intrusive by adding `ensureGTFSLoaded({ silent })`, `GTFS_LOADED_ONCE` flag, and background preload on window `load` to avoid showing overlay repeatedly. 
- Enhanced linkification of train headers to produce internal links for details, improved header DOM handling and fav-star application. 
- Numerous UI tweaks: spacing, font sizes, pills, disruption card styles, plural/label wording changes (e.g. “Suppr. partielles”), and safe event binding fixes (e.g. `btnJeu`). 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69e41dfdc832d9164ef79f035e64b)