### PR TITLE
Page-based navigation and background map loading in index02.html

### DIFF
--- a/index02.html
+++ b/index02.html
@@ -7185,6 +7185,18 @@ html, body{ overflow-x: hidden; }
   }
 }
 
+
+.app-page{ display:none; }
+.app-page.is-page-active{ display:block; }
+body.page-home #home{ display:flex; }
+body.page-favoris #favTrainsWidget{ display:block !important; }
+body.page-search #search,
+body.page-carte #carte,
+body.page-carte #affluence,
+body.page-loisirs #divertissement,
+body.page-loisirs #multimedia,
+body.page-stats #stats{ display:block; }
+
 </style>
   <style>
 @supports (-webkit-touch-callout: none) {
@@ -7210,6 +7222,15 @@ function renderRowsChunked(htmlRows, tbody, chunk=200){
   requestAnimationFrame(step);
 }
   
+
+function ensureCarteFrameLoaded(){
+  const frame = document.querySelector('#carte iframe');
+  if (!frame || frame.dataset.srcLoaded === '1') return;
+  const src = frame.dataset.src || '';
+  if (!src) return;
+  frame.src = src;
+  frame.dataset.srcLoaded = '1';
+}
 
 function initEmbeddedCarteFrame(){
   const frame = document.querySelector('#carte iframe');
@@ -7244,10 +7265,25 @@ function initEmbeddedCarteFrame(){
   });
 }
 
-document.addEventListener('DOMContentLoaded', initEmbeddedCarteFrame);
+function scheduleCarteBackgroundLoad(){
+  const run = () => { ensureCarteFrameLoaded(); initEmbeddedCarteFrame(); };
+  if ('requestIdleCallback' in window){
+    window.requestIdleCallback(run, { timeout: 1800 });
+  } else {
+    setTimeout(run, 900);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  scheduleCarteBackgroundLoad();
+});
 
 function syncCarteFullscreenMode(){
   const active = (location.hash || '') === '#carte';
+  if (active) {
+    ensureCarteFrameLoaded();
+    initEmbeddedCarteFrame();
+  }
   const topH = Math.round(document.querySelector('.top-bar')?.getBoundingClientRect().height || parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--top-bar-height')) || 72);
   const botH = Math.round(document.querySelector('.bottom-nav')?.getBoundingClientRect().height || parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--bottom-bar-height')) || 84);
   document.documentElement.style.setProperty('--carte-top-offset', `${topH}px`);
@@ -7257,8 +7293,6 @@ function syncCarteFullscreenMode(){
 
   const frame = document.querySelector('#carte iframe');
   if (frame) frame.style.pointerEvents = active ? 'auto' : 'none';
-
-  if (active) initEmbeddedCarteFrame();
 }
 
 window.addEventListener('hashchange', syncCarteFullscreenMode);
@@ -7686,7 +7720,7 @@ html, body{
 </div>
 
   </div>
-  <section id="home" class="home-section" aria-label="Accueil">
+  <section id="home" class="home-section app-page" data-page="home" aria-label="Accueil">
   <div class="home-dashboard">
     <div class="home-welcome-line">Bienvenue 🐮 dans votre bétaillère Nancy–Metz–Lux 👋</div>
 
@@ -8049,7 +8083,7 @@ html, body{
   </div>
 
 <!-- Widget Favoris Matin / Soir (visible si connecté) -->
-<section id="favTrainsWidget" class="fav-widget" style="display:none; position:relative; z-index:2;">
+<section id="favTrainsWidget" class="fav-widget app-page" data-page="favoris" style="display:none; position:relative; z-index:2;">
   <div class="fav-head">
     <div class="fav-title">⭐ Mes bétaillères favorites</div>
     <button id="favOpenPrefs" class="fav-btn" type="button">Modifier</button>
@@ -8093,7 +8127,7 @@ html, body{
 </section>
 
 <!-- Console de Commande -->
-<div class="command-console" id="search">
+<div class="command-console app-page" id="search" data-page="search">
   <div class="console-header"> Console de Commande – Sélection des Bétaillères</div>
 
   <!-- 1) GÉNÉRATION PERSONNALISÉE -->
@@ -8298,7 +8332,7 @@ html, body{
 </div>
 
 <!-- BLOC 1 : Perturbations + Informations -->
-<div id="disruptionsSummary" class="command-console" style="display:none;">
+<div id="disruptionsSummary" class="command-console app-page" data-page="search" style="display:none;">
   <div class="disruption-header">Perturbations en cours</div>
   <div id="disruptionsContent"></div>
 </div>
@@ -8314,7 +8348,7 @@ html, body{
 </div>
 
 <!-- BLOC 2 : Infos trains -->
-<div id="trainInfo"></div>
+<div id="trainInfo" class="app-page" data-page="search"></div>
 <section id="trainDetailPanel" class="train-detail-panel" hidden aria-live="polite">
   <div class="train-detail-top">
     <div>
@@ -8344,24 +8378,24 @@ html, body{
   </div>
 </section>
 
-<div id="refreshContainer" style="display:none; text-align:center; margin:8px 0 6px;">
+<div id="refreshContainer" class="app-page" data-page="search" style="display:none; text-align:center; margin:8px 0 6px;">
   <button id="refreshButton" class="refresh-btn">Actualiser les données</button>
 </div>
 
-<section id="carte" class="media-section" aria-label="Carte en direct">
+<section id="carte" class="media-section app-page" data-page="carte" aria-label="Carte en direct">
   <h2>Carte en direct</h2>
   <p>Accès complet à la carte La Bétaillère sans quitter l’application.</p>
   <div class="map-embed-shell">
     <iframe
-      src="https://www.labetaillere.fr/carte.html?embed=1"
+      data-src="https://www.labetaillere.fr/carte.html?embed=1"
       title="Carte La Bétaillère"
-      loading="lazy"
+      loading="eager"
       referrerpolicy="strict-origin-when-cross-origin"
       allowfullscreen></iframe>
   </div>
 </section>
 
-<section id="affluence" class="media-section" aria-label="Affluence">
+<section id="affluence" class="media-section app-page" data-page="carte" aria-label="Affluence">
   <h2>Affluence (J0 à J+14)</h2>
   <p>Choisis une date, puis clique sur un train pour voir tous les arrêts + la courbe d’affluence. (Les filtres avancés sont optionnels.)</p>
   <style>
@@ -9148,12 +9182,12 @@ html, body{
     </div>	
   </div></section>
 
-<section id="divertissement" class="media-section" aria-label="Loisirs" style="display:none;">
+<section id="divertissement" class="media-section app-page" data-page="loisirs" aria-label="Loisirs" style="display:none;">
   <h2>Loisirs</h2>
   <p>Retrouve ici les sous-catégories Multimédia, Bingo et Jeu.</p>
 </section>
 
-<section id="multimedia" class="media-section" aria-label="Multimédia">
+<section id="multimedia" class="media-section app-page" data-page="loisirs" aria-label="Multimédia">
   <h2>Multimédia</h2>
   <p>Retrouve ici les vidéos de La Bétaillère, accessibles en un clic comme les raccourcis Bingo/Jeu.</p>
   <div class="media-grid">
@@ -9176,7 +9210,7 @@ html, body{
 </section>
 
 <!-- Console Statistiques -->
-<div class="command-console" id="stats">
+<div class="command-console app-page" id="stats" data-page="stats">
   <div class="console-header">Console de Commande – Statistiques</div>
   <details id="statsConsole" class="console-section">
     <summary class="section-summary">
@@ -21456,6 +21490,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function handleAnchorClick(a){
     const href = a.getAttribute('href') || '';
     if (!href.startsWith('#') || href === '#') return false;
+    if (a.closest('.bottom-nav')) return false;
     const id = href.slice(1);
     const target = document.getElementById(id);
     if (!target) return false;
@@ -22481,6 +22516,66 @@ async function loadAffluenceDate(dateStr){
     if (closeBtn && panel) closeBtn.addEventListener('click', () => { panel.hidden = true; destroyAffChart(); });
   });
 })();
+
+(function(){
+  const PAGE_HASH_ALIASES = {
+    '#home': 'home',
+    '#search': 'search',
+    '#carte': 'carte',
+    '#affluence': 'carte',
+    '#favoris': 'favoris',
+    '#favtrainswidget': 'favoris',
+    '#stats': 'stats',
+    '#statsconsole': 'stats',
+    '#loisirs': 'loisirs',
+    '#divertissement': 'loisirs',
+    '#multimedia': 'loisirs'
+  };
+
+  const navItems = Array.from(document.querySelectorAll('.bottom-nav__item[href]'));
+  const pages = Array.from(document.querySelectorAll('.app-page[data-page]'));
+
+  function pageFromHash(hash){
+    return PAGE_HASH_ALIASES[String(hash || '').toLowerCase()] || 'home';
+  }
+
+  function syncActiveNav(page){
+    navItems.forEach((item) => {
+      const targetPage = pageFromHash(item.getAttribute('href') || '');
+      const active = targetPage === page;
+      item.classList.toggle('active', active);
+      item.setAttribute('aria-current', active ? 'page' : 'false');
+    });
+  }
+
+  function syncPages(){
+    const hash = location.hash || '#home';
+    const page = pageFromHash(hash);
+
+    document.body.classList.remove('page-home','page-search','page-carte','page-favoris','page-stats','page-loisirs');
+    document.body.classList.add(`page-${page}`);
+
+    pages.forEach((node) => {
+      const active = node.dataset.page === page;
+      node.classList.toggle('is-page-active', active);
+      if (node.id === 'favTrainsWidget' && !active){
+        node.style.display = 'none';
+      }
+    });
+
+    if (page === 'favoris'){
+      const fav = document.getElementById('favTrainsWidget');
+      if (fav) fav.style.display = 'block';
+    }
+
+    syncActiveNav(page);
+  }
+
+  window.addEventListener('hashchange', syncPages);
+  document.addEventListener('DOMContentLoaded', syncPages);
+  syncPages();
+})();
+
 
 (function(){
   const nav = document.getElementById('tableauViewNav');


### PR DESCRIPTION
### Motivation
- Reduce navigation jank by switching the long single-page layout to discrete pages so navigation no longer blocks while heavy content loads. 
- Load the embedded map in background (deferred) so the iframe initialization does not impact overall page responsiveness. 
- Preserve the visual layout of the homepage while enabling page routing and improving mobile/anchor behavior.

### Description
- Add page routing support by marking main blocks with `.app-page` and `data-page` (`home`, `search`, `carte`, `favoris`, `stats`, `loisirs`) and adding lightweight CSS to show only the active page. 
- Insert a small hash router that maps bottom-nav anchors to logical pages and keeps the nav state synchronized with the active page. 
- Prevent bottom-nav clicks from being intercepted by the generic smooth-scroll handler so hash-based routing is not blocked. 
- Defer map iframe loading by moving `src` to `data-src`, add `ensureCarteFrameLoaded()` and `scheduleCarteBackgroundLoad()` using `requestIdleCallback` fallback, and force immediate load/init when the user opens `#carte`.

### Testing
- Ran `git diff --check` to verify no whitespace issues and it returned clean results. 
- Launched a local server with `python3 -m http.server 8000` and captured pages using a Playwright script that navigated to `index02.html#home` and `index02.html#carte` and saved screenshots. 
- Verified the map iframe is not immediately fetched on initial load and that it is loaded when navigating to `#carte`, and observed the Playwright screenshots for both `#home` and `#carte` (successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afecb9abf0832db245fd3e963ade7f)