### PR TITLE
Densify station & train modal layout for increased row visibility

### DIFF
--- a/carte.html
+++ b/carte.html
@@ -56,27 +56,27 @@
     .station-marker.station-major{ color:#ffe28a; border-color:#ffc85740; background:rgba(255,200,87,0.08); }
     .station-marker.station-regular{ color:#c5f36f; border-color:#6cad3a33; background:rgba(111,173,58,0.07); }
     .station-marker:focus-visible{ outline:2px solid #a0ff00; outline-offset:2px; }
-    .trip-panel{ position:fixed; top:96px; right:18px; width:320px; max-height:calc(100vh - 140px); background:rgba(11,15,26,0.95); border:1px solid #20324b; border-radius:14px; box-shadow:0 18px 36px rgba(0,0,0,0.35); padding:16px; display:flex; flex-direction:column; gap:12px; backdrop-filter:blur(6px); overflow:hidden; z-index:3000; transition:transform 0.26s ease, opacity 0.22s ease; }
+    .trip-panel{ position:fixed; top:96px; right:18px; width:340px; max-height:calc(100vh - 124px); background:rgba(11,15,26,0.95); border:1px solid #20324b; border-radius:14px; box-shadow:0 18px 36px rgba(0,0,0,0.35); padding:12px; display:flex; flex-direction:column; gap:9px; backdrop-filter:blur(6px); overflow:hidden; z-index:3000; transition:transform 0.26s ease, opacity 0.22s ease; }
     .trip-panel.hidden{ display:none; }
-    .trip-panel-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
-    .trip-panel-header-right{ display:flex; align-items:center; gap:8px; margin-left:auto; }
-    .station-board-now{ font-size:16px; color:#e8f4ff; font-weight:700; letter-spacing:.01em; padding:0; border:none; background:transparent; white-space:nowrap; line-height:1.2; }
+    .trip-panel-header{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+    .trip-panel-header-right{ display:flex; align-items:center; gap:6px; margin-left:auto; }
+    .station-board-now{ font-size:15px; color:#e8f4ff; font-weight:700; letter-spacing:.01em; padding:0; border:none; background:transparent; white-space:nowrap; line-height:1.1; }
     .trip-panel-back{ border:1px solid #2a3b55; background:rgba(11,15,26,0.75); color:#dcecff; font-size:12px; font-weight:700; border-radius:8px; padding:5px 9px; cursor:pointer; }
     .trip-panel-back:hover{ border-color:#5bd6ff; color:#a0ff00; }
-    .trip-panel-body{ display:flex; flex-direction:column; gap:12px; overflow:auto; padding-right:2px; }
-    .trip-panel-title{ display:flex; align-items:center; gap:8px; font-weight:700; font-size:16px; }
+    .trip-panel-body{ display:flex; flex-direction:column; gap:8px; overflow:auto; padding-right:2px; }
+    .trip-panel-title{ display:flex; align-items:center; gap:6px; font-weight:700; font-size:15px; }
     .trip-panel-icon{ font-size:20px; filter: drop-shadow(0 0 4px rgba(0,0,0,0.6)); }
     .trip-panel-close{ border:none; background:rgba(32,50,75,0.6); color:#e0f0ff; font-size:18px; width:28px; height:28px; border-radius:50%; cursor:pointer; display:flex; align-items:center; justify-content:center; }
     .trip-panel-close:hover{ background:rgba(160,255,0,0.25); color:#0b0f1a; }
-    .trip-panel-summary{ font-size:13px; line-height:1.4; color:#aabbd1; }
-    .trip-progress{ display:flex; flex-direction:column; gap:6px; }
+    .trip-panel-summary{ font-size:12px; line-height:1.3; color:#aabbd1; }
+    .trip-progress{ display:flex; flex-direction:column; gap:4px; }
     .trip-progress-bar{ position:relative; height:6px; width:100%; background:#162233; border-radius:999px; overflow:hidden; }
     .trip-progress-bar-fill{ position:absolute; top:0; left:0; height:100%; background:linear-gradient(90deg,#00f0ff,#a0ff00); width:0%; transition:width 0.4s ease; }
-    .trip-progress-text{ font-size:12px; color:#94a7c4; }
-    .trip-stops{ flex:1; overflow:auto; padding-right:4px; display:flex; flex-direction:column; gap:10px; }
-    .trip-stops.station-mode{ gap:8px; }
-    .trip-stops-title{ font-size:12px; color:#8093b5; text-transform:uppercase; letter-spacing:.08em; }
-    .trip-stop{ position:relative; display:flex; gap:12px; align-items:flex-start; padding-left:12px; --connector-progress:0; }
+    .trip-progress-text{ font-size:11px; color:#94a7c4; }
+    .trip-stops{ flex:1; overflow:auto; padding-right:2px; display:flex; flex-direction:column; gap:8px; }
+    .trip-stops.station-mode{ gap:6px; }
+    .trip-stops-title{ font-size:11px; color:#8093b5; text-transform:uppercase; letter-spacing:.08em; }
+    .trip-stop{ position:relative; display:flex; gap:8px; align-items:flex-start; padding-left:10px; --connector-progress:0; }
     .trip-stop::before{ content:''; position:absolute; left:0; top:6px; width:10px; height:10px; border-radius:50%; background:#2a3b55; box-shadow:0 0 6px rgba(0,240,255,0.3); transition:transform 0.3s ease, box-shadow 0.3s ease; }
     .trip-stop.passed::before{ background:#2c8bff; opacity:0.6; box-shadow:none; }
     .trip-stop.current::before{ background:#00f0ff; box-shadow:0 0 10px rgba(0,240,255,0.8); }
@@ -86,13 +86,13 @@
     .trip-stop.passed{ --connector-progress:1; }
     .trip-stop:not(:last-child)::after{ content:''; position:absolute; left:4px; top:16px; bottom:-10px; width:2px; background:linear-gradient(180deg, rgba(0,240,255,0.55) 0%, rgba(0,240,255,0.55) calc(var(--connector-progress, 0) * 100%), rgba(36,50,73,0.6) calc(var(--connector-progress, 0) * 100%), rgba(36,50,73,0.6) 100%); transition:background 0.3s ease; }
     .trip-stop:last-child::after{ display:none; }
-    .stop-time{ display:flex; flex-direction:column; gap:2px; align-items:flex-end; font-size:12px; color:#90a1b8; min-width:86px; font-variant-numeric:tabular-nums; }
+    .stop-time{ display:flex; flex-direction:column; gap:1px; align-items:flex-end; font-size:11px; color:#90a1b8; min-width:78px; font-variant-numeric:tabular-nums; }
     .stop-time .time-entry{ line-height:1.1; padding:0; margin:0; }
     .stop-time .time-arr{ color:#8fa1be; }
     .stop-time .time-dep{ color:#d6e6ff; font-weight:600; }
    .stop-time .time-neutral{ color:#90a1b8; }
     .stop-time .time-entry-plan{ display:block; }
-    .stop-time .time-entry-rt{ display:block; font-size:11px; opacity:0.85; }
+    .stop-time .time-entry-rt{ display:block; font-size:10px; opacity:0.85; }
     .stop-time .time-entry-rt--delay{ color:#ffc48a; }
     .stop-time .time-entry-rt--advance{ color:#9eff9e; }
     .stop-time .time-entry-rt--ontime{ color:#a0ff00; opacity:0.75; }
@@ -106,23 +106,23 @@
     .trip-panel.cancelled .trip-panel-summary{ color:#ffb4b4; }
     .trip-panel.cancelled .trip-panel-realtime strong{ color:#ffb4b4; }
     .trip-panel.cancelled .trip-panel-realtime-diff{ color:#ff8989; }
-    .stop-main{ display:flex; flex-direction:column; gap:3px; }
-    .stop-name{ font-weight:600; font-size:14px; color:#e0f0ff; }
-    .stop-note{ font-size:11px; color:#7f92b1; text-transform:uppercase; letter-spacing:.04em; }
+    .stop-main{ display:flex; flex-direction:column; gap:2px; }
+    .stop-name{ font-weight:600; font-size:13px; color:#e0f0ff; line-height:1.15; }
+    .stop-note{ font-size:10px; color:#7f92b1; text-transform:uppercase; letter-spacing:.04em; line-height:1.15; }
     .stop-note strong{ color:#a0ff00; font-weight:600; }
-    .trip-panel-delay{ display:inline-flex; flex-direction:column; gap:2px; margin-top:8px; padding:6px 10px; border-radius:10px; border:1px solid rgba(255,200,120,0.55); background:rgba(46,32,12,0.55); color:#ffd8a0; font-size:12px; box-shadow:0 0 8px rgba(0,0,0,0.2); }
+    .trip-panel-delay{ display:inline-flex; flex-direction:column; gap:1px; margin-top:6px; padding:5px 8px; border-radius:9px; border:1px solid rgba(255,200,120,0.55); background:rgba(46,32,12,0.55); color:#ffd8a0; font-size:11px; box-shadow:0 0 8px rgba(0,0,0,0.2); }
     .trip-panel-delay.delay-moderate{ border-color:rgba(255,210,150,0.65); background:rgba(128,76,12,0.55); color:#ffddb0; }
     .trip-panel-delay.delay-major{ border-color:rgba(255,170,120,0.7); background:rgba(128,52,12,0.55); color:#ffc7aa; }
     .trip-panel-delay.delay-severe{ border-color:rgba(255,150,150,0.75); background:rgba(128,24,24,0.6); color:#ffb6b6; }
     .trip-panel-delay.delay-cancelled{ border-color:rgba(255,150,190,0.75); background:rgba(120,24,52,0.58); color:#ffdce9; text-transform:uppercase; letter-spacing:.05em; }
-    .trip-panel-delay .trip-panel-delay-context{ font-size:11px; color:#c8d9f0; opacity:0.9; }
-    .trip-panel-disruption{ margin-top:8px; padding:8px 10px; border-radius:10px; border:1px solid rgba(255,176,96,0.7); background:rgba(110,56,10,0.55); color:#ffd3a0; font-size:12px; box-shadow:0 0 10px rgba(0,0,0,0.2); }
+    .trip-panel-delay .trip-panel-delay-context{ font-size:10px; color:#c8d9f0; opacity:0.9; }
+    .trip-panel-disruption{ margin-top:6px; padding:6px 8px; border-radius:9px; border:1px solid rgba(255,176,96,0.7); background:rgba(110,56,10,0.55); color:#ffd3a0; font-size:11px; box-shadow:0 0 10px rgba(0,0,0,0.2); }
     .trip-panel-disruption strong{ color:#ffe0b8; }
     .trip-panel-disruption.is-cancelled{ border-color:rgba(255,120,140,0.75); background:rgba(100,22,32,0.6); color:#ffc4ce; box-shadow:0 0 10px rgba(0,0,0,0.28); }
     .trip-panel-disruption.is-cancelled strong{ color:#ffd3da; }
-    .trip-panel-realtime{ font-size:12px; color:#ffc48a; margin-top:6px; display:flex; flex-wrap:wrap; gap:6px; align-items:center; }
+    .trip-panel-realtime{ font-size:11px; color:#ffc48a; margin-top:4px; display:flex; flex-wrap:wrap; gap:4px; align-items:center; }
     .trip-panel-realtime strong{ color:#ffd8a0; }
-    .trip-panel-realtime-diff{ font-size:11px; color:#ffb066; font-weight:600; }
+    .trip-panel-realtime-diff{ font-size:10px; color:#ffb066; font-weight:600; }
     .hidden{ display:none !important; }
     .fab-button{ border:1px solid #2a3b55; background:linear-gradient(135deg, rgba(11,15,26,0.9), rgba(10,24,38,0.9)); color:#e6f1ff; border-radius:12px; padding:10px 14px; font-size:13px; display:inline-flex; align-items:center; gap:8px; box-shadow:0 10px 22px rgba(0,0,0,0.35), 0 0 14px rgba(0,240,255,0.12); cursor:pointer; backdrop-filter:blur(8px); transition:border-color 0.2s ease, color 0.2s ease, background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease; }
     .fab-button:hover{ border-color:#5bd6ff; color:#a0ff00; transform:translateY(-1px); box-shadow:0 12px 24px rgba(0,0,0,0.45), 0 0 18px rgba(0,240,255,0.18); }
@@ -142,15 +142,15 @@
     .station-event-times{ display:flex; flex-direction:column; gap:2px; font-size:12px; color:#d6e6ff; }
     .station-event-status{ font-size:11px; color:#a0ff00; text-transform:uppercase; letter-spacing:.05em; }
     .station-event.empty{ justify-content:center; color:#8fa1be; font-size:13px; padding:16px; text-align:center; }
-    .station-train-link{ display:inline-flex; align-items:center; gap:6px; border:1px solid #2a3b55; border-radius:8px; padding:6px 10px; background:rgba(11,15,26,0.8); color:#e0f0ff; font-size:12px; cursor:pointer; text-shadow:0 0 4px #000; }
+    .station-train-link{ display:inline-flex; align-items:center; gap:4px; border:1px solid #2a3b55; border-radius:8px; padding:5px 8px; background:rgba(11,15,26,0.8); color:#e0f0ff; font-size:11px; cursor:pointer; text-shadow:0 0 4px #000; }
     .station-train-link:hover{ border-color:#5bd6ff; color:#a0ff00; }
     .station-train-link:focus-visible{ outline:2px solid #a0ff00; outline-offset:2px; }
-    .station-board-actions{ display:flex; flex-direction:row; align-items:center; justify-content:flex-end; gap:6px; }
-    .station-board-track{ display:inline-flex; flex-direction:column; align-items:center; justify-content:center; min-width:44px; min-height:34px; border-radius:8px; background:#eef2f7; color:#0b0f1a; font-weight:900; line-height:1.05; box-shadow:inset 0 0 0 1px rgba(8,15,25,0.12); }
+    .station-board-actions{ display:flex; flex-direction:row; align-items:center; justify-content:flex-end; gap:4px; }
+    .station-board-track{ display:inline-flex; flex-direction:column; align-items:center; justify-content:center; min-width:38px; min-height:30px; border-radius:8px; background:#eef2f7; color:#0b0f1a; font-weight:900; line-height:1.05; box-shadow:inset 0 0 0 1px rgba(8,15,25,0.12); }
     .station-board-track-label{ font-size:9px; font-weight:700; opacity:0.9; }
-    .station-board-track-value{ font-size:16px; font-weight:900; margin-top:0; line-height:1; }
-    .station-board-more-wrap{ display:flex; justify-content:center; padding:10px 8px 12px; border-top:1px solid rgba(33,50,75,0.75); }
-    .station-board-more{ border:1px solid #2a3b55; border-radius:8px; padding:8px 14px; background:#e9edf3; color:#6f0a74; font-weight:800; font-size:13px; cursor:pointer; }
+    .station-board-track-value{ font-size:14px; font-weight:900; margin-top:0; line-height:1; }
+    .station-board-more-wrap{ display:flex; justify-content:center; padding:8px 8px 10px; border-top:1px solid rgba(33,50,75,0.75); }
+    .station-board-more{ border:1px solid #2a3b55; border-radius:8px; padding:6px 12px; background:#e9edf3; color:#6f0a74; font-weight:800; font-size:12px; cursor:pointer; }
     .station-board-more:hover{ border-color:#5bd6ff; color:#3d0a84; }
 
     .station-time-plan{ font-weight:600; color:#d6e6ff; }
@@ -158,22 +158,22 @@
     .station-time-rt--delay{ color:#ffc48a; }
     .station-time-rt--advance{ color:#9eff9e; }
     .station-time-rt--ontime{ color:#a0ff00; opacity:0.75; }
-    .trip-panel.station-board-mode{ width:min(980px, calc(100vw - 36px)); max-height:calc(100vh - 128px); }
-    .station-board-grid{ display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+    .trip-panel.station-board-mode{ width:min(980px, calc(100vw - 30px)); max-height:calc(100vh - 112px); }
+    .station-board-grid{ display:grid; grid-template-columns:1fr 1fr; gap:9px; }
     .station-board-block{ border:1px solid #1f3655; border-radius:12px; background:rgba(8,14,24,0.78); overflow:hidden; }
-    .station-board-title{ padding:8px 10px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; font-size:12px; color:#d8ebff; border-bottom:1px solid #1d3048; background:linear-gradient(135deg, rgba(11,32,62,0.92), rgba(10,20,36,0.9)); }
-    .station-board-table-wrap{ max-height:45vh; overflow:auto; }
-    .station-board-table{ width:100%; border-collapse:collapse; font-size:12px; }
-    .station-board-table th{ position:sticky; top:0; z-index:1; text-align:left; background:#0d192a; color:#8fb2dd; font-size:10px; text-transform:uppercase; letter-spacing:.06em; padding:6px 8px; border-bottom:1px solid #1f3249; }
-    .station-board-table td{ padding:8px; border-bottom:1px solid rgba(33,50,75,0.75); vertical-align:middle; }
-    .station-board-time{ font-weight:800; color:#ffef3f; font-size:18px; line-height:1; }
-    .station-board-time--delayed{ display:flex; align-items:baseline; gap:8px; }
+    .station-board-title{ padding:6px 8px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; font-size:11px; color:#d8ebff; border-bottom:1px solid #1d3048; background:linear-gradient(135deg, rgba(11,32,62,0.92), rgba(10,20,36,0.9)); }
+    .station-board-table-wrap{ max-height:53vh; overflow:auto; }
+    .station-board-table{ width:100%; border-collapse:collapse; font-size:11px; }
+    .station-board-table th{ position:sticky; top:0; z-index:1; text-align:left; background:#0d192a; color:#8fb2dd; font-size:9px; text-transform:uppercase; letter-spacing:.06em; padding:5px 6px; border-bottom:1px solid #1f3249; }
+    .station-board-table td{ padding:5px 6px; border-bottom:1px solid rgba(33,50,75,0.75); vertical-align:middle; }
+    .station-board-time{ font-weight:800; color:#ffef3f; font-size:16px; line-height:1; }
+    .station-board-time--delayed{ display:flex; align-items:baseline; gap:6px; }
     .station-board-time-planned{ color:#ffef3f; text-decoration:line-through; text-decoration-thickness:2px; text-decoration-color:#ffef3f; opacity:0.95; }
     .station-board-time-delayed{ color:#ff9a3c; font-weight:900; }
-    .station-board-time-sub{ font-size:10px; color:#90a7c8; margin-top:2px; }
-    .station-board-way{ font-weight:700; color:#e8f4ff; }
-    .station-board-train{ color:#99bee8; font-size:11px; white-space:nowrap; }
-    .station-board-state{ font-weight:700; font-size:11px; text-transform:uppercase; letter-spacing:.02em; color:#a0ff00; }
+    .station-board-time-sub{ font-size:9px; color:#90a7c8; margin-top:1px; }
+    .station-board-way{ font-weight:700; color:#e8f4ff; font-size:12px; line-height:1.15; }
+    .station-board-train{ color:#99bee8; font-size:10px; white-space:nowrap; }
+    .station-board-state{ font-weight:700; font-size:10px; text-transform:uppercase; letter-spacing:.02em; color:#a0ff00; }
     .station-board-state.is-delay{ color:#ffbe84; }
     .station-board-state.is-advance{ color:#8dffa7; }
     .station-board-empty{ padding:12px; color:#9ab1d6; font-size:12px; }
@@ -185,9 +185,9 @@
     .station-board-row-imminent td{ animation:station-board-blink 0.9s ease-in-out infinite; }
     @keyframes station-board-blink{ 0%,100%{ opacity:1; } 50%{ opacity:0.45; } }
     @media (max-width: 900px){
-      .trip-panel.station-board-mode{ width:calc(100% - 18px); }
+      .trip-panel.station-board-mode{ width:calc(100% - 12px); max-height:68vh; }
       .station-board-grid{ grid-template-columns:1fr; }
-      .station-board-table-wrap{ max-height:24vh; }
+      .station-board-table-wrap{ max-height:28vh; }
     }
     .controls-toggle{ position:fixed; right:14px; bottom:14px; z-index:1250; }
     body.lite-ui header,
@@ -227,14 +227,14 @@
       .panel .badge{ font-size:11px; }
       .panel label{ font-size:12px; }
       .ctrl input[type="range"]{ width:140px; }
-      .trip-panel{ position:fixed; top:auto; bottom:12px; left:50%; right:auto; width:calc(100% - 24px); max-height:50vh; min-height:36vh; transform:translate(-50%, 110%); border-radius:18px 18px 14px 14px; }
+      .trip-panel{ position:fixed; top:auto; bottom:12px; left:50%; right:auto; width:calc(100% - 20px); max-height:62vh; min-height:34vh; transform:translate(-50%, 110%); border-radius:18px 18px 14px 14px; }
       body.trip-panel-open .trip-panel{ transform:translate(-50%, 0); }
       .trip-panel-header{ position:sticky; top:0; padding:4px 0 8px; margin:0 -2px; background:linear-gradient(180deg, rgba(11,15,26,0.98) 0%, rgba(11,15,26,0.94) 70%, rgba(11,15,26,0.88) 100%); z-index:1; }
-      .trip-panel-body{ max-height:calc(50vh - 64px); padding-right:6px; }
+      .trip-panel-body{ max-height:calc(62vh - 58px); padding-right:4px; }
       .trip-panel-header{ flex-wrap:wrap; }
       .trip-panel-title{ font-size:15px; }
-      .trip-panel-summary{ font-size:12px; }
-      .trip-stops{ max-height:40vh; }
+      .trip-panel-summary{ font-size:11px; }
+      .trip-stops{ max-height:48vh; }
       :root{
         --marker-font:clamp(14px, 3vw, 17px);
         --marker-gap:clamp(4px, 1.4vw, 7px);
@@ -253,8 +253,8 @@
       .header-title{ font-size:15px; }
       .panel{ gap:8px; padding:12px; border-radius:14px; }
       .donate-link{ max-width:200px; padding:8px 11px; font-size:12px; }
-      .trip-panel{ bottom:10px; width:calc(100% - 16px); padding:14px; }
-      .trip-panel-body{ max-height:calc(50vh - 56px); }
+      .trip-panel{ bottom:10px; width:calc(100% - 12px); padding:12px; }
+      .trip-panel-body{ max-height:calc(62vh - 52px); }
       .trip-panel-title{ justify-content:center; width:100%; }
       .trip-panel-close{ width:26px; height:26px; font-size:16px; }
       .trip-panel-summary{ text-align:left; }


### PR DESCRIPTION
### Motivation
- Improve readability of station and train detail modals so more stop/departure rows are visible without removing any existing information.
- Keep the same data while concentrating visual space by reducing paddings, gaps and some font sizes to show more lines at once.
- Ensure the modal/table layouts adapt to mobile breakpoints so the density gains apply on small screens.

### Description
- Tightened modal container sizing and spacing by updating `.trip-panel` width, padding and gaps in `carte.html` so the panel uses more usable area.
- Reduced inter-item gaps and font sizes for stop rows and times (`.trip-stops`, `.trip-stop`, `.stop-time`, `.stop-name`, `.trip-panel-summary`) to increase visible rows.
- Compacted station-board layout and table cells (track badge, details button, `station-board-table`, `.station-board-track`, `.station-train-link`, `.station-board-more`) to present more departures/arrivals per viewport.
- Adjusted responsive rules for `@media (max-width: 900px)` and `@media (max-width: 520px)` to raise available modal/table heights and avoid excessive scrolling on mobile.

### Testing
- Ran `git diff --check` to validate no whitespace/diff errors, which passed. 
- Served the site with `python3 -m http.server 4173` and captured a visual regression check using a Playwright screenshot of `http://127.0.0.1:4173/carte.html`, which completed successfully. 
- Changes committed (file `carte.html`) and basic repository checks (`git status`) were used to validate the patch applied cleanly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b031043344832d9a8827855a638669)