### PR TITLE
UI: add bottom-nav SVG icons, clickable trip-panel train link, live comments, game embed and small UX fixes

### DIFF
--- a/ber_icons_pack/accueil.svg
+++ b/ber_icons_pack/accueil.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00f0ff"/><stop offset="1" stop-color="#00a3ff"/></linearGradient></defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="rgba(0,20,35,0.85)" stroke="url(#g)" stroke-width="3"/>
+  <text x="32" y="39" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#dffbff" font-weight="700">H</text>
+</svg>

--- a/ber_icons_pack/carte.svg
+++ b/ber_icons_pack/carte.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00f0ff"/><stop offset="1" stop-color="#00a3ff"/></linearGradient></defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="rgba(0,20,35,0.85)" stroke="url(#g)" stroke-width="3"/>
+  <text x="32" y="39" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#dffbff" font-weight="700">M</text>
+</svg>

--- a/ber_icons_pack/compte.svg
+++ b/ber_icons_pack/compte.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00f0ff"/><stop offset="1" stop-color="#00a3ff"/></linearGradient></defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="rgba(0,20,35,0.85)" stroke="url(#g)" stroke-width="3"/>
+  <text x="32" y="39" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#dffbff" font-weight="700">C</text>
+</svg>

--- a/ber_icons_pack/favoris.svg
+++ b/ber_icons_pack/favoris.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00f0ff"/><stop offset="1" stop-color="#00a3ff"/></linearGradient></defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="rgba(0,20,35,0.85)" stroke="url(#g)" stroke-width="3"/>
+  <text x="32" y="39" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#dffbff" font-weight="700">F</text>
+</svg>

--- a/ber_icons_pack/loisirs.svg
+++ b/ber_icons_pack/loisirs.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00f0ff"/><stop offset="1" stop-color="#00a3ff"/></linearGradient></defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="rgba(0,20,35,0.85)" stroke="url(#g)" stroke-width="3"/>
+  <text x="32" y="39" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#dffbff" font-weight="700">L</text>
+</svg>

--- a/ber_icons_pack/stats.svg
+++ b/ber_icons_pack/stats.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00f0ff"/><stop offset="1" stop-color="#00a3ff"/></linearGradient></defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="rgba(0,20,35,0.85)" stroke="url(#g)" stroke-width="3"/>
+  <text x="32" y="39" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#dffbff" font-weight="700">S</text>
+</svg>

--- a/ber_icons_pack/tableau.svg
+++ b/ber_icons_pack/tableau.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00f0ff"/><stop offset="1" stop-color="#00a3ff"/></linearGradient></defs>
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="rgba(0,20,35,0.85)" stroke="url(#g)" stroke-width="3"/>
+  <text x="32" y="39" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#dffbff" font-weight="700">T</text>
+</svg>

--- a/carte.html
+++ b/carte.html
@@ -65,6 +65,9 @@
     .trip-panel-back:hover{ border-color:#5bd6ff; color:#a0ff00; }
     .trip-panel-body{ display:flex; flex-direction:column; gap:12px; overflow:auto; padding-right:2px; }
     .trip-panel-title{ display:flex; align-items:center; gap:8px; font-weight:700; font-size:16px; }
+    .trip-panel-train-link{ border:0; background:none; color:inherit; font:inherit; padding:0; margin:0; text-align:left; cursor:default; }
+    .trip-panel-train-link.is-clickable{ cursor:pointer; text-decoration:underline; text-decoration-thickness:1px; text-underline-offset:2px; }
+    .trip-panel-train-link.is-clickable:hover{ color:#a0ff00; }
     .trip-panel-icon{ font-size:20px; filter: drop-shadow(0 0 4px rgba(0,0,0,0.6)); }
     .trip-panel-close{ border:none; background:rgba(32,50,75,0.6); color:#e0f0ff; font-size:18px; width:28px; height:28px; border-radius:50%; cursor:pointer; display:flex; align-items:center; justify-content:center; }
     .trip-panel-close:hover{ background:rgba(160,255,0,0.25); color:#0b0f1a; }
@@ -328,7 +331,7 @@
     <div class="trip-panel-header">
       <div class="trip-panel-title">
         <span id="trip-panel-icon" class="trip-panel-icon" aria-hidden="true">🐄</span>
-        <span id="trip-panel-train">Sélectionnez une bétaillère ou une gare</span>
+        <button id="trip-panel-train" class="trip-panel-train-link" type="button" aria-label="Ouvrir le détail train">Sélectionnez une bétaillère ou une gare</button>
       </div>
       <div class="trip-panel-header-right"><button id="trip-panel-back" class="trip-panel-back hidden" type="button" aria-label="Retour à la gare">← Retour</button><span id="station-board-now" class="station-board-now hidden" aria-live="off"></span><button id="trip-panel-close" class="trip-panel-close" type="button" aria-label="Fermer">×</button></div>
     </div>
@@ -3776,6 +3779,14 @@ function sanitizeCflStationName(name){
 
   tripPanelCloseBtn.addEventListener('click', handleTripPanelClose);
   tripPanelCloseBtn.addEventListener('touchstart', handleTripPanelClose, { passive:false });
+  if (tripPanelTrainEl){
+    tripPanelTrainEl.addEventListener('click', ()=>{
+      if (!activeTripId) return;
+      const data = trainDataById.get(activeTripId) || buildStaticPanelTrainData(activeTripId);
+      if (!data) return;
+      requestTrainDetailOpenFromMap(data);
+    });
+  }
 
   function handleTripPanelBack(ev){
     if (ev){
@@ -3977,6 +3988,25 @@ const mapContainerEl = map.getContainer();
   }
 
 
+  function requestTrainDetailOpenFromMap(trainData){
+    const candidate = extractTrainNumberCandidate(trainData?.number)
+      || extractTrainNumberCandidate(trainData?.numberRaw)
+      || extractTrainNumberCandidate(trainData?.numberKey)
+      || extractTrainNumberCandidate(trainData?.id);
+    if (candidate == null) return false;
+    const trainNumber = String(candidate);
+    const ymd = todayYMD().ymd;
+    try {
+      if (window.parent && window.parent !== window && typeof window.parent.postMessage === 'function') {
+        window.parent.postMessage({ type: 'lb:open-train-detail', trainNumber, dateYmd: ymd, source: 'carte' }, '*');
+        return true;
+      }
+    } catch(e) {}
+    const url = `https://www.sncf-voyageurs.com/fr/voyagez-avec-nous/horaires-et-itineraires/recherche-de-train/detail-train/?numeroCirculation=${encodeURIComponent(trainNumber)}&dateCirculation=${encodeURIComponent(ymd)}`;
+    try { window.open(url, '_blank', 'noopener'); } catch(_) { location.href = url; }
+    return true;
+  }
+
   function openTripPanel(trainId, options = {}){
     const fromStationId = options?.fromStationId || null;
     activeTripId = trainId;
@@ -4106,6 +4136,12 @@ const mapContainerEl = map.getContainer();
     } else {
       tripPanelTrainEl.textContent = data.id || 'Sélectionnez une bétaillère';
     }
+
+    const canOpenDetail = extractTrainNumberCandidate(data.number) != null
+      || extractTrainNumberCandidate(data.numberRaw) != null
+      || extractTrainNumberCandidate(data.numberKey) != null;
+    tripPanelTrainEl.classList.toggle('is-clickable', canOpenDetail);
+    tripPanelTrainEl.title = canOpenDetail ? 'Ouvrir les détails du train' : '';
 
     if (!seq || !seq.length){
       tripPanelSummaryEl.textContent = 'Données de trajet indisponibles pour ce service.';

--- a/carteBETA.html
+++ b/carteBETA.html
@@ -57,6 +57,9 @@
     .trip-panel-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
     .trip-panel-body{ display:flex; flex-direction:column; gap:12px; overflow:auto; padding-right:2px; }
     .trip-panel-title{ display:flex; align-items:center; gap:8px; font-weight:700; font-size:16px; }
+    .trip-panel-train-link{ border:0; background:none; color:inherit; font:inherit; padding:0; margin:0; text-align:left; cursor:default; }
+    .trip-panel-train-link.is-clickable{ cursor:pointer; text-decoration:underline; text-decoration-thickness:1px; text-underline-offset:2px; }
+    .trip-panel-train-link.is-clickable:hover{ color:#a0ff00; }
     .trip-panel-icon{ font-size:20px; filter: drop-shadow(0 0 4px rgba(0,0,0,0.6)); }
     .trip-panel-close{ border:none; background:rgba(32,50,75,0.6); color:#e0f0ff; font-size:18px; width:28px; height:28px; border-radius:50%; cursor:pointer; display:flex; align-items:center; justify-content:center; }
     .trip-panel-close:hover{ background:rgba(160,255,0,0.25); color:#0b0f1a; }
@@ -252,7 +255,7 @@
     <div class="trip-panel-header">
       <div class="trip-panel-title">
         <span id="trip-panel-icon" class="trip-panel-icon" aria-hidden="true">🐄</span>
-        <span id="trip-panel-train">Sélectionnez une bétaillère ou une gare</span>
+        <button id="trip-panel-train" class="trip-panel-train-link" type="button" aria-label="Ouvrir le détail train">Sélectionnez une bétaillère ou une gare</button>
       </div>
       <button id="trip-panel-close" class="trip-panel-close" type="button" aria-label="Fermer">×</button>
     </div>
@@ -3366,6 +3369,14 @@ function sanitizeCflStationName(name){
 
   tripPanelCloseBtn.addEventListener('click', handleTripPanelClose);
   tripPanelCloseBtn.addEventListener('touchstart', handleTripPanelClose, { passive:false });
+  if (tripPanelTrainEl){
+    tripPanelTrainEl.addEventListener('click', ()=>{
+      if (!activeTripId) return;
+      const data = trainDataById.get(activeTripId);
+      if (!data) return;
+      requestTrainDetailOpenFromMap(data);
+    });
+  }
 
   map.on('click', ()=>{  
    if (activeTripId || activeStationId){
@@ -3521,6 +3532,25 @@ const mapContainerEl = map.getContainer();
     tripStopsEl.classList.remove('station-mode');
   }
 
+  function requestTrainDetailOpenFromMap(trainData){
+    const candidate = extractTrainNumberCandidate(trainData?.number)
+      || extractTrainNumberCandidate(trainData?.numberRaw)
+      || extractTrainNumberCandidate(trainData?.numberKey)
+      || extractTrainNumberCandidate(trainData?.id);
+    if (candidate == null) return false;
+    const trainNumber = String(candidate);
+    const ymd = todayYMD().ymd;
+    try {
+      if (window.parent && window.parent !== window && typeof window.parent.postMessage === 'function') {
+        window.parent.postMessage({ type: 'lb:open-train-detail', trainNumber, dateYmd: ymd, source: 'carte' }, '*');
+        return true;
+      }
+    } catch(e) {}
+    const url = `https://www.sncf-voyageurs.com/fr/voyagez-avec-nous/horaires-et-itineraires/recherche-de-train/detail-train/?numeroCirculation=${encodeURIComponent(trainNumber)}&dateCirculation=${encodeURIComponent(ymd)}`;
+    try { window.open(url, '_blank', 'noopener'); } catch(_) { location.href = url; }
+    return true;
+  }
+
   function openTripPanel(trainId){
     activeTripId = trainId;
     activeStationId = null;
@@ -3593,6 +3623,12 @@ const mapContainerEl = map.getContainer();
     } else {
       tripPanelTrainEl.textContent = data.id || 'Sélectionnez une bétaillère';
     }
+
+    const canOpenDetail = extractTrainNumberCandidate(data.number) != null
+      || extractTrainNumberCandidate(data.numberRaw) != null
+      || extractTrainNumberCandidate(data.numberKey) != null;
+    tripPanelTrainEl.classList.toggle('is-clickable', canOpenDetail);
+    tripPanelTrainEl.title = canOpenDetail ? 'Ouvrir les détails du train' : '';
 
     if (!seq || !seq.length){
       tripPanelSummaryEl.textContent = 'Données de trajet indisponibles pour ce service.';

--- a/index20.html
+++ b/index20.html
@@ -170,6 +170,77 @@ body {
   box-shadow: inset 0 0 12px rgba(0, 240, 255, 0.28), 0 0 18px rgba(0, 240, 255, 0.25);
 }
 
+.top-bar__support{
+  position: relative;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  border: 1px solid rgba(255, 207, 90, 0.75);
+  background: linear-gradient(135deg, rgba(255,214,102,.96), rgba(255,178,46,.92));
+  color:#2b1700;
+  border-radius:999px;
+  padding:7px 11px;
+  font-size:0.72rem;
+  font-weight:800;
+  text-decoration:none;
+  letter-spacing:.02em;
+  box-shadow: 0 0 0 1px rgba(255,245,210,.35) inset, 0 4px 14px rgba(255,170,40,.35);
+  transition: transform .18s ease, box-shadow .18s ease, filter .18s ease;
+}
+.top-bar__support::after{
+  content:'';
+  position:absolute;
+  inset:1px;
+  border-radius:999px;
+  background: linear-gradient(180deg, rgba(255,255,255,.35), rgba(255,255,255,0));
+  pointer-events:none;
+}
+.top-bar__support:hover,
+.top-bar__support:focus-visible{
+  transform: translateY(-1px) scale(1.02);
+  filter: brightness(1.02);
+  box-shadow: 0 0 0 1px rgba(255,248,220,.45) inset, 0 6px 18px rgba(255,170,40,.45);
+}
+.top-bar__support .euro{ font-size:.92rem; line-height:1; }
+.top-bar__support .label{
+  display:flex;
+  flex-direction:column;
+  line-height:1.02;
+  white-space:nowrap;
+}
+.top-bar__support .label .line2{ font-size:.64rem; font-weight:700; opacity:.88; }
+
+.table-legend-toggle{
+  margin-top: 8px;
+  border: 1px solid rgba(0,240,255,.2);
+  border-radius: 12px;
+  background: rgba(0,12,22,.38);
+  overflow: hidden;
+}
+.table-legend-toggle > summary{
+  list-style:none;
+  cursor:pointer;
+  padding: 7px 10px;
+  font-size: .78rem;
+  font-weight: 700;
+  color: #aef8ff;
+}
+.table-legend-toggle > summary::-webkit-details-marker{ display:none; }
+.table-legend-toggle .legend-content{
+  padding: 0 10px 10px;
+  font-size: .74rem;
+  line-height: 1.35;
+  color: #d9f7ff;
+}
+.table-legend-toggle ul{ margin: 6px 0 0 16px; padding:0; }
+.table-legend-toggle li{ margin: 4px 0; }
+
+@media (max-width: 600px){
+  .top-bar__support .euro{ display:none; }
+  .top-bar__support .label{ display:flex; }
+  .top-bar__support{ padding:7px 11px; min-width:auto; justify-content:center; }
+}
+
 
 /* ==== FIX: éléments invisibles mais cliquables (mobile / pas de hover) ==== */
 @media (hover: none){
@@ -458,6 +529,13 @@ body {
   line-height: 1;
   display:block;
   filter: drop-shadow(0 0 10px rgba(0, 240, 255, 0.65));
+}
+.bottom-nav__icon-img{
+  width: 34px;
+  height: 34px;
+  display:block;
+  object-fit:contain;
+  filter: drop-shadow(0 0 8px rgba(0,240,255,.55));
 }
 
 .bottom-nav__item:hover,
@@ -1615,6 +1693,17 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   background: linear-gradient(135deg, rgba(7, 15, 30, 0.96), rgba(11, 23, 42, 0.94));
   box-shadow: 0 10px 30px rgba(0, 240, 255, 0.10);
   padding: 14px;
+}
+body.page-carte .train-detail-panel{
+  position: fixed;
+  top: calc(var(--top-bar-height, 72px) + 10px);
+  right: 12px;
+  width: min(540px, calc(100vw - 24px));
+  max-height: calc(100dvh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 84px) - 24px);
+  overflow: auto;
+  margin: 0;
+  z-index: 1205;
+  box-shadow: 0 16px 36px rgba(0, 240, 255, 0.16), 0 8px 24px rgba(0,0,0,.35);
 }
 .train-detail-panel[hidden]{ display:none !important; }
 .train-detail-top{
@@ -4364,6 +4453,12 @@ body.modal-open{ overflow:hidden; }
 .lb-auth-switch button{
   width: min(240px, 100%);
 }
+
+.lb-auth-actions #lbBtnLogout{
+  margin-inline: auto;
+  justify-content: center;
+  text-align: center;
+}
 .lb-auth-links{
   margin-top: 10px;
   font-size: 0.8rem;
@@ -4719,8 +4814,20 @@ body.modal-open{ overflow:hidden; }
   color: #8fefff;
   text-decoration: underline;
 }
+
+
+/* Rendre le bas de page plus "app" tout en gardant les infos légales visibles */
+#bottom-bar,
+.footer-counter-wrapper{
+  display:none;
+}
+
+/* Mentions légales/confidentialité toujours accessibles */
+.legal-links{ display:flex; }
+#siteLicense{ display:block; }
 .cookie-banner{
   position: fixed;
+  isolation:isolate;
   left: 16px;
   right: 16px;
   bottom: 16px;
@@ -4742,9 +4849,26 @@ body.modal-open{ overflow:hidden; }
   display: none !important;
 }
 
+.cookie-banner__close{
+  position:absolute;
+  top:7px;
+  right:9px;
+  width:18px;
+  height:18px;
+  border:none;
+  border-radius:999px;
+  background: transparent;
+  color: rgba(210,245,255,.8);
+  font-size: 11px;
+  line-height: 1;
+  cursor:pointer;
+}
+.cookie-banner__close:hover{ background: rgba(120,220,255,.12); color:#fff; }
+
 .cookie-banner p{
   margin: 0;
   flex: 1 1 240px;
+  padding-right: 22px;
 }
 
 .cookie-banner a{
@@ -6835,6 +6959,64 @@ html, body{ overflow-x: hidden; }
   font-size: .95rem;
 }
 
+.live-wall-card{
+  border: 1px solid rgba(0,240,255,.25);
+  background: linear-gradient(135deg, rgba(6,16,30,.92), rgba(6,20,36,.86));
+}
+.live-wall-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  margin-bottom:8px;
+}
+.live-wall-title{ margin:0; font-size:1rem; letter-spacing:.04em; color:#7ef7ff; }
+.live-wall-feed{
+  max-height: 150px;
+  overflow:auto;
+  display:grid;
+  gap:6px;
+  padding-right:2px;
+}
+.live-wall-item{
+  border:1px solid rgba(0,240,255,.2);
+  border-radius:12px;
+  padding:6px 8px;
+  background:rgba(0,8,18,.45);
+  font-size:.84rem;
+}
+.live-wall-meta{ font-size:.72rem; opacity:.78; margin-bottom:3px; display:flex; gap:8px; flex-wrap:wrap; }
+.live-wall-form{ margin-top:8px; display:flex; gap:6px; }
+.live-wall-form input{ flex:1; min-width:0; }
+.live-wall-empty{ opacity:.7; font-size:.82rem; }
+
+.fav-comments-row{ margin-top:8px; display:flex; justify-content:flex-end; }
+.fav-comment-btn,
+.home-comment-pill{
+  border:1px solid rgba(0,240,255,.45);
+  border-radius:999px;
+  background:rgba(0,14,26,.58);
+  color:#dffbff;
+  padding:5px 10px;
+  font-size:.78rem;
+  cursor:pointer;
+}
+.home-comment-pill{ font-size:.7rem; padding:4px 8px; }
+
+.train-comments{
+  margin-top:10px;
+  border:1px solid rgba(0,240,255,.2);
+  border-radius:10px;
+  background:rgba(0,10,20,.35);
+  padding:10px;
+}
+.train-comments-head{ display:flex; justify-content:space-between; align-items:center; margin-bottom:6px; }
+.train-comments-list{ max-height:170px; overflow:auto; display:grid; gap:6px; }
+.train-comments-item{ border-bottom:1px dashed rgba(0,240,255,.14); padding-bottom:6px; }
+.train-comments-item:last-child{ border-bottom:none; padding-bottom:0; }
+.train-comments-form{ margin-top:8px; display:flex; gap:6px; }
+.train-comments-form input{ flex:1; min-width:0; }
+
 /* ===== Traffic card: soft tinted background by level ===== */
 .home-traffic-card{
   background: rgba(10, 20, 28, 0.55);
@@ -7186,11 +7368,77 @@ html, body{ overflow-x: hidden; }
   }
 }
 
+@media (max-width: 768px){
+  body.jeu-fullscreen #home,
+  body.jeu-fullscreen #search,
+  body.jeu-fullscreen #favTrainsWidget,
+  body.jeu-fullscreen #disruptionsSummary,
+  body.jeu-fullscreen #trainInfo,
+  body.jeu-fullscreen #refreshContainer,
+  body.jeu-fullscreen #affluence,
+  body.jeu-fullscreen #multimedia,
+  body.jeu-fullscreen #carte,
+  body.jeu-fullscreen #statsConsole,
+  body.jeu-fullscreen .home-card{ display:none !important; }
+
+  body.jeu-fullscreen #jeuContainer{
+    display:block !important;
+    position: fixed !important;
+    top: var(--carte-top-offset, var(--top-bar-height, 72px)) !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: var(--carte-bottom-offset, calc(max(var(--bottom-bar-height, 84px), var(--lb-bottomnav-h, 84px)) + env(safe-area-inset-bottom, 0px))) !important;
+    width: 100vw !important;
+    max-width: none !important;
+    z-index: 1000 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    border-radius: 0 !important;
+    background: #07101b;
+    overflow: hidden !important;
+  }
+  body.jeu-fullscreen #jeuContainer h2,
+  body.jeu-fullscreen #jeuContainer p{ display:none !important; }
+  body.jeu-fullscreen #jeuContainer .map-embed-shell{
+    position:absolute !important;
+    inset:0 !important;
+    height:100% !important;
+    border:none !important;
+    border-radius:0 !important;
+    box-shadow:none !important;
+  }
+  body.jeu-fullscreen #jeuContainer .map-embed-shell iframe{
+    width:100% !important;
+    height:100% !important;
+    min-height:100% !important;
+    border:0 !important;
+    background:#07101b;
+  }
+}
+
 
 /* === Navigation pages (1 onglet = 1 page) === */
+#jeuContainer{ display:none !important; }
+#jeuContainer .map-embed-shell{
+  border: 1px solid rgba(0,240,255,.24);
+  border-radius: 14px;
+  overflow:hidden;
+  background:#050d18;
+  min-height: 420px;
+}
+#jeuContainer #jeuFrame{
+  width:100%;
+  height: min(70vh, 780px);
+  border:0;
+  display:block;
+  background:#050d18;
+}
+body.loisirs-jeu-active #jeuContainer{ display:block !important; }
+body.loisirs-jeu-active #multimedia{ display:none !important; }
+
 .app-page{ display:none; }
 .app-page.is-page-active{ display:block; }
-body.page-home #home{ display:flex; }
+body.page-home #home{ display:grid; }
 body.page-favoris #favTrainsWidget{ display:block !important; }
 body.page-search #search,
 body.page-carte #carte,
@@ -7198,6 +7446,8 @@ body.page-carte #affluence,
 body.page-loisirs #divertissement,
 body.page-loisirs #multimedia,
 body.page-stats #stats{ display:block; }
+/* Masquer visuellement la section Affluence (conservée dans le code/DOM) */
+body.page-carte #affluence{ display:none !important; }
 </style>
   <style>
 @supports (-webkit-touch-callout: none) {
@@ -7538,6 +7788,7 @@ html, body{
   </div>
 </div>
 <div id="cookieBanner" class="cookie-banner" role="dialog" aria-live="polite" aria-label="Bandeau cookies" hidden>
+  <button class="cookie-banner__close" type="button" aria-label="Fermer le bandeau cookies">✕</button>
   <p>
     🍪 Ce site utilise des cookies pour améliorer l’expérience. Tu peux en savoir plus via la
     <a href="/confidentialite.html" target="_blank" rel="noopener">politique de confidentialité</a>.
@@ -7560,38 +7811,42 @@ html, body{
 
     
     <div class="top-bar__actions" aria-label="Actions rapides">
-</div>
+      <a class="top-bar__support" href="https://buymeacoffee.com/labetaillere" target="_blank" rel="noopener noreferrer" aria-label="Soutenir le projet">
+        <span class="euro" aria-hidden="true">€</span>
+        <span class="label"><span class="line1">Soutenir</span><span class="line2">le projet</span></span>
+      </a>
+    </div>
   </div>
 </header>
 
 <nav class="bottom-nav" aria-label="Navigation principale">
   <div class="bottom-nav__items">
     <a class="bottom-nav__item" href="#home">
-      <span class="bottom-nav__icon" aria-hidden="true">🏠</span>
+      <span class="bottom-nav__icon" aria-hidden="true"><img class="bottom-nav__icon-img" src="/ber_icons_pack/accueil.svg" alt="" loading="lazy"></span>
       <span class="bottom-nav__label">Accueil</span>
     </a>
     <a class="bottom-nav__item" href="#carte">
-      <span class="bottom-nav__icon" aria-hidden="true">🗺️</span>
+      <span class="bottom-nav__icon" aria-hidden="true"><img class="bottom-nav__icon-img" src="/ber_icons_pack/carte.svg" alt="" loading="lazy"></span>
       <span class="bottom-nav__label">Carte</span>
     </a>
     <a class="bottom-nav__item" href="#search">
-      <span class="bottom-nav__icon" aria-hidden="true">📋</span>
+      <span class="bottom-nav__icon" aria-hidden="true"><img class="bottom-nav__icon-img" src="/ber_icons_pack/tableau.svg" alt="" loading="lazy"></span>
       <span class="bottom-nav__label">Tableau</span>
     </a>
     <a class="bottom-nav__item" href="#favoris">
-      <span class="bottom-nav__icon" aria-hidden="true">⭐</span>
+      <span class="bottom-nav__icon" aria-hidden="true"><img class="bottom-nav__icon-img" src="/ber_icons_pack/favoris.svg" alt="" loading="lazy"></span>
       <span class="bottom-nav__label">Favoris</span>
     </a>
     <a class="bottom-nav__item" href="#stats">
-      <span class="bottom-nav__icon" aria-hidden="true">📊</span>
+      <span class="bottom-nav__icon" aria-hidden="true"><img class="bottom-nav__icon-img" src="/ber_icons_pack/stats.svg" alt="" loading="lazy"></span>
       <span class="bottom-nav__label">Stats</span>
     </a>
 	<a class="bottom-nav__item" href="#loisirs">
-      <span class="bottom-nav__icon" aria-hidden="true">🎉</span>
+      <span class="bottom-nav__icon" aria-hidden="true"><img class="bottom-nav__icon-img" src="/ber_icons_pack/loisirs.svg" alt="" loading="lazy"></span>
       <span class="bottom-nav__label">Loisirs</span>
     </a>  
     <button class="bottom-nav__item" id="bottomAccountBtn" type="button">
-      <span class="bottom-nav__icon" aria-hidden="true">👤</span>
+      <span class="bottom-nav__icon" aria-hidden="true"><img class="bottom-nav__icon-img" src="/ber_icons_pack/compte.svg" alt="" loading="lazy"></span>
       <span class="bottom-nav__label">Compte</span>
     </button>
   </div>
@@ -7701,7 +7956,19 @@ html, body{
   </div>
   <section id="home" class="home-section app-page" data-page="home" aria-label="Accueil">
   <div class="home-dashboard">
-    <div class="home-welcome-line">Bienvenue 🐮 dans votre bétaillère Nancy–Metz–Lux 👋</div>
+    <div id="homeWelcomeLine" class="home-welcome-line">Bienvenue 🐮 dans votre bétaillère Nancy–Metz–Lux 👋</div>
+
+    <article class="home-card live-wall-card" aria-label="Commentaires en direct">
+      <div class="live-wall-head">
+        <h2 class="live-wall-title">💬 En direct sur la ligne</h2>
+      </div>
+      <div id="homeLiveWallFeed" class="live-wall-feed"></div>
+      <div id="homeLiveWallCta" class="live-wall-empty">Connectez-vous avec un pseudo pour participer.</div>
+      <form id="homeLiveWallForm" class="live-wall-form" autocomplete="off">
+        <input id="homeLiveWallInput" type="text" maxlength="180" placeholder="Écrire un message (option: #88501)">
+        <button type="submit" class="train-detail-btn">Envoyer</button>
+      </form>
+    </article>
 
     <!-- État du trafic (accueil) -->
     <article class="home-card" aria-label="Info trafic">
@@ -7900,79 +8167,25 @@ html, body{
           <button class="lb-prefs-remove" type="button" data-remove-preset="L4">Supprimer la liste 4</button>
         </div>
       </div>
-      <div class="lb-prefs-options">
-        <label for="lbDefaultMode">Liste par défaut</label>
-        <select id="lbDefaultMode">
-          <option value="">Aucune</option>
-          <option value="AM">Liste 1</option>
-          <option value="PM">Liste 2</option>
-          <option value="L3">Liste 3</option>
-          <option value="L4">Liste 4</option>
-        </select>
-        <label class="lb-prefs-checkbox">
-          <input id="lbAutoLoad" type="checkbox">
-          Lancer automatiquement la génération rapide
-        </label>
+      <div class="lb-prefs-utility" style="margin-top:10px;">
+        <button id="lbAddPrefsList" class="lb-prefs-add" type="button">+ Ajouter une liste</button>
+        <button id="lbResetPresets" class="lb-prefs-reset" type="button">↺ Reset Matin / Soir</button>
       </div>
 
-      <div class="lb-prefs-options" style="margin-top:10px;">
-        
-<div class="prefs-block" id="lbWeatherPrefsBlock" style="margin-top:14px;">
-  <div class="prefs-title" style="display:flex;align-items:center;gap:10px;margin-bottom:8px;">
-    <span style="font-size:1.05rem;">🌦️</span>
-    <div style="font-weight:700;letter-spacing:.04em;">Météo (Accueil)</div>
-  </div>
-  <div class="prefs-desc" style="opacity:.9;font-size:.9rem;margin-bottom:10px;">
-    Choisis les gares <b>Départ</b> et <b>Arrivée</b> utilisées sur l’accueil (Maintenant + dans 1h).
-    Par défaut : <b>Metz → Luxembourg</b>.
-  </div>
+      <div class="lb-prefs-section" style="margin-top:10px;">
+        <div class="lb-prefs-section-title">Favoris & gares (source météo/stats/favoris)</div>
 
-  <div class="prefs-grid" style="display:grid;grid-template-columns:1fr;gap:10px;">
-    <label style="display:block;">
-      <div style="opacity:.9;font-size:.85rem;margin-bottom:6px;">Départ</div>
-      <input id="lbWxFromStation" list="lbStationsDatalist" placeholder="Ex : Metz"
-             style="width:100%;padding:10px 12px;border-radius:12px;" />
-    </label>
+        <label for="lbPseudo">👤 Pseudo</label>
+        <input id="lbPseudo" type="text" maxlength="24" placeholder="Ex : Celestia">
+        <small>Ce pseudo sera utilisé pour un futur espace commentaire / tchat.</small>
 
-    <label style="display:block;">
-      <div style="opacity:.9;font-size:.85rem;margin-bottom:6px;">Arrivée</div>
-      <input id="lbWxToStation" list="lbStationsDatalist" placeholder="Ex : Luxembourg"
-             style="width:100%;padding:10px 12px;border-radius:12px;" />
-    </label>
+        <label for="lbFavMorning">⭐ Train favori matin</label>
+        <input id="lbFavMorning" type="text" inputmode="numeric" placeholder="Ex : 88501" maxlength="6">
 
-    <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center;margin-top:2px;">
-      <button id="lbWxSaveLocalBtn" class="btn" type="button" style="padding:10px 14px;border-radius:14px;">
-        Enregistrer
-      </button>
-      <button id="lbWxResetBtn" class="btn" type="button" style="padding:10px 14px;border-radius:14px;opacity:.9;">
-        Réinitialiser (Metz → Luxembourg)
-      </button>
-      <div id="lbWxSaveHint" style="font-size:.85rem;opacity:.85;"></div>
-    </div>
-  </div>
-</div>
+        <label for="lbFavEvening">⭐ Train favori soir</label>
+        <input id="lbFavEvening" type="text" inputmode="numeric" placeholder="Ex : 88532" maxlength="6">
 
-<datalist id="lbStationsDatalist">
-  <option value="Luxembourg"></option>
-  <option value="Bettembourg"></option>
-  <option value="Hettange-Grande"></option>
-  <option value="Thionville"></option>
-  <option value="Uckange"></option>
-  <option value="Hagondange"></option>
-  <option value="Maizières-lès-Metz"></option>
-  <option value="Woippy"></option>
-  <option value="Metz"></option>
-  <option value="Pagny-sur-Moselle"></option>
-  <option value="Pont-à-Mousson"></option>
-  <option value="Nancy"></option>
-</datalist>
-
-<label for="lbFavMorning">⭐ Train Favori Matin</label>
-        <input id="lbFavMorning" type="text" placeholder="ex: 88501">
-        <label for="lbFavEvening" style="margin-top:8px;">⭐ Train Favori Soir</label>
-        <input id="lbFavEvening" type="text" placeholder="ex: 88730">
-        
-        <label for="lbFavFromStation" style="margin-top:12px;">🚉 Gare favorite (départ)</label>
+        <label for="lbFavFromStation">🚉 Gare favorite (départ)</label>
         <select id="lbFavFromStation" class="lb-station-select">
           <option value="">—</option>
           <option value="Metz">Metz</option>
@@ -7989,7 +8202,8 @@ html, body{
           <option value="Bettembourg">Bettembourg</option>
           <option value="Luxembourg">Luxembourg</option>
         </select>
-        <label for="lbFavToStation" style="margin-top:8px;">🚉 Gare favorite (arrivée)</label>
+
+        <label for="lbFavToStation">🚉 Gare favorite (arrivée)</label>
         <select id="lbFavToStation" class="lb-station-select">
           <option value="">—</option>
           <option value="Metz">Metz</option>
@@ -8006,56 +8220,14 @@ html, body{
           <option value="Bettembourg">Bettembourg</option>
           <option value="Luxembourg">Luxembourg</option>
         </select>
-<small>Astuce : mets un numéro SNCF (5 ou 6 chiffres). Vide = pas de widget pour ce créneau.</small>
-      </div>
-
-      <div class="lb-prefs-utility">
-        <button id="lbAddPrefsList" class="lb-prefs-add" type="button">+ Ajouter une liste</button>
-        <button id="lbResetPresets" class="lb-prefs-reset" type="button">↺ Reset Matin / Soir</button>
+        <small>Ces deux gares alimentent aussi la météo de l'accueil, le préremplissage stats et les favoris.</small>
       </div>
       <div class="lb-auth-actions">
         <button id="lbSavePrefs" class="auth-button" type="button">Enregistrer</button>
         <button id="lbClosePrefs" class="auth-button auth-button--ghost" type="button">Fermer</button>
       </div>
       
-      <div class="lb-account-box" id="lbWxPrefsBox" style="margin-top:10px;">
-        <h4 style="margin:0 0 8px;">🌦️ Météo (Accueil)</h4>
-        <p style="margin:0 0 10px; color:#aab6c8; font-size:0.9rem; line-height:1.4;">
-          La météo utilise automatiquement tes <strong>gares favorites</strong> ci-dessus (départ + arrivée).
-        </p>
-        <div style="display:none">
-          <div style="display:grid; grid-template-columns: 1fr 1fr; gap:10px;">
-            <div>
-              <label for="lbWxFromStation">Départ</label>
-              <input id="lbWxFromStation" list="lbWxStations" placeholder="Metz">
-            </div>
-            <div>
-              <label for="lbWxToStation">Arrivée</label>
-              <input id="lbWxToStation" list="lbWxStations" placeholder="Luxembourg">
-            </div>
-          </div>
-          <datalist id="lbWxStations">
-            <option value="Metz"></option>
-            <option value="Luxembourg"></option>
-            <option value="Nancy"></option>
-            <option value="Thionville"></option>
-            <option value="Hagondange"></option>
-            <option value="Uckange"></option>
-            <option value="Bettembourg"></option>
-            <option value="Hettange-Grande"></option>
-            <option value="Maizières-lès-Metz"></option>
-            <option value="Pagny-sur-Moselle"></option>
-            <option value="Pont-à-Mousson"></option>
-            <option value="Woippy"></option>
-            <option value="Metz-Nord"></option>
-          </datalist>
-        </div>
-
-        <div style="display:flex; gap:10px; flex-wrap:wrap; margin-top:10px;">
-          <button id="lbWxSaveLocal" class="auth-button auth-button--ghost" type="button">Enregistrer (local)</button>
-          <small style="color:#aab6c8;">(En plus du compte : ça marche même si le backend n’a pas encore ce champ)</small>
-        </div>
-      </div>
+      
 
       <div id="lbPrefsMsg" class="lb-auth-msg"></div>
     </div>
@@ -8078,6 +8250,7 @@ html, body{
         </div>
       </div>
       <div class="fav-meta" id="favMetaAM">—</div>
+      <div class="fav-comments-row"><button type="button" class="fav-comment-btn" id="favCommentsBtnAM">💬 0 commentaire</button></div>
       <div class="fav-line" id="favLineAM"></div>
       <div class="fav-cause" id="favCauseAM"></div>
       <details class="fav-details" id="favStatsAM">
@@ -8095,6 +8268,7 @@ html, body{
         </div>
       </div>
       <div class="fav-meta" id="favMetaPM">—</div>
+      <div class="fav-comments-row"><button type="button" class="fav-comment-btn" id="favCommentsBtnPM">💬 0 commentaire</button></div>
       <div class="fav-line" id="favLinePM"></div>
       <div class="fav-cause" id="favCausePM"></div>
       <details class="fav-details" id="favStatsPM">
@@ -8108,6 +8282,19 @@ html, body{
 <!-- Console de Commande -->
 <div class="command-console app-page" id="search" data-page="search">
   <div class="console-header"> Console de Commande – Sélection des Bétaillères</div>
+  <details class="table-legend-toggle">
+    <summary>ℹ️ Légende</summary>
+    <div class="legend-content">
+      <ul>
+        <li><span style="color:#7CFF4D;font-weight:bold;">UM3</span> : 3 rames Z24500</li>
+        <li><span style="color:#00f0ff;font-weight:bold;">UM</span> : 2 rames Z24500</li>
+        <li><span style="color:#bf00ff;font-weight:bold;">US</span> : 1 rame Z24500</li>
+        <li><span class="deleted">Texte barré rouge</span> : arrêt/train supprimé</li>
+        <li><span class="delay-strike">Horaire barré</span> puis <span class="retard">orange</span> : retard</li>
+        <li><span class="new-start">Bleu gras</span> : nouveau départ / terminus</li>
+      </ul>
+    </div>
+  </details>
 
   <!-- 1) GÉNÉRATION PERSONNALISÉE -->
   <details class="console-section">
@@ -8351,6 +8538,17 @@ html, body{
     <div class="aff-chart" style="margin-top:8px"><canvas id="trainDetailAffluenceChart" height="92"></canvas></div>
   </div>
   <div class="train-detail-route" id="trainDetailStops"></div>
+  <div class="train-comments" id="trainDetailComments">
+    <div class="train-comments-head">
+      <div class="k">Commentaires voyageurs</div>
+      <div id="trainDetailCommentsCount" class="v">0</div>
+    </div>
+    <div id="trainDetailCommentsList" class="train-comments-list"></div>
+    <form id="trainDetailCommentsForm" class="train-comments-form" autocomplete="off">
+      <input id="trainDetailCommentsInput" type="text" maxlength="180" placeholder="Ajouter un commentaire sur ce train">
+      <button type="submit" class="train-detail-btn">Publier</button>
+    </form>
+  </div>
   <div class="train-detail-actions">
     <a id="trainDetailAffBtn" class="train-detail-btn" href="#affluence">🚆 Ouvrir dans Affluence</a>
     <a id="trainDetailStatsBtn" class="train-detail-btn" href="#stats">📊 Voir schéma stats du train</a>
@@ -8366,7 +8564,7 @@ html, body{
   <p>Accès complet à la carte La Bétaillère sans quitter l’application.</p>
   <div class="map-embed-shell">
     <iframe
-      src="carte.html?embed=1"
+      src="carteBETA.html?embed=1"
       title="Carte La Bétaillère"
       loading="lazy"
       referrerpolicy="strict-origin-when-cross-origin"
@@ -8848,6 +9046,14 @@ html, body{
   padding-bottom: 10px !important;
 }
 
+
+/* Top logo +20% */
+.top-bar__logo{ width: 46px !important; height: 46px !important; }
+@media (max-width: 600px){
+  .top-bar__logo{ width: 38px !important; height: 38px !important; }
+  .bottom-nav__icon-img{ width: 30px !important; height: 30px !important; }
+}
+
 /* v23: ultra-compact Tableau console so everything fits on one mobile screen without scrolling */
 @media (max-width: 520px){
   /* reduce global vertical spacing a bit more */
@@ -8996,6 +9202,70 @@ html, body{
   }
 }
 
+
+/* ===== v27: Tableau mobile compact — réduire la typo et densifier l'écran ===== */
+@media (max-width: 520px){
+  #search .command-console{ margin-bottom: 8px !important; }
+  #search .command-console .console-header{ margin-bottom: 6px !important; }
+  #search .command-console .console-title{
+    font-size: clamp(15px, 3.8vw, 17px) !important;
+    line-height: 1.1 !important;
+    letter-spacing: .01em !important;
+  }
+
+  #search .command-console .console-section,
+  #search .command-console .console-card{
+    padding: 9px 10px !important;
+    margin-bottom: 8px !important;
+    border-radius: 14px !important;
+  }
+
+  #search .manual-compact .compact-presets{ padding: 8px !important; gap: 6px !important; }
+  #search .manual-compact .preset-stack,
+  #search .manual-compact .shortcuts-grid{ gap: 6px !important; }
+  #search .manual-compact .shortcut-btn,
+  #search .manual-compact .compact-presets .preset-btn{
+    min-height: 34px !important;
+    padding: 6px 8px !important;
+    font-size: 13px !important;
+    line-height: 1.05 !important;
+  }
+
+  #search .manual-compact .station-swap{ padding: 8px 10px !important; min-height: 84px !important; }
+  #search .manual-compact .station-fields{ padding-right: 58px !important; }
+  #search .manual-compact .station-row{ padding: 3px 0 !important; }
+  #search .manual-compact .station-label{ font-size: 11px !important; }
+  #search .manual-compact .station-search,
+  #search .manual-compact .station-input{
+    height: 32px !important;
+    padding: 6px 9px !important;
+    font-size: 16px !important;
+  }
+  #search .manual-compact .swap-btn--center{
+    width: 34px !important;
+    height: 34px !important;
+    right: 10px !important;
+  }
+
+  #search .manual-compact .date-picker-wrap,
+  #search .manual-compact .filters-date-time{ gap: 6px !important; }
+  #search .manual-compact .time-range label,
+  #search .manual-compact .field-caption{ font-size: 11px !important; }
+
+  #search .manual-compact .time-slider{ margin-top: 6px !important; }
+  #search .manual-compact .time-values{ margin-top: 4px !important; font-size: 12px !important; }
+  #search .manual-compact .filters-options{ gap: 6px !important; }
+  #search .manual-compact .option-toggle{
+    padding: 6px 8px !important;
+    min-height: 30px !important;
+  }
+  #search .manual-compact .option-toggle span{ font-size: 11px !important; }
+
+  #search .manual-compact .actions-main{ margin-top: 8px !important; }
+  #search .manual-compact .proposer-btn,
+  #search #btnProposer{ min-height: 36px !important; padding: 8px 10px !important; font-size: 13px !important; }
+}
+
 /* ===== PATCH smartphone 2026-03-02: tableau full height + console plus pro ===== */
 @media (max-width: 768px){
   #trainInfo .table-scroll{
@@ -9048,31 +9318,38 @@ html, body{
   backdrop-filter: blur(10px);
   gap: 6px;
 }
-#tableauViewNav .tableau-view-tab{
+#tableauViewNav .tableau-view-tab,
+#loisirsViewNav .tableau-view-tab{
   flex:1 1 0;
   min-width:0;
   margin:0 !important;
-  padding: 7px 6px !important;
-  border-radius: 10px;
-  border: 1px solid rgba(0, 240, 255, 0.24);
-  background: rgba(0, 12, 24, 0.55);
+  padding: 8px 7px !important;
+  border-radius: 12px;
+  border: 1px solid rgba(90, 235, 255, 0.34);
+  background: linear-gradient(160deg, rgba(6,24,38,.86), rgba(4,16,30,.8));
   color:#dffbff;
-  font-size: .70rem !important;
+  font-size: .72rem !important;
   font-weight: 700;
   letter-spacing: .02em;
-  line-height: 1.15;
+  line-height: 1.08;
+  text-align:center;
   max-width:none !important;
+  box-shadow: inset 0 1px 0 rgba(170,245,255,.12), inset 0 -10px 22px rgba(0,180,220,.10), 0 2px 10px rgba(0,0,0,.25);
+  transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
 }
-#tableauViewNav .tableau-view-tab.is-active{
-  border-color: rgba(0, 240, 255, 0.65);
-  background: linear-gradient(135deg, rgba(0,255,255,.86), rgba(0,170,255,.86));
+#tableauViewNav .tableau-view-tab:hover,
+#loisirsViewNav .tableau-view-tab:hover{
+  border-color: rgba(120, 245, 255, 0.55);
+  transform: translateY(-1px);
+}
+#tableauViewNav .tableau-view-tab.is-active,
+#loisirsViewNav .tableau-view-tab.is-active{
+  border-color: rgba(0, 240, 255, 0.85);
+  background: linear-gradient(135deg, rgba(0,255,255,.94), rgba(0,190,255,.90));
   color:#00111a;
-  box-shadow: 0 0 14px rgba(0,240,255,.45), inset 0 0 14px rgba(0,240,255,.35);
+  box-shadow: 0 0 0 1px rgba(170,255,255,.38) inset, 0 0 16px rgba(0,240,255,.45), inset 0 0 12px rgba(0,220,255,.28);
 }
-#tableauViewNav .tableau-view-tab--search{
-  font-weight: 800;
-  letter-spacing: .03em;
-}
+#tableauViewNav .tableau-view-tab--search{ font-weight: 800; letter-spacing: .03em; }
 @media (max-width: 768px){
   body.tableau-view-nav-visible{ --tableau-viewbar-h: 64px; }
   #tableauViewNav.is-visible{
@@ -9104,16 +9381,6 @@ html, body{
   box-shadow: 0 8px 24px rgba(0, 240, 255, 0.16);
   backdrop-filter: blur(10px);
   gap: 6px;
-}
-#loisirsViewNav .tableau-view-tab{
-  flex:1 1 0;
-  min-width:0;
-}
-#loisirsViewNav .tableau-view-tab.is-active{
-  border-color: rgba(0, 240, 255, 0.65);
-  background: linear-gradient(135deg, rgba(0,255,255,.86), rgba(0,170,255,.86));
-  color:#00111a;
-  box-shadow: 0 0 14px rgba(0,240,255,.45), inset 0 0 14px rgba(0,240,255,.35);
 }
 @media (max-width: 768px){
   #loisirsViewNav.is-visible{
@@ -9202,6 +9469,14 @@ html, body{
       <iframe src="https://www.youtube.com/embed/4O_aCit0OW8" title="Bétaillère vidéo 5" allowfullscreen></iframe>
     </div>
   </div>
+</section>
+
+<section id="jeuContainer" class="media-section" aria-label="Jeu">
+  <h2>Jeu</h2>
+  <div class="map-embed-shell">
+    <iframe id="jeuFrame" title="Jeu Bétaillère" src="about:blank" loading="lazy" referrerpolicy="no-referrer"></iframe>
+  </div>
+  <a id="jeuFallbackLink" href="/jeuBETA.html" target="_blank" rel="noopener" style="display:none;position:absolute;right:10px;top:10px;z-index:2;font-size:.72rem;padding:6px 10px;border-radius:999px;background:rgba(0,0,0,.45);border:1px solid rgba(0,240,255,.35);color:#dffbff;text-decoration:none;">Ouvrir le jeu ↗</a>
 </section>
 
 <!-- Console Statistiques -->
@@ -9547,14 +9822,6 @@ html, body{
   </details>
 </div>
 
-<!-- Bouton don -->
-<div style="text-align: center;">
-  <a href="https://buymeacoffee.com/labetaillere"
-     class="bouton-don" target="_blank" rel="noopener noreferrer">
-     ☕ Soutenir le projet
-  </a>
-</div>
-
 <div id="presetBuilderModal" class="lb-auth-modal" aria-hidden="true">
   <div class="lb-auth-card" role="dialog" aria-modal="true" aria-labelledby="presetBuilderTitle">
     <button id="presetBuilderClose" class="lb-auth-close tron-close-button" type="button" aria-label="Fermer"></button>
@@ -9580,34 +9847,6 @@ html, body{
   </div>
 </div>
 
-   <div style="font-size: 0.9em; line-height: 1.6; border-top: 1px solid #ccc; margin-top: 1em; padding-top: 0.5em;"></div>
-  
-<!-- CONTENEUR BAS -->
-<div id="bottom-bar" style="display: flex; align-items: center; justify-content: space-between; gap: 20px; margin-top: 2em; flex-wrap: wrap;">
-
-  <div id="liens-utiles" style="flex: 1; min-width: 80px;">
-    <h3>Liens utiles</h3>
-    <ul>
-      <li><a href="https://www.cfl.lu/fr-fr" target="_blank">CFL</a></li>
-      <li><a href="https://www.ter.sncf.com/grand-est" target="_blank">TER GRAND EST</a></li>
-      <li><a href="https://www.sncf-connect.com/" target="_blank">SNCF CONNECT</a></li>
-    </ul>
-  </div>
-
-  <!-- Vidéo YouTube au centre -->
-  <div id="video-center" style="flex: 2; min-width: 200px; text-align: center;">
-    <iframe
-      width="288" height="162"
-      src="https://www.youtube.com/embed/rWFDBMcNTL8?controls=1&rel=0&modestbranding=1"
-      title="Bétail TER"
-      frameborder="0"
-      allow="autoplay; encrypted-media"
-      allowfullscreen
-      style="border-radius: 8px;"
-    ></iframe>
-  </div>
-
-</div>
 
 <div class="footer-counter-wrapper">
   <div id="compteur-visites" class="footer-counter" aria-live="polite">Visites : ...</div>
@@ -9618,18 +9857,6 @@ html, body{
   <a href="/confidentialite.html">Politique de confidentialité</a>
 </div>
 
-<div style="font-size: 0.7em; line-height: 1.4; border-top: 1px solid #ccc; margin-top: 0.5em; padding-top: 0.5em;">
-  <h3 style="font-size:1em; margin-bottom: 0.5em;">📘 Légende du tableau des bétaillères </h3>
-  <ul style="list-style: disc; margin-left: 1.2em; padding-left: 0.5em;">
-    <li><span style="color:#7CFF4D; font-weight:bold;">Train en UM3</span> : Unité Multiple 3 rames, Z24500</li>
-    <li><span style="color: #00f0ff; font-weight: bold;">Train en UM</span> : Unité Multiple 2 rames, Z24500</li>
-    <li><span style="color: #bf00ff; font-weight: bold;">Train en US</span> : Unité Simple 1 rame, Z24500</li>
-    <li><span class="deleted">Texte barré en rouge</span> : arrêt supprimé ou train totalement supprimé ( SNCF)</li>
-    <li><span class="delay-strike">Horaire barré</span> puis <span class="retard">horaire orange</span> : retard  SNCF ou GTFS-RT (éphémère) </li>
-    <li><span class="new-start">Texte bleu gras</span> : nouvelle gare de départ/terminus (suppression partielle)</li>
-  </ul>
-  <p style="margin-top: 0.5em;"><strong>Sources :</strong>  SNCF, GTFS & GTFS-RT</p>
-</div>
 
   <!-- Modale Blague (popup interne responsive) -->
   <div id="modalBlague" style="display:none; position:fixed; top:50%; left:50%; transform: translate(-50%, -50%);
@@ -9642,7 +9869,7 @@ html, body{
   <div id="fondModal" style="display:none; position:fixed; top:0; left:0; width:100vw; height:100vh; background:rgba(0,0,0,0.5); z-index:999;"></div>
 
   <!-- LICENCE -->
-<div style="text-align: center; font-size: 0.8em; margin-top: 3em; padding: 1em 10px; color: #88ffff; background: linear-gradient(145deg, #11151f, #080c14); border-top: 1px solid #00ffff;">
+<div id="siteLicense" style="text-align: center; font-size: 0.8em; margin-top: 3em; padding: 1em 10px; color: #88ffff; background: linear-gradient(145deg, #11151f, #080c14); border-top: 1px solid #00ffff;">
   <p style="margin: 0.5em 0;">
     © 2024-2025 <strong>TekMate Lux</strong> – Tous droits réservés.<br>
     Ce projet est sous licence 
@@ -9691,9 +9918,8 @@ if (container && !container.querySelector('.disruption-box')) {
     
  let mainTableRendered = false;   
 
-/* ---------- BOUTON BLAGUES ---------- */
-$('#btnBingo').click(function() {
-  const blagues = [
+/* ---------- PHRASES BINGO (source unique) ---------- */
+window.phrasesBingo = [
     "Le retard du train ? Le conducteur a fait une pause café... trop longue ! ☕️😄",
     "Pourquoi le train est en retard ? Il a pris le temps de saluer les vaches au bord des rails 🐄🚂",
     "La cause du retard : un troupeau de canards traverse la voie. Coin coin ! 🦆🛤️",
@@ -9742,16 +9968,8 @@ $('#btnBingo').click(function() {
     "Le train a fait un arrêt non prévu... pour un pique-nique improvisé ! 🧺🚄",
     "Le conducteur a voulu tester un nouveau chemin, ça a pris un peu plus de temps. 🗺️🚆",
     "Le train attendait un passager VIP... qui a pris son temps ! 👑🚂"
-  ];
-  const blague = blagues[Math.floor(Math.random() * blagues.length)];
-  $('#texteBlague').text(blague);
-  $('#modalBlague').fadeIn();
-  $('#fondModal').fadeIn();
-});
-$('#fermerBlague, #fondModal').click(function() {
-  $('#modalBlague').fadeOut();
-  $('#fondModal').fadeOut();
-});
+];
+
 
 // ===== Numéro de train : 5 ou 6 chiffres =====
 function extractTrainNumber(s){
@@ -18527,6 +18745,144 @@ function scheduleWeatherAfterTableSettled(){
     return data;
   };
 
+  const LB_COMMENTS_STORAGE_KEY = 'lb_comments_v1';
+  const lbCommentsChannel = ('BroadcastChannel' in window) ? new BroadcastChannel('lb_comments_channel') : null;
+  let lbCommentState = { wall: [], trains: {} };
+  let lbCurrentDetailTrain = '';
+
+  const safePseudo = () => String(lbPrefsCache?.pseudo || '').trim().slice(0,24);
+  const isCommentingAllowed = () => window.lbIsAuthed === true && !!safePseudo();
+
+  function loadCommentState(){
+    try{
+      const raw = localStorage.getItem(LB_COMMENTS_STORAGE_KEY);
+      if (!raw) return { wall: [], trains: {} };
+      const js = JSON.parse(raw);
+      if (!js || typeof js !== 'object') return { wall: [], trains: {} };
+      return {
+        wall: Array.isArray(js.wall) ? js.wall : [],
+        trains: (js.trains && typeof js.trains === 'object') ? js.trains : {}
+      };
+    }catch(e){
+      return { wall: [], trains: {} };
+    }
+  }
+
+  function saveCommentState(){
+    try{ localStorage.setItem(LB_COMMENTS_STORAGE_KEY, JSON.stringify(lbCommentState)); }catch(e){}
+    try{ lbCommentsChannel?.postMessage({ type: 'sync' }); }catch(e){}
+  }
+
+  function getTrainComments(trainNumber){
+    const key = String(trainNumber || '').trim();
+    if (!key) return [];
+    const list = lbCommentState?.trains?.[key];
+    return Array.isArray(list) ? list.slice().sort((a,b)=>(b.ts||0)-(a.ts||0)) : [];
+  }
+
+  function getTrainCommentCount(trainNumber){
+    return getTrainComments(trainNumber).length;
+  }
+
+  function addComment({ text, trainNumber = '' }){
+    const pseudo = safePseudo();
+    if (!isCommentingAllowed()) throw new Error('Connexion + pseudo requis');
+    const msg = String(text || '').trim().slice(0,180);
+    if (!msg) throw new Error('Commentaire vide');
+    const train = String(trainNumber || '').trim();
+    const item = {
+      id: `${Date.now()}_${Math.random().toString(36).slice(2,8)}`,
+      pseudo,
+      text: msg,
+      trainNumber: train,
+      ts: Date.now()
+    };
+    lbCommentState.wall = [item, ...(lbCommentState.wall || [])].slice(0,60);
+    if (train){
+      const arr = Array.isArray(lbCommentState.trains[train]) ? lbCommentState.trains[train] : [];
+      lbCommentState.trains[train] = [item, ...arr].slice(0,120);
+    }
+    saveCommentState();
+    renderCommentsUI();
+    return item;
+  }
+
+  const fmtHour = (ts) => {
+    try{ return new Date(ts || Date.now()).toLocaleTimeString('fr-FR', { hour:'2-digit', minute:'2-digit' }); }
+    catch(e){ return '—'; }
+  };
+
+  function renderHomeLiveWall(){
+    const feed = $('homeLiveWallFeed');
+    const form = $('homeLiveWallForm');
+    const cta = $('homeLiveWallCta');
+    if (!feed || !form || !cta) return;
+    const wall = Array.isArray(lbCommentState.wall) ? lbCommentState.wall.slice(0,12) : [];
+    if (!wall.length) {
+      feed.innerHTML = '<div class="live-wall-empty">Aucun commentaire pour le moment.</div>';
+    } else {
+      feed.innerHTML = wall.map((it) => `
+        <div class="live-wall-item">
+          <div class="live-wall-meta"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span>${fmtHour(it.ts)}</span>${it.trainNumber ? `<span>#${escapeHtml(it.trainNumber)}</span>` : ''}</div>
+          <div>${escapeHtml(it.text || '')}</div>
+        </div>
+      `).join('');
+    }
+    const can = isCommentingAllowed();
+    form.style.display = can ? 'flex' : 'none';
+    cta.style.display = can ? 'none' : 'block';
+    if (!window.lbIsAuthed) cta.textContent = 'Connectez-vous pour commenter en direct.';
+    else if (!safePseudo()) cta.textContent = 'Ajoutez un pseudo dans Mes préférences pour commenter.';
+  }
+
+  function renderTrainComments(trainNumber){
+    const listEl = $('trainDetailCommentsList');
+    const countEl = $('trainDetailCommentsCount');
+    const form = $('trainDetailCommentsForm');
+    if (!listEl || !countEl || !form) return;
+    const train = String(trainNumber || lbCurrentDetailTrain || '').trim();
+    const comments = getTrainComments(train).slice(0,30);
+    countEl.textContent = String(comments.length);
+    listEl.innerHTML = comments.length
+      ? comments.map((it)=>`<div class="train-comments-item"><div class="live-wall-meta"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span>${fmtHour(it.ts)}</span></div><div>${escapeHtml(it.text || '')}</div></div>`).join('')
+      : '<div class="live-wall-empty">Pas encore de commentaire sur ce train.</div>';
+    form.style.display = isCommentingAllowed() ? 'flex' : 'none';
+  }
+
+  function updateCommentButtons(){
+    ['AM','PM'].forEach((k)=>{
+      const btn = $(k === 'AM' ? 'favCommentsBtnAM' : 'favCommentsBtnPM');
+      const trainText = ($(k === 'AM' ? 'favTrainAM' : 'favTrainPM')?.textContent || '').match(/\d{5,6}/);
+      const train = trainText ? trainText[0] : '';
+      if (!btn) return;
+      if (!train){
+        btn.textContent = '💬 0 commentaire';
+        btn.disabled = true;
+        return;
+      }
+      btn.disabled = false;
+      const c = getTrainCommentCount(train);
+      btn.textContent = `💬 ${c} commentaire${c>1?'s':''}`;
+      btn.dataset.train = train;
+    });
+  }
+
+  function renderCommentsUI(){
+    renderHomeLiveWall();
+    renderTrainComments(lbCurrentDetailTrain);
+    updateCommentButtons();
+    try { if (typeof lbRenderHomeFavPreview === 'function' && window.lbIsAuthed === true) lbRenderHomeFavPreview(); } catch(e) {}
+  }
+
+  window.lbComments = {
+    setCurrentTrain(trainNumber){
+      lbCurrentDetailTrain = String(trainNumber || '').trim();
+      renderTrainComments(lbCurrentDetailTrain);
+    },
+    refresh(){ renderCommentsUI(); },
+    count(trainNumber){ return getTrainCommentCount(trainNumber); }
+  };
+
   const openModal = () => {
     const modal = $("lbAuthModal");
     if (!modal) return;
@@ -18566,10 +18922,21 @@ function scheduleWeatherAfterTableSettled(){
     window.lbPrefsCache = lbPrefsCache;
 
     // Remplir les champs favoris dans la modale Préférences
+    const pseudoInput = $("lbPseudo");
     const favAM = $("lbFavMorning");
     const favPM = $("lbFavEvening");
+    if (pseudoInput) pseudoInput.value = (prefs.pseudo || "").trim();
     if (favAM) favAM.value = prefs.favoriteMorningTrain || "";
     if (favPM) favPM.value = prefs.favoriteEveningTrain || "";
+    try{
+      const line = document.getElementById('homeWelcomeLine');
+      if (line){
+        const pseudo = String(prefs.pseudo || '').trim();
+        line.textContent = pseudo
+          ? `Bienvenue ${pseudo} dans votre bétaillère Nancy–Metz–Lux 👋`
+          : 'Bienvenue 🐮 dans votre bétaillère Nancy–Metz–Lux 👋';
+      }
+    }catch(e){}
     // Gare favorite (départ/arrivée) -> utilisée comme valeur par défaut dans l'onglet Affluence
     const favFrom = $("lbFavFromStation");
     const favTo   = $("lbFavToStation");
@@ -18597,21 +18964,9 @@ function scheduleWeatherAfterTableSettled(){
 
     // Rafraîchir le widget favoris
     try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
+    try { renderCommentsUI(); } catch(e) {}
 
-    const defaultMode = String(prefs.defaultMode || '').toUpperCase();
-    const autoLoad = !!prefs.autoLoad;
     if (!options.auto) return;
-    if (!lbPrefsAppliedOnce && defaultMode) {
-      const kind = defaultMode === 'SOIR' ? 'PM' : (defaultMode === 'MATIN' ? 'AM' : defaultMode);
-      if (['AM', 'PM', 'L3', 'L4'].includes(kind)) {
-        applyRapidPreset(kind, { auto: true, openModal: false, focus: false });
-        if (autoLoad) {
-          const trigger = document.querySelector(`.preset-btn[data-preset-kind="${kind}"]`);
-          if (trigger) trigger.classList.add('is-active');
-        }
-      }
-      lbPrefsAppliedOnce = true;
-    }
   };
 
   const loadPreferences = async () => {
@@ -19455,12 +19810,16 @@ function getGtfsDelayForStop(trainNumber, stopName){
 
     if (!trainId){
       meta.textContent = '➡️ Choisis un train dans tes préférences.';
+      if (card) card.dataset.train = '';
+      updateCommentButtons();
       if (statsEl){ statsEl.open = false; }
       return;
     }
+    if (card) card.dataset.train = String(trainId || '');
 
     if (payload?.error){
       meta.textContent = `🚫 ${payload.error}`;
+      updateCommentButtons();
       if (statsEl){
         renderFavStats(kind, trainId).catch(()=>{});
         if (!statsEl.hasAttribute('data-user-opened')) statsEl.open = false;
@@ -19471,6 +19830,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
     const train = payload?.train;
     if (!train){
       meta.textContent = '🚫 Données indisponibles.';
+      updateCommentButtons();
       return;
     }
 
@@ -19534,6 +19894,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
         renderFavStats(kind, trainId).catch(()=>{});
         if (!statsEl.hasAttribute('data-user-opened')) statsEl.open = false;
       }
+      updateCommentButtons();
       return;
     }
 
@@ -19653,6 +20014,7 @@ if (statsEl){
       renderFavStats(kind, trainId).catch(()=>{});
       if (!statsEl.hasAttribute('data-user-opened')) statsEl.open = false;
     }
+    updateCommentButtons();
   };
   // Clic sur "Détail" dans l'affluence des favoris -> ouvre la section Affluence + détail du train
   if (!window.__lbFavAffOpenBound){
@@ -19724,6 +20086,14 @@ if (statsEl){
 
   let favWidgetTimer = null;
 
+  function shouldShowFavoritesWidget(){
+    if (window.lbIsAuthed !== true) return false;
+    const body = document.body;
+    if (body?.classList?.contains('page-favoris')) return true;
+    const hash = String(location.hash || '').toLowerCase();
+    return hash === '#favoris' || hash === '#favtrainswidget';
+  }
+
   window.updateFavoriteWidgetFromPrefs = async () => {
     const root = document.getElementById('favTrainsWidget');
     if (!root) return;
@@ -19735,7 +20105,7 @@ if (statsEl){
       return;
     }
 
-    root.style.display = 'block';
+    root.style.display = shouldShowFavoritesWidget() ? 'block' : 'none';
     try{ if (typeof ensureFavInHome==='function') ensureFavInHome(); }catch(e){}
 
     // S'assurer que les retards GTFS-RT sont chargés (même source que le tableau)
@@ -19818,6 +20188,7 @@ if (statsEl){
       msg(`✅ Connecté : ${me?.user?.email || "utilisateur"}`);
       await loadPreferences();
       try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") await window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
+      try { renderCommentsUI(); } catch(e) {}
     } catch {
       openBtn.textContent = "Se connecter";
       logoutBtn.style.display = "none";
@@ -19841,7 +20212,12 @@ if (statsEl){
       }
       lbPrefsCache = null;
       window.lbPrefsCache = null;
+      try {
+        const line = document.getElementById('homeWelcomeLine');
+        if (line) line.textContent = 'Bienvenue 🐮 dans votre bétaillère Nancy–Metz–Lux 👋';
+      } catch(e) {}
       try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
+      try { renderCommentsUI(); } catch(e) {}
       lbPrefsAppliedOnce = false;
       customRapidPresets.AM = null;
       customRapidPresets.PM = null;
@@ -19856,8 +20232,9 @@ if (statsEl){
       }
       msg("ℹ️ Non connecté");
     }
-    updateQuickAddButton();
-    updateSelectionApplyButton();
+  updateQuickAddButton();
+  updateSelectionApplyButton();
+  renderCommentsUI();
   };
 
   const openBtn = $("lbBtnOpenAuth");
@@ -19885,7 +20262,49 @@ if (statsEl){
   const deleteLink = $("lbDeleteLink");
   const switchBtn = $("lbAuthSwitchBtn");
 
+  lbCommentState = loadCommentState();
+  try{
+    lbCommentsChannel?.addEventListener('message', () => {
+      lbCommentState = loadCommentState();
+      renderCommentsUI();
+    });
+  }catch(e){}
+  window.addEventListener('storage', (ev) => {
+    if (ev.key !== LB_COMMENTS_STORAGE_KEY) return;
+    lbCommentState = loadCommentState();
+    renderCommentsUI();
+  });
+
   if (!openBtn || !closeBtn || !modal || !submitBtn || !logoutBtn) return;
+
+  $('homeLiveWallForm')?.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const input = $('homeLiveWallInput');
+    if (!input) return;
+    const raw = String(input.value || '').trim();
+    const trainMatch = raw.match(/#?(\d{5,6})/);
+    const train = trainMatch ? trainMatch[1] : '';
+    try{ addComment({ text: raw, trainNumber: train }); input.value = ''; }
+    catch(err){ alert(String(err?.message || err)); }
+  });
+
+  $('trainDetailCommentsForm')?.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const input = $('trainDetailCommentsInput');
+    if (!input || !lbCurrentDetailTrain) return;
+    try{ addComment({ text: input.value, trainNumber: lbCurrentDetailTrain }); input.value = ''; }
+    catch(err){ alert(String(err?.message || err)); }
+  });
+
+  ['favCommentsBtnAM','favCommentsBtnPM'].forEach((id) => {
+    $(id)?.addEventListener('click', () => {
+      const train = String($(id)?.dataset.train || '');
+      if (!train || typeof window.lbOpenTrainDetail !== 'function') return;
+      const dt = document.getElementById('trainDate')?.value || luxTodayYMD();
+      window.lbOpenTrainDetail(train, dt);
+      setTimeout(() => $('trainDetailCommentsInput')?.focus(), 120);
+    });
+  });
 
   openBtn.addEventListener("click", openModal);
   closeBtn.addEventListener("click", closeModal);
@@ -20024,9 +20443,14 @@ if (statsEl){
   };
 
   const getNextOptionalPresetKey = () => {
-    const candidate = PREFS_LIST_CONFIG.filter((item) => item.optional)
-      .find(({ key }) => !presetHasContent(customRapidPresets[key]));
-    return candidate?.key || null;
+    const optional = PREFS_LIST_CONFIG.filter((item) => item.optional);
+    for (const { key } of optional) {
+      const fields = getPresetFields(key);
+      if (!fields?.section) continue;
+      const hidden = getComputedStyle(fields.section).display === 'none';
+      if (hidden) return key;
+    }
+    return null;
   };
 
   const hasHiddenOptionalPreset = () => Boolean(getNextOptionalPresetKey());
@@ -20105,20 +20529,12 @@ if (statsEl){
     prefsModal.style.display = "flex";
     prefsModal.setAttribute("aria-hidden", "false");
     if (!options.skipLoad) {
-      const defaultMode = $("lbDefaultMode");
-      const autoLoad = $("lbAutoLoad");
       PREFS_LIST_CONFIG.forEach(({ key }) => {
         const fields = getPresetFields(key);
         const preset = getPresetFromCache(key) || {};
         if (fields?.label) fields.label.value = preset?.label || "";
         if (fields?.trains) fields.trains.value = (preset?.trains || []).join(", ");
       });
-      if (defaultMode) {
-        const rawDefault = String(lbPrefsCache?.defaultMode || "").toUpperCase();
-        const mapped = rawDefault === "MATIN" ? "AM" : (rawDefault === "SOIR" ? "PM" : rawDefault);
-        defaultMode.value = mapped;
-      }
-      if (autoLoad) autoLoad.checked = !!lbPrefsCache?.autoLoad;
       syncOptionalPrefsSections();
       updateDefaultListOptions();
       updatePrefsAddButton();
@@ -20308,9 +20724,6 @@ if (statsEl){
 
   if (prefsSaveBtn) {
     prefsSaveBtn.addEventListener("click", async () => {
-      const defaultMode = $("lbDefaultMode");
-      const autoLoad = $("lbAutoLoad");
-
       const payloadPresets = {};
       for (const item of PREFS_LIST_CONFIG) {
         const fields = getPresetFields(item.key);
@@ -20331,13 +20744,13 @@ if (statsEl){
         };
       }
 
+      const pseudo = ($("lbPseudo")?.value || "").trim().slice(0,24);
       const favMorning = $("lbFavMorning")?.value?.trim() || "";
       const favEvening = $("lbFavEvening")?.value?.trim() || "";
 
       const payload = {
         rapidPresets: payloadPresets,
-        defaultMode: defaultMode?.value || "",
-        autoLoad: !!autoLoad?.checked,
+        pseudo,
         favoriteMorningTrain: favMorning,
         favoriteEveningTrain: favEvening,
         favoriteFromStation: (document.getElementById('lbFavFromStation')?.value || '').trim(),
@@ -20489,6 +20902,7 @@ if (statsEl){
   }
   
   setMode("login");
+  renderCommentsUI();
   refreshAccountUI();
 })();
 // Compteur de visites labetaillere.fr
@@ -20514,7 +20928,7 @@ if (statsEl){
     const key = 'lbCookieConsent';
     let consent = null;
     try {
-      consent = localStorage.getItem(key);
+      consent = localStorage.getItem(key) || sessionStorage.getItem(key);
     } catch (err) {
       console.warn('Impossible de lire le consentement cookies', err);
     }
@@ -20524,17 +20938,20 @@ if (statsEl){
     banner.setAttribute('aria-hidden', 'false');
     const accept = banner.querySelector('.cookie-accept');
     const close = banner.querySelector('.cookie-decline');
+    const closeTop = banner.querySelector('.cookie-banner__close');
     const dismiss = (value) => {
       try {
         localStorage.setItem(key, value);
       } catch (err) {
         console.warn('Impossible de stocker le consentement cookies', err);
+        try { sessionStorage.setItem(key, value); } catch(_){}
       }
       banner.hidden = true;
       banner.setAttribute('aria-hidden', 'true');
     };
     if (accept) accept.addEventListener('click', () => dismiss('accepted'));
     if (close) close.addEventListener('click', () => dismiss('dismissed'));
+    if (closeTop) closeTop.addEventListener('click', () => dismiss('dismissed'));
   };
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initCookieBanner);
@@ -21306,6 +21723,9 @@ function lbRenderHomeFavPreview(){
 
   const buildRow = (k, data, label) => {
     const trainTxt = data.train && data.train !== '—' ? data.train : '—';
+    const trainMatch = String(trainTxt).match(/\d{5,6}/);
+    const trainNo = trainMatch ? trainMatch[0] : '';
+    const cc = trainNo ? getTrainCommentCount(trainNo) : 0;
     const metaTxt  = data.meta && data.meta !== '—' ? data.meta : '';
     const safeMeta = metaTxt ? escapeHtml(metaTxt) : '<span style="opacity:.55">—</span>';
 
@@ -21316,6 +21736,7 @@ function lbRenderHomeFavPreview(){
           <div class="home-fav-meta">${safeMeta}</div>
         </div>
         <div class="fav-train-badge home-fav-badge">${renderBadge(data.state)}</div>
+        <button type="button" class="home-comment-pill" data-train-comment="${trainNo}">💬 ${cc}</button>
       </div>
     `;
   };
@@ -21373,6 +21794,14 @@ function lbRenderHomeFavPreview(){
     const k = row.getAttribute('data-fav-k');
     row.addEventListener('click', ()=>jumpToFav(k));
     row.addEventListener('keydown', (e)=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); jumpToFav(k);} });
+  });
+  slot.querySelectorAll('.home-comment-pill').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const train = String(btn.dataset.trainComment || '');
+      if (!train || typeof window.lbOpenTrainDetail !== 'function') return;
+      window.lbOpenTrainDetail(train, document.getElementById('trainDate')?.value || luxTodayYMD());
+    });
   });
 }
 
@@ -22423,6 +22852,7 @@ async function loadAffluenceDate(dateStr){
     const statsBtn = document.getElementById('trainDetailStatsBtn');
 
     panel.hidden = false;
+    try { window.lbComments?.setCurrentTrain(String(trainNumber || '')); } catch(e) {}
     titleEl.textContent = `Train ${trainNumber}`;
     nextEl.textContent = 'Chargement…';
     relEl.textContent = 'Chargement…';
@@ -22509,8 +22939,25 @@ async function loadAffluenceDate(dateStr){
       };
     }
 
-    panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    if (document.body.classList.contains('page-search')) {
+      panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
   }
+
+  window.lbOpenTrainDetail = openInternalTrainPanel;
+
+  window.addEventListener('message', (ev) => {
+    const d = ev && ev.data;
+    if (!d || d.type !== 'lb:open-train-detail') return;
+    const raw = String(d.trainNumber || '').match(/\d{5,6}/);
+    if (!raw) return;
+    const dateIso = /^\d{4}-\d{2}-\d{2}$/.test(String(d.dateIso || ''))
+      ? String(d.dateIso)
+      : (/^\d{8}$/.test(String(d.dateYmd || ''))
+          ? `${String(d.dateYmd).slice(0,4)}-${String(d.dateYmd).slice(4,6)}-${String(d.dateYmd).slice(6,8)}`
+          : (document.getElementById('trainDate')?.value || luxTodayYMD()));
+    openInternalTrainPanel(raw[0], dateIso);
+  });
 
   document.addEventListener('click', (e) => {
     const a = e.target.closest && e.target.closest('#trainInfo a.train-link');
@@ -22525,7 +22972,11 @@ async function loadAffluenceDate(dateStr){
   document.addEventListener('DOMContentLoaded', () => {
     const closeBtn = document.getElementById('trainDetailClose');
     const panel = document.getElementById('trainDetailPanel');
-    if (closeBtn && panel) closeBtn.addEventListener('click', () => { panel.hidden = true; destroyAffChart(); });
+    if (closeBtn && panel) closeBtn.addEventListener('click', () => {
+      panel.hidden = true;
+      destroyAffChart();
+      try { window.lbComments?.setCurrentTrain(''); } catch(e) {}
+    });
   });
 })();
 
@@ -22718,12 +23169,70 @@ async function loadAffluenceDate(dateStr){
   const nav = document.getElementById('loisirsViewNav');
   const loisirsLink = document.querySelector('.bottom-nav__item[href="#loisirs"]');
   const multimediaSection = document.getElementById('multimedia');
-  const bingoBtn = document.getElementById('btnBingo');
-  const jeuBtn = document.getElementById('btnJeu');
+  const jeuSection = document.getElementById('jeuContainer');
+  const jeuFrame = document.getElementById('jeuFrame');
+  const jeuFallbackLink = document.getElementById('jeuFallbackLink');
+  const modalBlague = document.getElementById('modalBlague');
+  const fondModal = document.getElementById('fondModal');
+  const texteBlague = document.getElementById('texteBlague');
+  const fermerBlague = document.getElementById('fermerBlague');
   if (!nav || !loisirsLink || !multimediaSection) return;
 
   const tabs = Array.from(nav.querySelectorAll('[data-loisirs-view]'));
   const onLoisirsTab = () => ['#loisirs', '#divertissement', '#multimedia'].includes(location.hash || '');
+
+  const gameUrl = '/jeuBETA.html';
+  let gameLoaded = false;
+  let currentLoisirsView = 'multimedia';
+  if (jeuFrame){
+    jeuFrame.addEventListener('load', () => {
+      gameLoaded = true;
+      if (jeuFallbackLink) jeuFallbackLink.style.display = 'none';
+    });
+  }
+
+  const bingoFallback = [
+    "Bingo du jour : retard mystère, correspondance sportive et quai surprise. 🎯",
+    "Bingo TER : signalisation, météo, puis arrivée en héros. 🚆",
+    "Bingo validé : un train à l'heure, c'est un jackpot ! ⭐",
+    "Bingo express : quai modifié, train annoncé, suspense total. 🎲",
+    "Bingo frontaliers : correspondance réussie à la seconde près ! 🕒"
+  ];
+  let lastBingoLine = '';
+
+  function pickBingoLine(){
+    try {
+      if (Array.isArray(window.phrasesBingo) && window.phrasesBingo.length > 1) {
+        let candidate = window.phrasesBingo[Math.floor(Math.random() * window.phrasesBingo.length)];
+        if (candidate === lastBingoLine) {
+          candidate = window.phrasesBingo[(Math.floor(Math.random() * (window.phrasesBingo.length - 1)) + 1) % window.phrasesBingo.length];
+        }
+        lastBingoLine = candidate;
+        return candidate;
+      }
+    } catch(e){ console.warn('[loisirs bingo] random fallback', e); }
+    let candidate = bingoFallback[Math.floor(Math.random() * bingoFallback.length)];
+    if (candidate === lastBingoLine && bingoFallback.length > 1) {
+      candidate = bingoFallback[(bingoFallback.indexOf(candidate) + 1) % bingoFallback.length];
+    }
+    lastBingoLine = candidate;
+    return candidate;
+  }
+
+  function showBingoModal(){
+    if (!modalBlague || !fondModal || !texteBlague) return;
+    texteBlague.textContent = pickBingoLine();
+    modalBlague.style.display = 'block';
+    fondModal.style.display = 'block';
+  }
+
+  function hideBingoModal(){
+    if (modalBlague) modalBlague.style.display = 'none';
+    if (fondModal) fondModal.style.display = 'none';
+  }
+
+  fermerBlague?.addEventListener('click', hideBingoModal);
+  fondModal?.addEventListener('click', hideBingoModal);
 
   function activate(view){
     tabs.forEach(tab => {
@@ -22731,17 +23240,75 @@ async function loadAffluenceDate(dateStr){
       tab.classList.toggle('is-active', active);
       tab.setAttribute('aria-selected', active ? 'true' : 'false');
     });
+    currentLoisirsView = view;
+  }
+
+  function setJeuFullscreen(active){
+    document.body.classList.toggle('jeu-fullscreen', active);
+  }
+
+  function setJeuActive(active){
+    document.body.classList.toggle('loisirs-jeu-active', active);
+    if (!active && jeuSection) jeuSection.style.display = 'none';
+  }
+
+  function stopEmbeddedGame(){
+    if (!jeuFrame) return;
+    try {
+      const w = jeuFrame.contentWindow;
+      const d = jeuFrame.contentDocument;
+      const audio = d && d.getElementById ? d.getElementById('gameMusic') : null;
+      if (audio && typeof audio.pause === 'function') {
+        audio.pause();
+        try { audio.currentTime = 0; } catch(_) {}
+      }
+      if (w && typeof w.postMessage === 'function') {
+        w.postMessage({ type: 'lb:game:stop-audio' }, '*');
+      }
+    } catch(e) {}
+    try {
+      jeuFrame.src = 'about:blank';
+      jeuFrame.removeAttribute('data-loaded');
+    } catch(e) {}
+    gameLoaded = false;
+    if (jeuFallbackLink) jeuFallbackLink.style.display = 'none';
   }
 
   function openView(view, opts = {}){
     activate(view);
     if (view === 'multimedia'){
+      setJeuActive(false);
+      setJeuFullscreen(false);
+      stopEmbeddedGame();
       if ((location.hash || '') !== '#multimedia') location.hash = 'multimedia';
       if (opts.scroll !== false) requestAnimationFrame(() => multimediaSection.scrollIntoView({ behavior: 'smooth', block: 'start' }));
       return;
     }
-    if (view === 'bingo') bingoBtn?.click();
-    if (view === 'jeu') jeuBtn?.click();
+    if (view === 'bingo'){
+      setJeuActive(false);
+      setJeuFullscreen(false);
+      stopEmbeddedGame();
+      if ((location.hash || '') !== '#divertissement') location.hash = 'divertissement';
+      showBingoModal();
+      return;
+    }
+    if (view === 'jeu'){
+      if ((location.hash || '') !== '#divertissement') location.hash = 'divertissement';
+      if (jeuFrame){
+        if (!jeuFrame.dataset.loaded || !jeuFrame.src || jeuFrame.src.endsWith('about:blank')) {
+          gameLoaded = false;
+          jeuFrame.src = gameUrl;
+          jeuFrame.dataset.loaded = '1';
+        }
+        setTimeout(() => {
+          if (!gameLoaded && jeuFallbackLink) jeuFallbackLink.style.display = 'inline-flex';
+        }, 3000);
+      }
+      setJeuActive(true);
+      if (jeuSection) jeuSection.style.display = 'block';
+      const mobile = window.matchMedia && window.matchMedia('(max-width: 768px)').matches;
+      setJeuFullscreen(!!mobile);
+    }
   }
 
   function refresh(){
@@ -22749,14 +23316,43 @@ async function loadAffluenceDate(dateStr){
     nav.hidden = !show;
     nav.classList.toggle('is-visible', show);
     document.body.classList.toggle('loisirs-view-nav-visible', show);
-    if (show){
-      const current = (location.hash || '') === '#multimedia' ? 'multimedia' : (tabs.find(t => t.classList.contains('is-active'))?.dataset.loisirsView || 'multimedia');
-      activate(current);
+    if (!show) {
+      setJeuActive(false);
+      setJeuFullscreen(false);
+      stopEmbeddedGame();
+      hideBingoModal();
+      currentLoisirsView = 'multimedia';
+      return;
     }
+
+    const hash = location.hash || '';
+    if (hash === '#multimedia') {
+      currentLoisirsView = 'multimedia';
+      setJeuActive(false);
+      setJeuFullscreen(false);
+      stopEmbeddedGame();
+    } else if (currentLoisirsView === 'jeu') {
+      setJeuActive(true);
+    } else {
+      setJeuActive(false);
+      setJeuFullscreen(false);
+      stopEmbeddedGame();
+      currentLoisirsView = 'bingo';
+    }
+    activate(currentLoisirsView);
   }
 
   tabs.forEach(tab => {
     tab.addEventListener('click', () => openView(tab.dataset.loisirsView));
+  });
+
+  window.lbOpenLoisirsView = openView;
+  window.addEventListener('message', (ev) => {
+    const d = ev && ev.data;
+    if (!d || d.type !== 'lb:loisirs:return') return;
+    if ((location.hash || '') !== '#loisirs') location.hash = 'loisirs';
+    openView('multimedia', { scroll: true });
+    stopEmbeddedGame();
   });
 
   loisirsLink.addEventListener('click', (e) => {
@@ -22772,6 +23368,11 @@ async function loadAffluenceDate(dateStr){
         nav.hidden = true;
         nav.classList.remove('is-visible');
         document.body.classList.remove('loisirs-view-nav-visible');
+        setJeuActive(false);
+        setJeuFullscreen(false);
+        stopEmbeddedGame();
+        hideBingoModal();
+        currentLoisirsView = 'multimedia';
       }
     }, { passive: true });
   });
@@ -22861,10 +23462,3 @@ async function loadAffluenceDate(dateStr){
 
 </body>
 </html>
-      // localStorage (pour fonctionner même déconnecté / fallback)
-      try{
-        localStorage.setItem('lb_weatherStations', JSON.stringify({
-          from: payload.favoriteFromStation || '',
-          to: payload.favoriteToStation || ''
-        }));
-      }catch(e){}

--- a/jeuBETA.html
+++ b/jeuBETA.html
@@ -610,7 +610,38 @@
     }
 
     document.getElementById('restartBtn').addEventListener('click', ()=> initGame());
-    document.getElementById('returnBtn').addEventListener('click', ()=> { window.location.href='https://www.labetaillere.fr/'; });
+
+    function stopGameMusic(reset = true){
+      const audio = document.getElementById('gameMusic');
+      if (!audio) return;
+      try { audio.pause(); } catch(_) {}
+      if (reset) {
+        try { audio.currentTime = 0; } catch(_) {}
+      }
+    }
+
+    document.getElementById('returnBtn').addEventListener('click', ()=> {
+      stopGameMusic(true);
+  try {
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage({ type: 'lb:loisirs:return' }, '*');
+      return;
+    }
+  } catch(e) {}
+  window.location.href='/index20.html#loisirs';
+});
+
+    window.addEventListener('message', (ev) => {
+      const data = ev && ev.data;
+      if (!data || data.type !== 'lb:game:stop-audio') return;
+      stopGameMusic(true);
+    });
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState !== 'visible') stopGameMusic(false);
+    });
+    window.addEventListener('pagehide', () => stopGameMusic(false));
+    window.addEventListener('beforeunload', () => stopGameMusic(false));
 
     const pauseBtn = document.getElementById("pauseBtn");
     pauseBtn.disabled = true;


### PR DESCRIPTION
### Motivation
- Replace emoji nav icons with packaged SVG assets and add a donate CTA to improve branding and consistency.
- Make the trip panel train label actionable so embedded maps/apps can open a full train detail view.
- Add a simple in-app comments/live-wall and per-train comments to increase user interaction and allow offline persistence.
- Improve multimedia/game integration and various mobile/UX polish (cookie close, legend toggle, train detail placement, etc.).

### Description
- Added a new icon pack under `ber_icons_pack/` (`accueil.svg`, `carte.svg`, `tableau.svg`, `favoris.svg`, `loisirs.svg`, `compte.svg`, `stats.svg`) and switched bottom navigation to load these images with `.bottom-nav__icon-img` styling.
- Updated `carte.html` and `carteBETA.html` to turn the trip panel title into a clickable `<button>` (`.trip-panel-train`) with new styles and behavior, added `requestTrainDetailOpenFromMap()` which attempts to `postMessage` to a parent frame (or falls back to opening the SNCF detail URL), and toggles `is-clickable` UI state depending on train data.
- Large changes in `index20.html` include many CSS/UI additions (support pill, legend toggle, cookie banner close button, responsive/viewport fixes), replacement of the embedded map with `carteBETA.html`, positioning fixes for the train detail panel on the carte page, and additions for a game embed (`#jeuContainer`, `#jeuFrame`) including fullscreen handling.
- Implemented a client-side comments system persisted in `localStorage` under `lb_comments_v1` and synchronized via `BroadcastChannel`, with APIs and UI rendering functions (`addComment`, `getTrainComments`, `renderHomeLiveWall`, `renderTrainComments`, `lbComments`), plus hooks to display comment counts in favorites, home preview and train detail panel; comments are tied to a user pseudo preference saved in prefs.
- Added message listeners and cross-frame integration: listen for `lb:open-train-detail` to open internal train detail, `lb:loisirs:return` for game->parent navigation, and support sending `lb:game:stop-audio` to the embedded game to stop music; `jeuBETA.html` updated to respect these messages and to stop/reset audio when returning.

### Testing
- No automated tests were added or executed for this change; all changes were implemented as UI/feature additions and require manual/browser verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b024b0d074832db4e5912faccff01a)