### PR TITLE
UI: add support CTA, cookie close, loisir/game panels and mobile/tableau tweaks

### DIFF
--- a/index20.html
+++ b/index20.html
@@ -170,6 +170,76 @@ body {
   box-shadow: inset 0 0 12px rgba(0, 240, 255, 0.28), 0 0 18px rgba(0, 240, 255, 0.25);
 }
 
+.top-bar__support{
+  position: relative;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  border: 1px solid rgba(255, 207, 90, 0.75);
+  background: linear-gradient(135deg, rgba(255,214,102,.96), rgba(255,178,46,.92));
+  color:#2b1700;
+  border-radius:999px;
+  padding:7px 11px;
+  font-size:0.72rem;
+  font-weight:800;
+  text-decoration:none;
+  letter-spacing:.02em;
+  box-shadow: 0 0 0 1px rgba(255,245,210,.35) inset, 0 4px 14px rgba(255,170,40,.35);
+  transition: transform .18s ease, box-shadow .18s ease, filter .18s ease;
+}
+.top-bar__support::after{
+  content:'';
+  position:absolute;
+  inset:1px;
+  border-radius:999px;
+  background: linear-gradient(180deg, rgba(255,255,255,.35), rgba(255,255,255,0));
+  pointer-events:none;
+}
+.top-bar__support:hover,
+.top-bar__support:focus-visible{
+  transform: translateY(-1px) scale(1.02);
+  filter: brightness(1.02);
+  box-shadow: 0 0 0 1px rgba(255,248,220,.45) inset, 0 6px 18px rgba(255,170,40,.45);
+}
+.top-bar__support .euro{ font-size:.92rem; line-height:1; }
+.top-bar__support .label{
+  display:flex;
+  flex-direction:column;
+  line-height:1.02;
+  white-space:nowrap;
+}
+.top-bar__support .label .line2{ font-size:.64rem; font-weight:700; opacity:.88; }
+
+.table-legend-toggle{
+  margin-top: 8px;
+  border: 1px solid rgba(0,240,255,.2);
+  border-radius: 12px;
+  background: rgba(0,12,22,.38);
+  overflow: hidden;
+}
+.table-legend-toggle > summary{
+  list-style:none;
+  cursor:pointer;
+  padding: 7px 10px;
+  font-size: .78rem;
+  font-weight: 700;
+  color: #aef8ff;
+}
+.table-legend-toggle > summary::-webkit-details-marker{ display:none; }
+.table-legend-toggle .legend-content{
+  padding: 0 10px 10px;
+  font-size: .74rem;
+  line-height: 1.35;
+  color: #d9f7ff;
+}
+.table-legend-toggle ul{ margin: 6px 0 0 16px; padding:0; }
+.table-legend-toggle li{ margin: 4px 0; }
+
+@media (max-width: 600px){
+  .top-bar__support .label{ display:none; }
+  .top-bar__support{ padding:7px 9px; min-width:36px; justify-content:center; }
+}
+
 
 /* ==== FIX: éléments invisibles mais cliquables (mobile / pas de hover) ==== */
 @media (hover: none){
@@ -4719,8 +4789,21 @@ body.modal-open{ overflow:hidden; }
   color: #8fefff;
   text-decoration: underline;
 }
+
+
+/* Rendre le bas de page plus "app" tout en gardant les infos légales visibles */
+#bottom-bar,
+.footer-counter-wrapper{
+  display:none;
+}
+body.page-loisirs #bottom-bar{ display:flex; }
+
+/* Mentions légales/confidentialité toujours accessibles */
+.legal-links{ display:flex; }
+#siteLicense{ display:block; }
 .cookie-banner{
   position: fixed;
+  isolation:isolate;
   left: 16px;
   right: 16px;
   bottom: 16px;
@@ -4742,9 +4825,26 @@ body.modal-open{ overflow:hidden; }
   display: none !important;
 }
 
+.cookie-banner__close{
+  position:absolute;
+  top:7px;
+  right:9px;
+  width:18px;
+  height:18px;
+  border:none;
+  border-radius:999px;
+  background: transparent;
+  color: rgba(210,245,255,.8);
+  font-size: 11px;
+  line-height: 1;
+  cursor:pointer;
+}
+.cookie-banner__close:hover{ background: rgba(120,220,255,.12); color:#fff; }
+
 .cookie-banner p{
   margin: 0;
   flex: 1 1 240px;
+  padding-right: 22px;
 }
 
 .cookie-banner a{
@@ -7186,11 +7286,59 @@ html, body{ overflow-x: hidden; }
   }
 }
 
+@media (max-width: 768px){
+  body.jeu-fullscreen #home,
+  body.jeu-fullscreen #search,
+  body.jeu-fullscreen #favTrainsWidget,
+  body.jeu-fullscreen #disruptionsSummary,
+  body.jeu-fullscreen #trainInfo,
+  body.jeu-fullscreen #refreshContainer,
+  body.jeu-fullscreen #affluence,
+  body.jeu-fullscreen #multimedia,
+  body.jeu-fullscreen #carte,
+  body.jeu-fullscreen #statsConsole,
+  body.jeu-fullscreen .home-card{ display:none !important; }
+
+  body.jeu-fullscreen #jeuContainer{
+    display:block !important;
+    position: fixed !important;
+    top: var(--carte-top-offset, var(--top-bar-height, 72px)) !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: var(--carte-bottom-offset, calc(max(var(--bottom-bar-height, 84px), var(--lb-bottomnav-h, 84px)) + env(safe-area-inset-bottom, 0px))) !important;
+    width: 100vw !important;
+    max-width: none !important;
+    z-index: 1000 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    border-radius: 0 !important;
+    background: #07101b;
+    overflow: hidden !important;
+  }
+  body.jeu-fullscreen #jeuContainer h2,
+  body.jeu-fullscreen #jeuContainer p{ display:none !important; }
+  body.jeu-fullscreen #jeuContainer .map-embed-shell{
+    position:absolute !important;
+    inset:0 !important;
+    height:100% !important;
+    border:none !important;
+    border-radius:0 !important;
+    box-shadow:none !important;
+  }
+  body.jeu-fullscreen #jeuContainer .map-embed-shell iframe{
+    width:100% !important;
+    height:100% !important;
+    min-height:100% !important;
+    border:0 !important;
+    background:#07101b;
+  }
+}
+
 
 /* === Navigation pages (1 onglet = 1 page) === */
 .app-page{ display:none; }
 .app-page.is-page-active{ display:block; }
-body.page-home #home{ display:flex; }
+body.page-home #home{ display:grid; }
 body.page-favoris #favTrainsWidget{ display:block !important; }
 body.page-search #search,
 body.page-carte #carte,
@@ -7538,6 +7686,7 @@ html, body{
   </div>
 </div>
 <div id="cookieBanner" class="cookie-banner" role="dialog" aria-live="polite" aria-label="Bandeau cookies" hidden>
+  <button class="cookie-banner__close" type="button" aria-label="Fermer le bandeau cookies">✕</button>
   <p>
     🍪 Ce site utilise des cookies pour améliorer l’expérience. Tu peux en savoir plus via la
     <a href="/confidentialite.html" target="_blank" rel="noopener">politique de confidentialité</a>.
@@ -7560,7 +7709,11 @@ html, body{
 
     
     <div class="top-bar__actions" aria-label="Actions rapides">
-</div>
+      <a class="top-bar__support" href="https://buymeacoffee.com/labetaillere" target="_blank" rel="noopener noreferrer" aria-label="Soutenir le projet">
+        <span class="euro" aria-hidden="true">€</span>
+        <span class="label"><span class="line1">Soutenir</span><span class="line2">le projet</span></span>
+      </a>
+    </div>
   </div>
 </header>
 
@@ -8108,6 +8261,19 @@ html, body{
 <!-- Console de Commande -->
 <div class="command-console app-page" id="search" data-page="search">
   <div class="console-header"> Console de Commande – Sélection des Bétaillères</div>
+  <details class="table-legend-toggle">
+    <summary>ℹ️ Légende</summary>
+    <div class="legend-content">
+      <ul>
+        <li><span style="color:#7CFF4D;font-weight:bold;">UM3</span> : 3 rames Z24500</li>
+        <li><span style="color:#00f0ff;font-weight:bold;">UM</span> : 2 rames Z24500</li>
+        <li><span style="color:#bf00ff;font-weight:bold;">US</span> : 1 rame Z24500</li>
+        <li><span class="deleted">Texte barré rouge</span> : arrêt/train supprimé</li>
+        <li><span class="delay-strike">Horaire barré</span> puis <span class="retard">orange</span> : retard</li>
+        <li><span class="new-start">Bleu gras</span> : nouveau départ / terminus</li>
+      </ul>
+    </div>
+  </details>
 
   <!-- 1) GÉNÉRATION PERSONNALISÉE -->
   <details class="console-section">
@@ -8996,6 +9162,70 @@ html, body{
   }
 }
 
+
+/* ===== v27: Tableau mobile compact — réduire la typo et densifier l'écran ===== */
+@media (max-width: 520px){
+  #search .command-console{ margin-bottom: 8px !important; }
+  #search .command-console .console-header{ margin-bottom: 6px !important; }
+  #search .command-console .console-title{
+    font-size: clamp(15px, 3.8vw, 17px) !important;
+    line-height: 1.1 !important;
+    letter-spacing: .01em !important;
+  }
+
+  #search .command-console .console-section,
+  #search .command-console .console-card{
+    padding: 9px 10px !important;
+    margin-bottom: 8px !important;
+    border-radius: 14px !important;
+  }
+
+  #search .manual-compact .compact-presets{ padding: 8px !important; gap: 6px !important; }
+  #search .manual-compact .preset-stack,
+  #search .manual-compact .shortcuts-grid{ gap: 6px !important; }
+  #search .manual-compact .shortcut-btn,
+  #search .manual-compact .compact-presets .preset-btn{
+    min-height: 34px !important;
+    padding: 6px 8px !important;
+    font-size: 13px !important;
+    line-height: 1.05 !important;
+  }
+
+  #search .manual-compact .station-swap{ padding: 8px 10px !important; min-height: 84px !important; }
+  #search .manual-compact .station-fields{ padding-right: 58px !important; }
+  #search .manual-compact .station-row{ padding: 3px 0 !important; }
+  #search .manual-compact .station-label{ font-size: 11px !important; }
+  #search .manual-compact .station-search,
+  #search .manual-compact .station-input{
+    height: 32px !important;
+    padding: 6px 9px !important;
+    font-size: 16px !important;
+  }
+  #search .manual-compact .swap-btn--center{
+    width: 34px !important;
+    height: 34px !important;
+    right: 10px !important;
+  }
+
+  #search .manual-compact .date-picker-wrap,
+  #search .manual-compact .filters-date-time{ gap: 6px !important; }
+  #search .manual-compact .time-range label,
+  #search .manual-compact .field-caption{ font-size: 11px !important; }
+
+  #search .manual-compact .time-slider{ margin-top: 6px !important; }
+  #search .manual-compact .time-values{ margin-top: 4px !important; font-size: 12px !important; }
+  #search .manual-compact .filters-options{ gap: 6px !important; }
+  #search .manual-compact .option-toggle{
+    padding: 6px 8px !important;
+    min-height: 30px !important;
+  }
+  #search .manual-compact .option-toggle span{ font-size: 11px !important; }
+
+  #search .manual-compact .actions-main{ margin-top: 8px !important; }
+  #search .manual-compact .proposer-btn,
+  #search #btnProposer{ min-height: 36px !important; padding: 8px 10px !important; font-size: 13px !important; }
+}
+
 /* ===== PATCH smartphone 2026-03-02: tableau full height + console plus pro ===== */
 @media (max-width: 768px){
   #trainInfo .table-scroll{
@@ -9048,31 +9278,38 @@ html, body{
   backdrop-filter: blur(10px);
   gap: 6px;
 }
-#tableauViewNav .tableau-view-tab{
+#tableauViewNav .tableau-view-tab,
+#loisirsViewNav .tableau-view-tab{
   flex:1 1 0;
   min-width:0;
   margin:0 !important;
-  padding: 7px 6px !important;
-  border-radius: 10px;
-  border: 1px solid rgba(0, 240, 255, 0.24);
-  background: rgba(0, 12, 24, 0.55);
+  padding: 8px 7px !important;
+  border-radius: 12px;
+  border: 1px solid rgba(90, 235, 255, 0.34);
+  background: linear-gradient(160deg, rgba(6,24,38,.86), rgba(4,16,30,.8));
   color:#dffbff;
-  font-size: .70rem !important;
+  font-size: .72rem !important;
   font-weight: 700;
   letter-spacing: .02em;
-  line-height: 1.15;
+  line-height: 1.08;
+  text-align:center;
   max-width:none !important;
+  box-shadow: inset 0 1px 0 rgba(170,245,255,.12), inset 0 -10px 22px rgba(0,180,220,.10), 0 2px 10px rgba(0,0,0,.25);
+  transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
 }
-#tableauViewNav .tableau-view-tab.is-active{
-  border-color: rgba(0, 240, 255, 0.65);
-  background: linear-gradient(135deg, rgba(0,255,255,.86), rgba(0,170,255,.86));
+#tableauViewNav .tableau-view-tab:hover,
+#loisirsViewNav .tableau-view-tab:hover{
+  border-color: rgba(120, 245, 255, 0.55);
+  transform: translateY(-1px);
+}
+#tableauViewNav .tableau-view-tab.is-active,
+#loisirsViewNav .tableau-view-tab.is-active{
+  border-color: rgba(0, 240, 255, 0.85);
+  background: linear-gradient(135deg, rgba(0,255,255,.94), rgba(0,190,255,.90));
   color:#00111a;
-  box-shadow: 0 0 14px rgba(0,240,255,.45), inset 0 0 14px rgba(0,240,255,.35);
+  box-shadow: 0 0 0 1px rgba(170,255,255,.38) inset, 0 0 16px rgba(0,240,255,.45), inset 0 0 12px rgba(0,220,255,.28);
 }
-#tableauViewNav .tableau-view-tab--search{
-  font-weight: 800;
-  letter-spacing: .03em;
-}
+#tableauViewNav .tableau-view-tab--search{ font-weight: 800; letter-spacing: .03em; }
 @media (max-width: 768px){
   body.tableau-view-nav-visible{ --tableau-viewbar-h: 64px; }
   #tableauViewNav.is-visible{
@@ -9104,16 +9341,6 @@ html, body{
   box-shadow: 0 8px 24px rgba(0, 240, 255, 0.16);
   backdrop-filter: blur(10px);
   gap: 6px;
-}
-#loisirsViewNav .tableau-view-tab{
-  flex:1 1 0;
-  min-width:0;
-}
-#loisirsViewNav .tableau-view-tab.is-active{
-  border-color: rgba(0, 240, 255, 0.65);
-  background: linear-gradient(135deg, rgba(0,255,255,.86), rgba(0,170,255,.86));
-  color:#00111a;
-  box-shadow: 0 0 14px rgba(0,240,255,.45), inset 0 0 14px rgba(0,240,255,.35);
 }
 @media (max-width: 768px){
   #loisirsViewNav.is-visible{
@@ -9201,6 +9428,13 @@ html, body{
     <div class="media-card">
       <iframe src="https://www.youtube.com/embed/4O_aCit0OW8" title="Bétaillère vidéo 5" allowfullscreen></iframe>
     </div>
+  </div>
+</section>
+
+<section id="jeuContainer" class="media-section app-page" data-page="loisirs" aria-label="Jeu" style="display:none;">
+  <h2>Jeu</h2>
+  <div class="map-embed-shell">
+    <iframe id="jeuFrame" title="Jeu Bétaillère" src="about:blank" loading="lazy" referrerpolicy="no-referrer"></iframe>
   </div>
 </section>
 
@@ -9547,14 +9781,6 @@ html, body{
   </details>
 </div>
 
-<!-- Bouton don -->
-<div style="text-align: center;">
-  <a href="https://buymeacoffee.com/labetaillere"
-     class="bouton-don" target="_blank" rel="noopener noreferrer">
-     ☕ Soutenir le projet
-  </a>
-</div>
-
 <div id="presetBuilderModal" class="lb-auth-modal" aria-hidden="true">
   <div class="lb-auth-card" role="dialog" aria-modal="true" aria-labelledby="presetBuilderTitle">
     <button id="presetBuilderClose" class="lb-auth-close tron-close-button" type="button" aria-label="Fermer"></button>
@@ -9580,8 +9806,7 @@ html, body{
   </div>
 </div>
 
-   <div style="font-size: 0.9em; line-height: 1.6; border-top: 1px solid #ccc; margin-top: 1em; padding-top: 0.5em;"></div>
-  
+
 <!-- CONTENEUR BAS -->
 <div id="bottom-bar" style="display: flex; align-items: center; justify-content: space-between; gap: 20px; margin-top: 2em; flex-wrap: wrap;">
 
@@ -9618,18 +9843,6 @@ html, body{
   <a href="/confidentialite.html">Politique de confidentialité</a>
 </div>
 
-<div style="font-size: 0.7em; line-height: 1.4; border-top: 1px solid #ccc; margin-top: 0.5em; padding-top: 0.5em;">
-  <h3 style="font-size:1em; margin-bottom: 0.5em;">📘 Légende du tableau des bétaillères </h3>
-  <ul style="list-style: disc; margin-left: 1.2em; padding-left: 0.5em;">
-    <li><span style="color:#7CFF4D; font-weight:bold;">Train en UM3</span> : Unité Multiple 3 rames, Z24500</li>
-    <li><span style="color: #00f0ff; font-weight: bold;">Train en UM</span> : Unité Multiple 2 rames, Z24500</li>
-    <li><span style="color: #bf00ff; font-weight: bold;">Train en US</span> : Unité Simple 1 rame, Z24500</li>
-    <li><span class="deleted">Texte barré en rouge</span> : arrêt supprimé ou train totalement supprimé ( SNCF)</li>
-    <li><span class="delay-strike">Horaire barré</span> puis <span class="retard">horaire orange</span> : retard  SNCF ou GTFS-RT (éphémère) </li>
-    <li><span class="new-start">Texte bleu gras</span> : nouvelle gare de départ/terminus (suppression partielle)</li>
-  </ul>
-  <p style="margin-top: 0.5em;"><strong>Sources :</strong>  SNCF, GTFS & GTFS-RT</p>
-</div>
 
   <!-- Modale Blague (popup interne responsive) -->
   <div id="modalBlague" style="display:none; position:fixed; top:50%; left:50%; transform: translate(-50%, -50%);
@@ -9642,7 +9855,7 @@ html, body{
   <div id="fondModal" style="display:none; position:fixed; top:0; left:0; width:100vw; height:100vh; background:rgba(0,0,0,0.5); z-index:999;"></div>
 
   <!-- LICENCE -->
-<div style="text-align: center; font-size: 0.8em; margin-top: 3em; padding: 1em 10px; color: #88ffff; background: linear-gradient(145deg, #11151f, #080c14); border-top: 1px solid #00ffff;">
+<div id="siteLicense" style="text-align: center; font-size: 0.8em; margin-top: 3em; padding: 1em 10px; color: #88ffff; background: linear-gradient(145deg, #11151f, #080c14); border-top: 1px solid #00ffff;">
   <p style="margin: 0.5em 0;">
     © 2024-2025 <strong>TekMate Lux</strong> – Tous droits réservés.<br>
     Ce projet est sous licence 
@@ -20514,7 +20727,7 @@ if (statsEl){
     const key = 'lbCookieConsent';
     let consent = null;
     try {
-      consent = localStorage.getItem(key);
+      consent = localStorage.getItem(key) || sessionStorage.getItem(key);
     } catch (err) {
       console.warn('Impossible de lire le consentement cookies', err);
     }
@@ -20524,17 +20737,20 @@ if (statsEl){
     banner.setAttribute('aria-hidden', 'false');
     const accept = banner.querySelector('.cookie-accept');
     const close = banner.querySelector('.cookie-decline');
+    const closeTop = banner.querySelector('.cookie-banner__close');
     const dismiss = (value) => {
       try {
         localStorage.setItem(key, value);
       } catch (err) {
         console.warn('Impossible de stocker le consentement cookies', err);
+        try { sessionStorage.setItem(key, value); } catch(_){}
       }
       banner.hidden = true;
       banner.setAttribute('aria-hidden', 'true');
     };
     if (accept) accept.addEventListener('click', () => dismiss('accepted'));
     if (close) close.addEventListener('click', () => dismiss('dismissed'));
+    if (closeTop) closeTop.addEventListener('click', () => dismiss('dismissed'));
   };
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initCookieBanner);
@@ -22718,12 +22934,47 @@ async function loadAffluenceDate(dateStr){
   const nav = document.getElementById('loisirsViewNav');
   const loisirsLink = document.querySelector('.bottom-nav__item[href="#loisirs"]');
   const multimediaSection = document.getElementById('multimedia');
-  const bingoBtn = document.getElementById('btnBingo');
-  const jeuBtn = document.getElementById('btnJeu');
+  const jeuSection = document.getElementById('jeuContainer');
+  const jeuFrame = document.getElementById('jeuFrame');
+  const modalBlague = document.getElementById('modalBlague');
+  const fondModal = document.getElementById('fondModal');
+  const texteBlague = document.getElementById('texteBlague');
+  const fermerBlague = document.getElementById('fermerBlague');
   if (!nav || !loisirsLink || !multimediaSection) return;
 
   const tabs = Array.from(nav.querySelectorAll('[data-loisirs-view]'));
   const onLoisirsTab = () => ['#loisirs', '#divertissement', '#multimedia'].includes(location.hash || '');
+  const bingoFallback = [
+    "Bingo du jour : retard mystère, correspondance sportive et quai surprise. 🎯",
+    "Bingo TER : signalisation, météo, puis arrivée en héros. 🚆",
+    "Bingo validé : un train à l'heure, c'est un jackpot ! ⭐"
+  ];
+
+  function pickBingoLine(){
+    try {
+      if (typeof pickBingoForDate === 'function') {
+        const d = new Date();
+        const key = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+        return pickBingoForDate(key);
+      }
+    } catch(e){ console.warn('[loisirs bingo] fallback', e); }
+    return bingoFallback[Math.floor(Math.random() * bingoFallback.length)];
+  }
+
+  function showBingoModal(){
+    if (!modalBlague || !fondModal || !texteBlague) return;
+    texteBlague.textContent = pickBingoLine();
+    modalBlague.style.display = 'block';
+    fondModal.style.display = 'block';
+  }
+
+  function hideBingoModal(){
+    if (modalBlague) modalBlague.style.display = 'none';
+    if (fondModal) fondModal.style.display = 'none';
+  }
+
+  fermerBlague?.addEventListener('click', hideBingoModal);
+  fondModal?.addEventListener('click', hideBingoModal);
 
   function activate(view){
     tabs.forEach(tab => {
@@ -22733,15 +22984,33 @@ async function loadAffluenceDate(dateStr){
     });
   }
 
+  function setJeuFullscreen(active){
+    document.body.classList.toggle('jeu-fullscreen', active);
+  }
+
   function openView(view, opts = {}){
     activate(view);
     if (view === 'multimedia'){
+      setJeuFullscreen(false);
       if ((location.hash || '') !== '#multimedia') location.hash = 'multimedia';
       if (opts.scroll !== false) requestAnimationFrame(() => multimediaSection.scrollIntoView({ behavior: 'smooth', block: 'start' }));
       return;
     }
-    if (view === 'bingo') bingoBtn?.click();
-    if (view === 'jeu') jeuBtn?.click();
+    if (view === 'bingo'){
+      setJeuFullscreen(false);
+      if ((location.hash || '') !== '#divertissement') location.hash = 'divertissement';
+      showBingoModal();
+      return;
+    }
+    if (view === 'jeu'){
+      if ((location.hash || '') !== '#divertissement') location.hash = 'divertissement';
+      if (jeuFrame && !jeuFrame.dataset.loaded){
+        jeuFrame.src = 'https://tekmate-lux.github.io/Assistant-train/jeuBETA.html';
+        jeuFrame.dataset.loaded = '1';
+      }
+      if (jeuSection) jeuSection.style.display = 'block';
+      setJeuFullscreen(true);
+    }
   }
 
   function refresh(){
@@ -22749,10 +23018,17 @@ async function loadAffluenceDate(dateStr){
     nav.hidden = !show;
     nav.classList.toggle('is-visible', show);
     document.body.classList.toggle('loisirs-view-nav-visible', show);
-    if (show){
-      const current = (location.hash || '') === '#multimedia' ? 'multimedia' : (tabs.find(t => t.classList.contains('is-active'))?.dataset.loisirsView || 'multimedia');
-      activate(current);
+    if (!show) {
+      setJeuFullscreen(false);
+      hideBingoModal();
+      return;
     }
+    const hash = location.hash || '';
+    let current = 'multimedia';
+    if (document.body.classList.contains('jeu-fullscreen')) current = 'jeu';
+    else if (hash === '#multimedia') current = 'multimedia';
+    else if (hash === '#divertissement') current = 'bingo';
+    activate(current);
   }
 
   tabs.forEach(tab => {
@@ -22772,6 +23048,8 @@ async function loadAffluenceDate(dateStr){
         nav.hidden = true;
         nav.classList.remove('is-visible');
         document.body.classList.remove('loisirs-view-nav-visible');
+        setJeuFullscreen(false);
+        hideBingoModal();
       }
     }, { passive: true });
   });
@@ -22861,10 +23139,3 @@ async function loadAffluenceDate(dateStr){
 
 </body>
 </html>
-      // localStorage (pour fonctionner même déconnecté / fallback)
-      try{
-        localStorage.setItem('lb_weatherStations', JSON.stringify({
-          from: payload.favoriteFromStation || '',
-          to: payload.favoriteToStation || ''
-        }));
-      }catch(e){}


### PR DESCRIPTION
### Motivation
- Introduce a visible support call-to-action and improve the loisirs (multimedia/game/bingo) experience for users. 
- Make the cookie banner more accessible with an explicit close control and more robust storage fallback. 
- Improve mobile/tableau density and fullscreen behaviour for the embedded game and compact table view. 

### Description
- Added a new `.top-bar__support` CTA linking to `https://buymeacoffee.com/labetaillere` and corresponding styles, and removed the standalone donate button. 
- Implemented a cookie banner close button (`.cookie-banner__close`) and updated the banner logic to read/write `localStorage` with a `sessionStorage` fallback and wire the close button to dismiss behavior. 
- Introduced a collapsible table legend (`.table-legend-toggle`) in the search console and moved the footer/site license into `#siteLicense`, hiding the bottom bar by default and keeping legal links visible. 
- Added a `#jeuContainer` iframe for the game, a bingo modal (`#modalBlague`) and supporting JS to lazily load the game iframe, toggle `body.jeu-fullscreen`, and show/hide a bingo modal with fallback phrases. 
- Multiple CSS improvements for mobile and tablet: denser `#search` console styles, compact table typography (`@media (max-width:520px)`), updated `#tableauViewNav`/`#loisirsViewNav` tab styling, and rules to hide non-game content in `body.jeu-fullscreen`. 
- Minor adjustments: `cookie-banner` `isolation:isolate`, box-shadow/palette refinements, and small DOM reorganizations (inserted support link in `.top-bar__actions`, removed old donate block). 

### Testing
- Ran automated linters and static checks including `ESLint` and `Stylelint`, which completed without errors. 
- Ran automated HTML/CSS validation and a headless smoke test that loads the page, toggles the cookie banner and opens the loisirs views to ensure no console errors; all checks passed. 
- No unit tests were changed; integration smoke tests confirmed the new iframe lazy-load, cookie consent persistence and bingo modal behavior under automated test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b024b0d074832db4e5912faccff01a)