### PR TITLE
Add compact comment wall to home (index20.html)

### DIFF
--- a/index20.html
+++ b/index20.html
@@ -707,6 +707,112 @@ body {
 .traffic-pill--orange{ background:rgba(255,138,26,.14); border-color:rgba(255,138,26,.45); color:#ffba74; }
 .traffic-pill--red{ background:rgba(255,49,49,.14); border-color:rgba(255,49,49,.45); color:#ff8d8d; }
 .traffic-pill--loading{ background:rgba(0,240,255,.12); border-color:rgba(0,240,255,.35); color:#8ff9ff; }
+
+.live-wall-card{
+  border: 1px solid rgba(0,240,255,.25);
+  background: linear-gradient(135deg, rgba(6,16,30,.92), rgba(6,20,36,.86));
+}
+.live-wall-card--home{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.live-wall-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  margin-bottom:2px;
+}
+.live-wall-title{ margin:0; font-size:1rem; letter-spacing:.04em; color:#7ef7ff; }
+.live-wall-badge{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:38px;
+  padding:4px 9px;
+  border-radius:999px;
+  border:1px solid rgba(0,240,255,.32);
+  background:rgba(0,14,26,.58);
+  color:#dffbff;
+  font-size:.72rem;
+  font-weight:800;
+}
+.live-wall-feed{
+  display:grid;
+  gap:6px;
+}
+.live-wall-feed--home{
+  max-height: 196px;
+  overflow:auto;
+  padding-right:2px;
+}
+.live-wall-item{
+  border:1px solid rgba(0,240,255,.2);
+  border-radius:12px;
+  padding:6px 8px;
+  background:rgba(0,8,18,.45);
+  font-size:.84rem;
+}
+.live-wall-item--home{
+  padding:6px 8px;
+}
+.live-wall-item-text{
+  line-height:1.22;
+  display:-webkit-box;
+  -webkit-line-clamp:2;
+  -webkit-box-orient:vertical;
+  overflow:hidden;
+}
+.live-wall-meta{ font-size:.72rem; opacity:.78; margin-bottom:3px; display:flex; gap:8px; flex-wrap:wrap; }
+.live-wall-form{ margin-top:2px; display:flex; gap:6px; }
+.live-wall-form input{ flex:1; min-width:0; }
+.live-wall-empty,
+.live-wall-cta{ opacity:.7; font-size:.82rem; }
+
+.fav-comments-row{ margin-top:8px; display:flex; justify-content:flex-end; }
+.fav-comment-btn,
+.home-comment-pill{
+  border:1px solid rgba(0,240,255,.45);
+  border-radius:999px;
+  background:rgba(0,14,26,.58);
+  color:#dffbff;
+  padding:5px 10px;
+  font-size:.78rem;
+  cursor:pointer;
+}
+.home-comment-pill{ font-size:.7rem; padding:4px 8px; }
+
+.train-comments{
+  margin-top:10px;
+  border:1px solid rgba(0,240,255,.2);
+  border-radius:10px;
+  background:rgba(0,10,20,.35);
+  padding:10px;
+}
+.train-comments-head{ display:flex; justify-content:space-between; align-items:center; margin-bottom:6px; }
+.train-comments-list{ max-height:170px; overflow:auto; display:grid; gap:6px; }
+.train-comments-item{ border-bottom:1px dashed rgba(0,240,255,.14); padding-bottom:6px; }
+.train-comments-item:last-child{ border-bottom:none; padding-bottom:0; }
+.train-comments-form{ margin-top:8px; display:flex; gap:6px; }
+.train-comments-form input{ flex:1; min-width:0; }
+
+@media (max-width: 820px){
+  .live-wall-card--home{ order: 2; }
+}
+
+@media (max-width: 600px){
+  .live-wall-card--home{
+    padding: 10px 12px !important;
+    gap: 6px;
+  }
+  .live-wall-title{ font-size: .94rem; }
+  .live-wall-badge{ font-size:.68rem; padding:3px 8px; min-width:34px; }
+  .live-wall-feed--home{ max-height: 176px; gap:5px; }
+  .live-wall-item--home{ padding:5px 7px; }
+  .live-wall-item--home .live-wall-meta{ font-size:.68rem; margin-bottom:2px; gap:6px; }
+  .live-wall-item--home .live-wall-item-text{ font-size:.76rem; }
+}
 .quick-links{
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -8129,6 +8235,21 @@ html, body{
       </div>
     </article>
 
+    <article class="home-card live-wall-card live-wall-card--home" aria-label="Mur de commentaires">
+      <div class="live-wall-head">
+        <h2 class="live-wall-title">Commentaires</h2>
+        <span class="live-wall-badge" id="homeLiveWallCount">0</span>
+      </div>
+      <div id="homeLiveWallFeed" class="live-wall-feed live-wall-feed--home">
+        <div class="live-wall-empty">Aucun commentaire pour le moment.</div>
+      </div>
+      <div id="homeLiveWallCta" class="live-wall-cta" hidden>Connectez-vous pour commenter en direct.</div>
+      <form id="homeLiveWallForm" class="live-wall-form" autocomplete="off" hidden>
+        <input id="homeLiveWallInput" type="text" maxlength="180" placeholder="Partager une info rapide">
+        <button type="submit" class="auth-button">Envoyer</button>
+      </form>
+    </article>
+
     <article class="home-card" aria-label="Météo sur votre ligne">
       <h2>Météo sur votre ligne</h2>
 
@@ -8679,6 +8800,17 @@ html, body{
     <div class="aff-chart" style="margin-top:8px"><canvas id="trainDetailAffluenceChart" height="92"></canvas></div>
   </div>
   <div class="train-detail-route" id="trainDetailStops"></div>
+  <div class="train-comments" id="trainDetailComments">
+    <div class="train-comments-head">
+      <strong>Commentaires</strong>
+      <span id="trainDetailCommentsCount">0</span>
+    </div>
+    <div id="trainDetailCommentsList" class="train-comments-list"></div>
+    <form id="trainDetailCommentsForm" class="train-comments-form" autocomplete="off" hidden>
+      <input id="trainDetailCommentsInput" type="text" maxlength="180" placeholder="Ajouter un commentaire sur ce train">
+      <button type="submit" class="auth-button">Envoyer</button>
+    </form>
+  </div>
   <div class="train-detail-actions">
     <a id="trainDetailAffBtn" class="train-detail-btn" href="#affluence">🚆 Ouvrir dans Affluence</a>
     <a id="trainDetailStatsBtn" class="train-detail-btn" href="#stats">📊 Voir schéma stats du train</a>
@@ -19127,6 +19259,175 @@ function scheduleWeatherAfterTableSettled(){
     return data;
   };
 
+  const LB_COMMENTS_STORAGE_KEY = 'lb_comments_v1';
+  const lbCommentsChannel = ('BroadcastChannel' in window) ? new BroadcastChannel('lb_comments_channel') : null;
+  let lbCommentState = { wall: [], trains: {} };
+  let lbCurrentDetailTrain = '';
+
+  const safePseudo = () => String(lbPrefsCache?.pseudo || '').trim().slice(0,24);
+  const isCommentingAllowed = () => window.lbIsAuthed === true && !!safePseudo();
+
+  function loadCommentState(){
+    try{
+      const raw = localStorage.getItem(LB_COMMENTS_STORAGE_KEY);
+      if (!raw) return { wall: [], trains: {} };
+      const js = JSON.parse(raw);
+      if (!js || typeof js !== 'object') return { wall: [], trains: {} };
+      return {
+        wall: Array.isArray(js.wall) ? js.wall : [],
+        trains: (js.trains && typeof js.trains === 'object') ? js.trains : {}
+      };
+    }catch(e){
+      return { wall: [], trains: {} };
+    }
+  }
+
+  function saveCommentState(){
+    try{ localStorage.setItem(LB_COMMENTS_STORAGE_KEY, JSON.stringify(lbCommentState)); }catch(e){}
+    try{ lbCommentsChannel?.postMessage({ type: 'sync' }); }catch(e){}
+  }
+
+  function getTrainComments(trainNumber){
+    const key = String(trainNumber || '').trim();
+    if (!key) return [];
+    const list = lbCommentState?.trains?.[key];
+    return Array.isArray(list) ? list.slice().sort((a,b)=>(b.ts||0)-(a.ts||0)) : [];
+  }
+
+  function getTrainCommentCount(trainNumber){
+    return getTrainComments(trainNumber).length;
+  }
+
+  function addComment({ text, trainNumber = '' }){
+    const pseudo = safePseudo();
+    if (!isCommentingAllowed()) throw new Error('Connexion + pseudo requis');
+    const msg = String(text || '').trim().slice(0,180);
+    if (!msg) throw new Error('Commentaire vide');
+    const train = String(trainNumber || '').trim();
+    const item = {
+      id: `${Date.now()}_${Math.random().toString(36).slice(2,8)}`,
+      pseudo,
+      text: msg,
+      trainNumber: train,
+      ts: Date.now()
+    };
+    lbCommentState.wall = [item, ...(lbCommentState.wall || [])].slice(0,60);
+    if (train){
+      const arr = Array.isArray(lbCommentState.trains[train]) ? lbCommentState.trains[train] : [];
+      lbCommentState.trains[train] = [item, ...arr].slice(0,120);
+    }
+    saveCommentState();
+    renderCommentsUI();
+    return item;
+  }
+
+  const fmtHour = (ts) => {
+    try{ return new Date(ts || Date.now()).toLocaleTimeString('fr-FR', { hour:'2-digit', minute:'2-digit' }); }
+    catch(e){ return '—'; }
+  };
+
+  function renderHomeLiveWall(){
+    const feed = $('homeLiveWallFeed');
+    const form = $('homeLiveWallForm');
+    const cta = $('homeLiveWallCta');
+    const countEl = $('homeLiveWallCount');
+    if (!feed || !form || !cta || !countEl) return;
+    const wall = Array.isArray(lbCommentState.wall) ? lbCommentState.wall.slice(0,4) : [];
+    countEl.textContent = String(wall.length);
+    if (!wall.length) {
+      feed.innerHTML = '<div class="live-wall-empty">Aucun commentaire pour le moment.</div>';
+    } else {
+      feed.innerHTML = wall.map((it) => `
+        <div class="live-wall-item live-wall-item--home">
+          <div class="live-wall-meta"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span>${fmtHour(it.ts)}</span>${it.trainNumber ? `<span>#${escapeHtml(it.trainNumber)}</span>` : ''}</div>
+          <div class="live-wall-item-text">${escapeHtml(it.text || '')}</div>
+        </div>
+      `).join('');
+    }
+    const can = isCommentingAllowed();
+    form.hidden = !can;
+    cta.hidden = can;
+    if (!window.lbIsAuthed) cta.textContent = 'Connectez-vous pour commenter en direct.';
+    else if (!safePseudo()) cta.textContent = 'Ajoutez un pseudo dans Mes préférences pour commenter.';
+    else cta.textContent = '';
+  }
+
+  function renderTrainComments(trainNumber){
+    const listEl = $('trainDetailCommentsList');
+    const countEl = $('trainDetailCommentsCount');
+    const form = $('trainDetailCommentsForm');
+    if (!listEl || !countEl || !form) return;
+    const train = String(trainNumber || lbCurrentDetailTrain || '').trim();
+    const comments = getTrainComments(train).slice(0,30);
+    countEl.textContent = String(comments.length);
+    listEl.innerHTML = comments.length
+      ? comments.map((it)=>`<div class="train-comments-item"><div class="live-wall-meta"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span>${fmtHour(it.ts)}</span></div><div>${escapeHtml(it.text || '')}</div></div>`).join('')
+      : '<div class="live-wall-empty">Pas encore de commentaire sur ce train.</div>';
+    form.hidden = !isCommentingAllowed();
+  }
+
+  function renderCommentsUI(){
+    renderHomeLiveWall();
+    renderTrainComments(lbCurrentDetailTrain);
+    try { if (typeof lbRenderHomeFavPreview === 'function' && window.lbIsAuthed === true) lbRenderHomeFavPreview(); } catch(e) {}
+  }
+
+  function bindCommentForms(){
+    const homeForm = $('homeLiveWallForm');
+    const homeInput = $('homeLiveWallInput');
+    if (homeForm && !homeForm.dataset.bound){
+      homeForm.dataset.bound = '1';
+      homeForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        try{
+          addComment({ text: homeInput?.value || '' });
+          if (homeInput) homeInput.value = '';
+        }catch(err){
+          alert(err?.message || "Impossible d'ajouter le commentaire.");
+        }
+      });
+    }
+    const trainForm = $('trainDetailCommentsForm');
+    const trainInput = $('trainDetailCommentsInput');
+    if (trainForm && !trainForm.dataset.bound){
+      trainForm.dataset.bound = '1';
+      trainForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        try{
+          addComment({ text: trainInput?.value || '', trainNumber: lbCurrentDetailTrain });
+          if (trainInput) trainInput.value = '';
+        }catch(err){
+          alert(err?.message || "Impossible d'ajouter le commentaire.");
+        }
+      });
+    }
+    try{
+      lbCommentsChannel?.addEventListener('message', (ev) => {
+        if (ev?.data?.type !== 'sync') return;
+        lbCommentState = loadCommentState();
+        renderCommentsUI();
+      });
+    }catch(e){}
+    window.addEventListener('storage', (ev) => {
+      if (ev.key !== LB_COMMENTS_STORAGE_KEY) return;
+      lbCommentState = loadCommentState();
+      renderCommentsUI();
+    });
+  }
+
+  window.lbComments = {
+    setCurrentTrain(trainNumber){
+      lbCurrentDetailTrain = String(trainNumber || '').trim();
+      renderTrainComments(lbCurrentDetailTrain);
+    },
+    refresh(){ renderCommentsUI(); },
+    count(trainNumber){ return getTrainCommentCount(trainNumber); }
+  };
+
+  lbCommentState = loadCommentState();
+  bindCommentForms();
+  renderCommentsUI();
+
   const openModal = () => {
     const modal = $("lbAuthModal");
     if (!modal) return;
@@ -19204,7 +19505,7 @@ function scheduleWeatherAfterTableSettled(){
       const wx = getUserWxPrefsOrDefault();
       updateHomeWeather(wx.from, wx.to).catch(()=>{});
     }catch(e){}
-
+    try{ window.lbComments?.refresh(); }catch(e){}
 
     // Rafraîchir le widget favoris
     try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
@@ -20424,6 +20725,7 @@ if (statsEl){
       msg(`✅ Connecté : ${me?.user?.email || "utilisateur"}`);
       await loadPreferences();
       try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") await window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
+      try{ window.lbComments?.refresh(); }catch(e){}
     } catch {
       openBtn.textContent = "Se connecter";
       logoutBtn.style.display = "none";
@@ -20465,6 +20767,7 @@ if (statsEl){
         window.updateStatsConsoleAuth(false);
       }
       msg("ℹ️ Non connecté");
+      try{ window.lbComments?.refresh(); }catch(e){}
     }
     updateQuickAddButton();
     updateSelectionApplyButton();
@@ -21913,6 +22216,9 @@ function lbRenderHomeFavPreview(){
 
   const buildRow = (k, data, label) => {
     const trainTxt = data.train && data.train !== '—' ? data.train : '—';
+    const trainMatch = String(trainTxt).match(/\d{5,6}/);
+    const trainNo = trainMatch ? trainMatch[0] : '';
+    const cc = trainNo ? getTrainCommentCount(trainNo) : 0;
     const metaTxt  = data.meta && data.meta !== '—' ? data.meta : '';
     const safeMeta = metaTxt ? escapeHtml(metaTxt) : '<span style="opacity:.55">—</span>';
 
@@ -21923,6 +22229,7 @@ function lbRenderHomeFavPreview(){
           <div class="home-fav-meta">${safeMeta}</div>
         </div>
         <div class="fav-train-badge home-fav-badge">${renderBadge(data.state)}</div>
+        <button type="button" class="home-comment-pill" data-train-comment="${trainNo}">💬 ${cc}</button>
       </div>
     `;
   };
@@ -21980,6 +22287,14 @@ function lbRenderHomeFavPreview(){
     const k = row.getAttribute('data-fav-k');
     row.addEventListener('click', ()=>jumpToFav(k));
     row.addEventListener('keydown', (e)=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); jumpToFav(k);} });
+  });
+  slot.querySelectorAll('.home-comment-pill').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const train = String(btn.dataset.trainComment || '');
+      if (!train || typeof window.lbOpenTrainDetail !== 'function') return;
+      window.lbOpenTrainDetail(train, document.getElementById('trainDate')?.value || luxTodayYMD());
+    });
   });
 }
 
@@ -23030,6 +23345,8 @@ async function loadAffluenceDate(dateStr){
     const statsBtn = document.getElementById('trainDetailStatsBtn');
 
     panel.hidden = false;
+    lbCurrentDetailTrain = String(trainNumber || '').trim();
+    try{ window.lbComments?.setCurrentTrain(lbCurrentDetailTrain); }catch(e){}
     titleEl.textContent = `Train ${trainNumber}`;
     nextEl.textContent = 'Chargement…';
     relEl.textContent = 'Chargement…';


### PR DESCRIPTION
### Motivation
- Provide a compact, non-intrusive comment wall on the home screen placed just below the "Info trafic" card so mobile users can see recent community reports without disrupting the existing layout. 
- Reuse the comment logic already present in the project and wire basic per-train comments and fav-train comment entry points so users can jump from favorites to train details. 

### Description
- Add CSS rules and a new home card (`.live-wall-card.live-wall-card--home`) that renders a compact comment feed limited to the 4 most recent comments on the home screen. 
- Insert a small comment block into the train detail panel and add a 💬 button to each favorite row that opens the train detail for that train. 
- Implement a lightweight comment store and UI logic inside `index20.html` using `localStorage` (key `lb_comments_v1`) and a `BroadcastChannel` for cross-tab sync, including functions `loadCommentState`, `saveCommentState`, `getTrainComments`, `addComment`, `renderHomeLiveWall`, and `renderTrainComments`. 
- Wire form bindings and visibility rules: forms are shown only when `window.lbIsAuthed === true` and a pseudo exists in preferences, and the home wall refreshes when preferences/auth state changes (hooks added where preferences/auth are applied). 

### Testing
- Parsed all inline scripts from `index20.html` using Node's `vm.Script` to validate that injected JS is syntactically valid, and parsing completed successfully. 
- Reviewed the resulting diff to ensure the home card, favorite buttons and train-detail block were added and that the new functions are invoked when appropriate. 
- Verified the comment UI refresh is attempted after preferences/auth updates; no browser runtime screenshots were produced in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0304ae28832da4a93f5f6e21fb61)