### PR TITLE
Convertir la navigation en vues par onglet et activer le mode PWA

### DIFF
--- a/index00.html
+++ b/index00.html
@@ -10,6 +10,11 @@
   />
   <link rel="icon" href="favicon.jpg" type="image/jpeg" />
   <link rel="apple-touch-icon" href="favicon.jpg" />
+  <meta name="theme-color" content="#0b0f1a" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <link rel="manifest" href="manifest.webmanifest" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/nouislider@15.7.1/dist/nouislider.min.css">
   <script src="https://cdn.jsdelivr.net/npm/nouislider@15.7.1/dist/nouislider.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
@@ -35,6 +40,10 @@ body {
   margin-left: auto;
   margin-right: auto;
 }
+
+.app-page{ display:none !important; }
+.app-page.is-active{ display:block !important; animation: lbPageFade .18s ease; }
+@keyframes lbPageFade{ from{ opacity:.55; transform: translateY(4px);} to{ opacity:1; transform: translateY(0);} }
 
 :root{
   --top-bar-height: 72px;
@@ -461,7 +470,8 @@ body {
 }
 
 .bottom-nav__item:hover,
-.bottom-nav__item:focus-visible{
+.bottom-nav__item:focus-visible,
+.bottom-nav__item.is-active{
   color: #ffffff;
   outline: none;
 }
@@ -7686,7 +7696,7 @@ html, body{
 </div>
 
   </div>
-  <section id="home" class="home-section" aria-label="Accueil">
+  <section id="home" class="home-section app-page" data-page="home" aria-label="Accueil">
   <div class="home-dashboard">
     <div class="home-welcome-line">Bienvenue 🐮 dans votre bétaillère Nancy–Metz–Lux 👋</div>
 
@@ -8049,7 +8059,7 @@ html, body{
   </div>
 
 <!-- Widget Favoris Matin / Soir (visible si connecté) -->
-<section id="favTrainsWidget" class="fav-widget" style="display:none; position:relative; z-index:2;">
+<section id="favTrainsWidget" class="fav-widget app-page" data-page="favTrainsWidget" style="display:none; position:relative; z-index:2;">
   <div class="fav-head">
     <div class="fav-title">⭐ Mes bétaillères favorites</div>
     <button id="favOpenPrefs" class="fav-btn" type="button">Modifier</button>
@@ -8093,7 +8103,7 @@ html, body{
 </section>
 
 <!-- Console de Commande -->
-<div class="command-console" id="search">
+<div class="command-console app-page" id="search" data-page="search">
   <div class="console-header"> Console de Commande – Sélection des Bétaillères</div>
 
   <!-- 1) GÉNÉRATION PERSONNALISÉE -->
@@ -8348,7 +8358,7 @@ html, body{
   <button id="refreshButton" class="refresh-btn">Actualiser les données</button>
 </div>
 
-<section id="carte" class="media-section" aria-label="Carte en direct">
+<section id="carte" class="media-section app-page" data-page="carte" aria-label="Carte en direct">
   <h2>Carte en direct</h2>
   <p>Accès complet à la carte La Bétaillère sans quitter l’application.</p>
   <div class="map-embed-shell">
@@ -9148,12 +9158,12 @@ html, body{
     </div>	
   </div></section>
 
-<section id="divertissement" class="media-section" aria-label="Loisirs" style="display:none;">
+<section id="divertissement" class="media-section app-page" data-page="divertissement" aria-label="Loisirs" style="display:none;">
   <h2>Loisirs</h2>
   <p>Retrouve ici les sous-catégories Multimédia, Bingo et Jeu.</p>
 </section>
 
-<section id="multimedia" class="media-section" aria-label="Multimédia">
+<section id="multimedia" class="media-section app-page" data-page="divertissement" aria-label="Multimédia">
   <h2>Multimédia</h2>
   <p>Retrouve ici les vidéos de La Bétaillère, accessibles en un clic comme les raccourcis Bingo/Jeu.</p>
   <div class="media-grid">
@@ -9176,7 +9186,7 @@ html, body{
 </section>
 
 <!-- Console Statistiques -->
-<div class="command-console" id="stats">
+<div class="command-console app-page" id="stats" data-page="statsConsole">
   <div class="console-header">Console de Commande – Statistiques</div>
   <details id="statsConsole" class="console-section">
     <summary class="section-summary">
@@ -22671,6 +22681,48 @@ async function loadAffluenceDate(dateStr){
 })();
 
 (function(){
+  const pageTargets = {
+    '#home': ['home'],
+    '#carte': ['carte'],
+    '#search': ['search'],
+    '#favTrainsWidget': ['favTrainsWidget'],
+    '#statsConsole': ['statsConsole'],
+    '#stats': ['statsConsole'],
+    '#divertissement': ['divertissement'],
+    '#multimedia': ['divertissement']
+  };
+
+  function getPagesForHash(hash){
+    return pageTargets[hash] || ['home'];
+  }
+
+  function applyPageRoute(){
+    const hash = location.hash || '#home';
+    const activePages = new Set(getPagesForHash(hash));
+    document.querySelectorAll('.app-page[data-page]').forEach((el) => {
+      const show = activePages.has(el.dataset.page);
+      el.classList.toggle('is-active', show);
+      if (!show && el.tagName === 'DETAILS') el.open = false;
+    });
+
+    document.querySelectorAll('.bottom-nav__item[href]').forEach((item) => {
+      const href = item.getAttribute('href') || '';
+      const related = getPagesForHash(href);
+      const active = related.some((key) => activePages.has(key));
+      item.classList.toggle('is-active', active);
+      item.setAttribute('aria-current', active ? 'page' : 'false');
+    });
+
+    if (window.scrollY > 8) window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  document.addEventListener('DOMContentLoaded', applyPageRoute);
+  window.addEventListener('hashchange', applyPageRoute);
+  if (!location.hash) location.hash = 'home';
+  applyPageRoute();
+})();
+
+(function(){
   const modal = document.getElementById('alertDetailModal');
   const body = document.getElementById('alertDetailBody');
   const title = document.getElementById('alertDetailTitle');
@@ -22748,6 +22800,13 @@ async function loadAffluenceDate(dateStr){
 	
 </script>
 
+<script>
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('./service-worker.js').catch(() => {});
+  });
+}
+</script>
 </body>
 </html>
       // localStorage (pour fonctionner même déconnecté / fallback)

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,21 @@
+{
+  "name": "La Bétaillère",
+  "short_name": "Bétaillère",
+  "start_url": "./index00.html#home",
+  "display": "standalone",
+  "background_color": "#0b0f1a",
+  "theme_color": "#0b0f1a",
+  "lang": "fr",
+  "icons": [
+    {
+      "src": "favicon.jpg",
+      "sizes": "192x192",
+      "type": "image/jpeg"
+    },
+    {
+      "src": "favicon.jpg",
+      "sizes": "512x512",
+      "type": "image/jpeg"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,35 @@
+const CACHE_NAME = 'lbetaillere-v1';
+const ASSETS = [
+  './',
+  './index00.html',
+  './manifest.webmanifest',
+  './favicon.jpg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)));
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+      return fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => caches.match('./index00.html'));
+    })
+  );
+});


### PR DESCRIPTION
### Motivation
- Rendre l'application plus fluide et professionnelle en affichant une seule vue principale par onglet au lieu d'une longue page unique.
- Conserver la logique et le comportement existants (génération, favoris, stats, etc.) tout en facilitant l'utilisation sur mobile et PC.
- Préparer une base PWA simple pour permettre une installation en mode standalone et un cache offline léger.

### Description
- Ajout des meta et du lien `manifest.webmanifest` dans le `<head>` de `index00.html` et création de `manifest.webmanifest` avec `start_url`, `display` et icônes.
- Introduction de la classe CSS `.app-page` + `.is-active` et d'une animation légère pour afficher une seule vue à la fois; plusieurs sections principales ont été marquées avec `data-page` (ex. `data-page="home"`, `data-page="search"`).
- Injection d'un routeur hash en JS qui mappe les hash (`#home`, `#carte`, `#search`, `#favTrainsWidget`, `#statsConsole`, `#divertissement`, `#multimedia`) vers les pages, gère l'état actif des boutons de navigation bas et force un scroll en haut lors du changement de vue.
- Activation PWA minimaliste : enregistrement d'un `service-worker.js` qui met en cache les assets essentiels et fournit un fallback sur `index00.html`, et ajout du script d'enregistrement dans la page.

### Testing
- Vérifications statiques par recherche de motifs avec `rg` pour s'assurer que `manifest.webmanifest`, `service-worker.js`, `app-page`, `data-page` et le routeur sont présents, et ces commandes ont retourné les entrées attendues.
- Démarrage d'un serveur local via `python3 -m http.server` et chargement de la page pour vérifier l'intégration sans erreurs (serveur lancé avec succès).
- Captures automatisées desktop et mobile réalisées via Playwright (`mobile-search-page.png` et `desktop-home-page.png`) pour valider l'affichage des vues et la navigation (captures générées avec succès).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec9af0810832d8dd2d1cb0e46565d)