### PR TITLE
Add local live comment wall and per-train comments with favorites integration

### DIFF
--- a/index20.html
+++ b/index20.html
@@ -707,6 +707,138 @@ body {
 .traffic-pill--orange{ background:rgba(255,138,26,.14); border-color:rgba(255,138,26,.45); color:#ffba74; }
 .traffic-pill--red{ background:rgba(255,49,49,.14); border-color:rgba(255,49,49,.45); color:#ff8d8d; }
 .traffic-pill--loading{ background:rgba(0,240,255,.12); border-color:rgba(0,240,255,.35); color:#8ff9ff; }
+
+.live-wall-card{
+  border: 1px solid rgba(0,240,255,.25);
+  background: linear-gradient(135deg, rgba(6,16,30,.92), rgba(6,20,36,.86));
+}
+.live-wall-card--home{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.live-wall-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  margin-bottom:2px;
+}
+.live-wall-title{ margin:0; font-size:1rem; letter-spacing:.04em; color:#7ef7ff; }
+.live-wall-badge{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:38px;
+  padding:4px 9px;
+  border-radius:999px;
+  border:1px solid rgba(0,240,255,.32);
+  background:rgba(0,14,26,.58);
+  color:#dffbff;
+  font-size:.72rem;
+  font-weight:800;
+}
+.live-wall-feed{
+  display:grid;
+  gap:6px;
+}
+.live-wall-feed--home{
+  max-height: 196px;
+  overflow:auto;
+  padding-right:2px;
+}
+.live-wall-item{
+  border:1px solid rgba(0,240,255,.2);
+  border-radius:12px;
+  padding:6px 8px;
+  background:rgba(0,8,18,.45);
+  font-size:.84rem;
+}
+.live-wall-item--home{
+  padding:6px 8px;
+}
+.live-wall-item-text{
+  line-height:1.22;
+  display:-webkit-box;
+  -webkit-line-clamp:2;
+  -webkit-box-orient:vertical;
+  overflow:hidden;
+}
+.live-wall-meta{ font-size:.72rem; opacity:.78; margin-bottom:3px; display:flex; gap:8px; flex-wrap:wrap; }
+.live-wall-form{ margin-top:2px; display:flex; gap:6px; }
+.live-wall-form input{ flex:1; min-width:0; }
+.live-wall-empty,
+.live-wall-cta{ opacity:.7; font-size:.82rem; }
+
+.fav-comments-row{ margin-top:8px; display:flex; justify-content:flex-end; }
+.fav-comment-btn,
+.home-comment-pill{
+  border:1px solid rgba(0,240,255,.38);
+  border-radius:999px;
+  background:rgba(0,14,26,.48);
+  color:#dffbff;
+  padding:4px 8px;
+  font-size:.72rem;
+  cursor:pointer;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:5px;
+  white-space:nowrap;
+  min-width:52px;
+  line-height:1;
+}
+.home-comment-pill{
+  flex:0 0 auto;
+  align-self:center;
+}
+.home-comment-pill__emoji{
+  font-size:.82rem;
+  line-height:1;
+}
+.home-comment-pill__count{
+  font-size:.68rem;
+  font-weight:800;
+  letter-spacing:.02em;
+}
+.home-comment-pill:disabled{
+  opacity:.45;
+  cursor:default;
+}
+
+.train-comments{
+  margin-top:10px;
+  border:1px solid rgba(0,240,255,.2);
+  border-radius:10px;
+  background:rgba(0,10,20,.35);
+  padding:10px;
+}
+.train-comments-head{ display:flex; justify-content:space-between; align-items:center; margin-bottom:6px; }
+.train-comments-list{ max-height:170px; overflow:auto; display:grid; gap:6px; }
+.train-comments-item{ border-bottom:1px dashed rgba(0,240,255,.14); padding-bottom:6px; }
+.train-comments-item:last-child{ border-bottom:none; padding-bottom:0; }
+.train-comments-form{ margin-top:8px; display:flex; gap:6px; }
+.train-comments-form input{ flex:1; min-width:0; }
+
+@media (max-width: 820px){
+  .live-wall-card--home{ order: 2; }
+}
+
+@media (max-width: 600px){
+  .live-wall-card--home{
+    padding: 10px 12px !important;
+    gap: 6px;
+  }
+  .live-wall-title{ font-size: .94rem; }
+  .live-wall-badge{ font-size:.68rem; padding:3px 8px; min-width:34px; }
+  .live-wall-feed--home{ max-height: 176px; gap:5px; }
+  .live-wall-item--home{ padding:5px 7px; }
+  .live-wall-item--home .live-wall-meta{ font-size:.68rem; margin-bottom:2px; gap:6px; }
+  .live-wall-item--home .live-wall-item-text{ font-size:.76rem; }
+  .home-comment-pill{ min-width:46px; padding:4px 7px; gap:4px; }
+  .home-comment-pill__emoji{ font-size:.76rem; }
+  .home-comment-pill__count{ font-size:.64rem; }
+}
 .quick-links{
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -8129,6 +8261,21 @@ html, body{
       </div>
     </article>
 
+    <article class="home-card live-wall-card live-wall-card--home" aria-label="Mur de commentaires">
+      <div class="live-wall-head">
+        <h2 class="live-wall-title">Commentaires</h2>
+        <span class="live-wall-badge" id="homeLiveWallCount">0</span>
+      </div>
+      <div id="homeLiveWallFeed" class="live-wall-feed live-wall-feed--home">
+        <div class="live-wall-empty">Aucun commentaire pour le moment.</div>
+      </div>
+      <div id="homeLiveWallCta" class="live-wall-cta" hidden>Connectez-vous pour commenter en direct.</div>
+      <form id="homeLiveWallForm" class="live-wall-form" autocomplete="off" hidden>
+        <input id="homeLiveWallInput" type="text" maxlength="180" placeholder="Partager une info rapide">
+        <button type="submit" class="auth-button">Envoyer</button>
+      </form>
+    </article>
+
     <article class="home-card" aria-label="Météo sur votre ligne">
       <h2>Météo sur votre ligne</h2>
 
@@ -8679,6 +8826,17 @@ html, body{
     <div class="aff-chart" style="margin-top:8px"><canvas id="trainDetailAffluenceChart" height="92"></canvas></div>
   </div>
   <div class="train-detail-route" id="trainDetailStops"></div>
+  <div class="train-comments" id="trainDetailComments">
+    <div class="train-comments-head">
+      <strong>Commentaires</strong>
+      <span id="trainDetailCommentsCount">0</span>
+    </div>
+    <div id="trainDetailCommentsList" class="train-comments-list"></div>
+    <form id="trainDetailCommentsForm" class="train-comments-form" autocomplete="off" hidden>
+      <input id="trainDetailCommentsInput" type="text" maxlength="180" placeholder="Ajouter un commentaire sur ce train">
+      <button type="submit" class="auth-button">Envoyer</button>
+    </form>
+  </div>
   <div class="train-detail-actions">
     <a id="trainDetailAffBtn" class="train-detail-btn" href="#affluence">🚆 Ouvrir dans Affluence</a>
     <a id="trainDetailStatsBtn" class="train-detail-btn" href="#stats">📊 Voir schéma stats du train</a>
@@ -19127,6 +19285,185 @@ function scheduleWeatherAfterTableSettled(){
     return data;
   };
 
+  const LB_COMMENTS_STORAGE_KEY = 'lb_comments_v1';
+  const lbCommentsChannel = ('BroadcastChannel' in window) ? new BroadcastChannel('lb_comments_channel') : null;
+  let lbCommentState = { wall: [], trains: {} };
+  let lbCurrentDetailTrain = '';
+
+  const safePseudo = () => String(lbPrefsCache?.pseudo || '').trim().slice(0,24);
+  const isCommentingAllowed = () => window.lbIsAuthed === true && !!safePseudo();
+
+  function loadCommentState(){
+    try{
+      const raw = localStorage.getItem(LB_COMMENTS_STORAGE_KEY);
+      if (!raw) return { wall: [], trains: {} };
+      const js = JSON.parse(raw);
+      if (!js || typeof js !== 'object') return { wall: [], trains: {} };
+      return {
+        wall: Array.isArray(js.wall) ? js.wall : [],
+        trains: (js.trains && typeof js.trains === 'object') ? js.trains : {}
+      };
+    }catch(e){
+      return { wall: [], trains: {} };
+    }
+  }
+
+  function saveCommentState(){
+    try{ localStorage.setItem(LB_COMMENTS_STORAGE_KEY, JSON.stringify(lbCommentState)); }catch(e){}
+    try{ lbCommentsChannel?.postMessage({ type: 'sync' }); }catch(e){}
+  }
+
+  function getTrainComments(trainNumber){
+    const key = String(trainNumber || '').trim();
+    if (!key) return [];
+    const list = lbCommentState?.trains?.[key];
+    return Array.isArray(list) ? list.slice().sort((a,b)=>(b.ts||0)-(a.ts||0)) : [];
+  }
+
+  function getTrainCommentCount(trainNumber){
+    return getTrainComments(trainNumber).length;
+  }
+
+  function addComment({ text, trainNumber = '' }){
+    const pseudo = safePseudo();
+    if (!isCommentingAllowed()) throw new Error('Connexion + pseudo requis');
+    const msg = String(text || '').trim().slice(0,180);
+    if (!msg) throw new Error('Commentaire vide');
+    const train = String(trainNumber || '').trim();
+    const item = {
+      id: `${Date.now()}_${Math.random().toString(36).slice(2,8)}`,
+      pseudo,
+      text: msg,
+      trainNumber: train,
+      ts: Date.now()
+    };
+    lbCommentState.wall = [item, ...(lbCommentState.wall || [])].slice(0,60);
+    if (train){
+      const arr = Array.isArray(lbCommentState.trains[train]) ? lbCommentState.trains[train] : [];
+      lbCommentState.trains[train] = [item, ...arr].slice(0,120);
+    }
+    saveCommentState();
+    renderCommentsUI();
+    return item;
+  }
+
+  const fmtHour = (ts) => {
+    try{ return new Date(ts || Date.now()).toLocaleTimeString('fr-FR', { hour:'2-digit', minute:'2-digit' }); }
+    catch(e){ return '—'; }
+  };
+
+  function renderHomeLiveWall(){
+    const feed = $('homeLiveWallFeed');
+    const form = $('homeLiveWallForm');
+    const cta = $('homeLiveWallCta');
+    const countEl = $('homeLiveWallCount');
+    if (!feed || !form || !cta || !countEl) return;
+    const wall = Array.isArray(lbCommentState.wall) ? lbCommentState.wall.slice(0,4) : [];
+    countEl.textContent = String(wall.length);
+    if (!wall.length) {
+      feed.innerHTML = '<div class="live-wall-empty">Aucun commentaire pour le moment.</div>';
+    } else {
+      feed.innerHTML = wall.map((it) => `
+        <div class="live-wall-item live-wall-item--home">
+          <div class="live-wall-meta"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span>${fmtHour(it.ts)}</span>${it.trainNumber ? `<span>#${escapeHtml(it.trainNumber)}</span>` : ''}</div>
+          <div class="live-wall-item-text">${escapeHtml(it.text || '')}</div>
+        </div>
+      `).join('');
+    }
+    const can = isCommentingAllowed();
+    form.hidden = !can;
+    cta.hidden = can;
+    if (!window.lbIsAuthed) cta.textContent = 'Connectez-vous pour commenter en direct.';
+    else if (!safePseudo()) cta.textContent = 'Ajoutez un pseudo dans Mes préférences pour commenter.';
+    else cta.textContent = '';
+  }
+
+  function renderTrainComments(trainNumber){
+    const listEl = $('trainDetailCommentsList');
+    const countEl = $('trainDetailCommentsCount');
+    const form = $('trainDetailCommentsForm');
+    if (!listEl || !countEl || !form) return;
+    const train = String(trainNumber || lbCurrentDetailTrain || '').trim();
+    const comments = getTrainComments(train).slice(0,30);
+    countEl.textContent = String(comments.length);
+    listEl.innerHTML = comments.length
+      ? comments.map((it)=>`<div class="train-comments-item"><div class="live-wall-meta"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span>${fmtHour(it.ts)}</span></div><div>${escapeHtml(it.text || '')}</div></div>`).join('')
+      : '<div class="live-wall-empty">Pas encore de commentaire sur ce train.</div>';
+    form.hidden = !isCommentingAllowed();
+  }
+
+  function syncHomeFavCommentPills(){
+    document.querySelectorAll('.home-comment-pill').forEach((btn) => {
+      const train = String(btn.dataset.trainComment || '').trim();
+      const count = train ? getTrainCommentCount(train) : 0;
+      const countEl = btn.querySelector('.home-comment-pill__count');
+      if (countEl) countEl.textContent = String(count);
+      btn.disabled = !train;
+    });
+  }
+
+  function renderCommentsUI(){
+    renderHomeLiveWall();
+    renderTrainComments(lbCurrentDetailTrain);
+    syncHomeFavCommentPills();
+  }
+
+  function bindCommentForms(){
+    const homeForm = $('homeLiveWallForm');
+    const homeInput = $('homeLiveWallInput');
+    if (homeForm && !homeForm.dataset.bound){
+      homeForm.dataset.bound = '1';
+      homeForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        try{
+          addComment({ text: homeInput?.value || '' });
+          if (homeInput) homeInput.value = '';
+        }catch(err){
+          alert(err?.message || "Impossible d'ajouter le commentaire.");
+        }
+      });
+    }
+    const trainForm = $('trainDetailCommentsForm');
+    const trainInput = $('trainDetailCommentsInput');
+    if (trainForm && !trainForm.dataset.bound){
+      trainForm.dataset.bound = '1';
+      trainForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        try{
+          addComment({ text: trainInput?.value || '', trainNumber: lbCurrentDetailTrain });
+          if (trainInput) trainInput.value = '';
+        }catch(err){
+          alert(err?.message || "Impossible d'ajouter le commentaire.");
+        }
+      });
+    }
+    try{
+      lbCommentsChannel?.addEventListener('message', (ev) => {
+        if (ev?.data?.type !== 'sync') return;
+        lbCommentState = loadCommentState();
+        renderCommentsUI();
+      });
+    }catch(e){}
+    window.addEventListener('storage', (ev) => {
+      if (ev.key !== LB_COMMENTS_STORAGE_KEY) return;
+      lbCommentState = loadCommentState();
+      renderCommentsUI();
+    });
+  }
+
+  window.lbComments = {
+    setCurrentTrain(trainNumber){
+      lbCurrentDetailTrain = String(trainNumber || '').trim();
+      renderTrainComments(lbCurrentDetailTrain);
+    },
+    refresh(){ renderCommentsUI(); },
+    count(trainNumber){ return getTrainCommentCount(trainNumber); }
+  };
+
+  lbCommentState = loadCommentState();
+  bindCommentForms();
+  renderCommentsUI();
+
   const openModal = () => {
     const modal = $("lbAuthModal");
     if (!modal) return;
@@ -19204,7 +19541,7 @@ function scheduleWeatherAfterTableSettled(){
       const wx = getUserWxPrefsOrDefault();
       updateHomeWeather(wx.from, wx.to).catch(()=>{});
     }catch(e){}
-
+    try{ window.lbComments?.refresh(); }catch(e){}
 
     // Rafraîchir le widget favoris
     try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
@@ -20029,6 +20366,14 @@ function getGtfsDelayForStop(trainNumber, stopName){
   }
 
   const renderFavCard = (kind, trainId, payload) => {
+    window.__lbHomeFavPreviewData = window.__lbHomeFavPreviewData || {};
+    const syncHomeFavPreview = () => {
+      window.__lbHomeFavPreviewData[kind] = {
+        train: (title?.textContent || '').trim(),
+        meta: (meta?.textContent || '').trim(),
+        state: (badgeEl?.textContent || '').trim()
+      };
+    };
     const title   = document.getElementById(kind === 'AM' ? 'favTrainAM' : 'favTrainPM');
 	const badgeEl = document.getElementById(kind === 'AM' ? 'favStateAM' : 'favStatePM');
     const meta    = document.getElementById(kind === 'AM' ? 'favMetaAM'  : 'favMetaPM');
@@ -20053,12 +20398,14 @@ function getGtfsDelayForStop(trainNumber, stopName){
 
     if (!trainId){
       meta.textContent = '➡️ Choisis un train dans tes préférences.';
+      syncHomeFavPreview();
       if (statsEl){ statsEl.open = false; }
       return;
     }
 
     if (payload?.error){
       meta.textContent = `🚫 ${payload.error}`;
+      syncHomeFavPreview();
       if (statsEl){
         renderFavStats(kind, trainId).catch(()=>{});
         if (!statsEl.hasAttribute('data-user-opened')) statsEl.open = false;
@@ -20069,6 +20416,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
     const train = payload?.train;
     if (!train){
       meta.textContent = '🚫 Données indisponibles.';
+      syncHomeFavPreview();
       return;
     }
 
@@ -20251,6 +20599,7 @@ if (statsEl){
       renderFavStats(kind, trainId).catch(()=>{});
       if (!statsEl.hasAttribute('data-user-opened')) statsEl.open = false;
     }
+    syncHomeFavPreview();
   };
   // Clic sur "Détail" dans l'affluence des favoris -> ouvre la section Affluence + détail du train
   if (!window.__lbFavAffOpenBound){
@@ -20322,8 +20671,32 @@ if (statsEl){
 
   let favWidgetTimer = null;
 
+  function getHomeFavoriteTrainNo(kind){
+    const prefs = window.lbPrefsCache || null;
+    const explicit = String(kind === 'AM' ? (prefs?.favoriteMorningTrain || '') : (prefs?.favoriteEveningTrain || '')).trim();
+    if (/^\d{5,6}$/.test(explicit)) return explicit;
+
+    const rapid = prefs?.rapidPresets || {};
+    const preset = rapid[kind] || rapid[String(kind || '').toLowerCase()] || null;
+    const trains = Array.isArray(preset?.trains) ? preset.trains : [];
+    const fallback = trains.map((it) => String(it || '').trim()).find((it) => /^\d{5,6}$/.test(it)) || '';
+    return fallback;
+  }
+
+  function hasHomeAuthContext(){
+    const prefs = window.lbPrefsCache || null;
+    if (window.lbIsAuthed === true) return true;
+    if (!prefs || typeof prefs !== 'object') return false;
+    return !!(
+      String(prefs.pseudo || '').trim() ||
+      String(prefs.favoriteMorningTrain || '').trim() ||
+      String(prefs.favoriteEveningTrain || '').trim() ||
+      (prefs.rapidPresets && Object.keys(prefs.rapidPresets).length)
+    );
+  }
+
   function shouldShowFavoritesWidget(){
-    if (window.lbIsAuthed !== true) return false;
+    if (!hasHomeAuthContext()) return false;
     const body = document.body;
     if (body?.classList?.contains('page-favoris')) return true;
     const hash = String(location.hash || '').toLowerCase();
@@ -20334,7 +20707,7 @@ if (statsEl){
     const root = document.getElementById('favTrainsWidget');
     if (!root) return;
 
-    if (window.lbIsAuthed !== true) {
+    if (!hasHomeAuthContext()) {
       root.style.display = 'none';
       try{ if (typeof ensureFavInHome==='function') ensureFavInHome(); }catch(e){}
       if (favWidgetTimer) { clearInterval(favWidgetTimer); favWidgetTimer = null; }
@@ -20357,9 +20730,8 @@ if (statsEl){
       try { await loadCflVoiesByTrain({ forceFresh: false }); } catch(e) {}
     }
 
-    const prefs = window.lbPrefsCache || null;
-    const favAM = (prefs?.favoriteMorningTrain || '').trim();
-    const favPM = (prefs?.favoriteEveningTrain || '').trim();
+    const favAM = getHomeFavoriteTrainNo('AM');
+    const favPM = getHomeFavoriteTrainNo('PM');
 
     const [amRes, pmRes] = await Promise.allSettled([
       favAM ? fetchTrainToday(favAM) : Promise.resolve({ error: null }),
@@ -20424,6 +20796,7 @@ if (statsEl){
       msg(`✅ Connecté : ${me?.user?.email || "utilisateur"}`);
       await loadPreferences();
       try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") await window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
+      try{ window.lbComments?.refresh(); }catch(e){}
     } catch {
       openBtn.textContent = "Se connecter";
       logoutBtn.style.display = "none";
@@ -20465,6 +20838,7 @@ if (statsEl){
         window.updateStatsConsoleAuth(false);
       }
       msg("ℹ️ Non connecté");
+      try{ window.lbComments?.refresh(); }catch(e){}
     }
     updateQuickAddButton();
     updateSelectionApplyButton();
@@ -21882,104 +22256,91 @@ function lbRenderHomeFavPreview(){
   const slot = document.getElementById('homeFavSlot');
   if (!slot) return;
 
-  // lecture des infos déjà calculées par le widget favoris (AM/PM)
-  const read = (k) => {
-    const train = (document.getElementById('favTrain'+k)?.textContent || '').trim();
-    const meta  = (document.getElementById('favMeta'+k)?.textContent || '').trim();
-    const state = (document.getElementById('favState'+k)?.textContent || '').trim();
-    return { train, meta, state };
-  };
-
-  const am = read('AM');
-  const pm = read('PM');
-
   const toStateKey = (txt) => {
-    const t = (txt || '').toUpperCase();
+    const t = String(txt || '').toUpperCase();
     if (t.includes('ARRIV')) return 'after';
     if (t.includes('LIVE') || t.includes('EN COURS') || t.includes('EN ROUTE')) return 'running';
     if (t.includes('A VENIR') || t.includes('PROCHAIN') || t.includes('AVENIR')) return 'before';
     return 'unknown';
   };
 
-  const renderBadge = (stateTxt) => {
-    const key = toStateKey(stateTxt);
+  const renderBadge = (stateTxt, hasTrain) => {
+    const key = hasTrain && toStateKey(stateTxt) === 'unknown' ? 'before' : toStateKey(stateTxt);
     try{
       if (typeof buildWidgetStateBadge === 'function') return buildWidgetStateBadge(key);
     }catch(e){}
-    // fallback (au cas où)
     const label = (key === 'after') ? 'ARRIVÉ' : (key === 'running') ? 'Live' : (key === 'before') ? 'A VENIR' : '—';
     return `<span class="fav-state-badge fav-state-${key}">${escapeHtml(label)}</span>`;
   };
 
-  const buildRow = (k, data, label) => {
-    const trainTxt = data.train && data.train !== '—' ? data.train : '—';
-    const metaTxt  = data.meta && data.meta !== '—' ? data.meta : '';
-    const safeMeta = metaTxt ? escapeHtml(metaTxt) : '<span style="opacity:.55">—</span>';
+  const read = (k) => {
+    try{
+      const cache = window.__lbHomeFavPreviewData?.[k] || null;
+      if (cache && (cache.train || cache.meta || cache.state)) return cache;
+      return {
+        train: (document.getElementById('favTrain'+k)?.textContent || '').trim(),
+        meta: (document.getElementById('favMeta'+k)?.textContent || '').trim(),
+        state: (document.getElementById('favState'+k)?.textContent || '').trim()
+      };
+    }catch(e){
+      return { train:'', meta:'', state:'' };
+    }
+  };
+
+  const buildRow = (k, label) => {
+    const data = read(k);
+    const fallbackTrain = getHomeFavoriteTrainNo(k);
+    const trainMatch = String(data.train || '').match(/\d{5,6}/);
+    const trainNo = trainMatch ? trainMatch[0] : fallbackTrain;
+    const trainDisplay = String(data.train || '').trim() || trainNo || '—';
+    const metaText = String(data.meta || '').trim() || (trainNo ? 'Raccourci prêt.' : 'Ajoutez un train dans vos préférences.');
+    const count = trainNo ? getTrainCommentCount(trainNo) : 0;
 
     return `
       <div class="home-fav-row" data-fav-k="${k}" role="button" tabindex="0" aria-label="Ouvrir favoris ${label}">
         <div class="home-fav-left">
-          <div class="home-fav-train">${escapeHtml(trainTxt)} <span style="opacity:.6;font-weight:800;letter-spacing:.06em;">${label}</span></div>
-          <div class="home-fav-meta">${safeMeta}</div>
+          <div class="home-fav-train">${escapeHtml(trainDisplay)} <span style="opacity:.6;font-weight:800;letter-spacing:.06em;">${label}</span></div>
+          <div class="home-fav-meta">${escapeHtml(metaText)}</div>
         </div>
-        <div class="fav-train-badge home-fav-badge">${renderBadge(data.state)}</div>
+        <div class="fav-train-badge home-fav-badge">${renderBadge(data.state, !!trainNo)}</div>
+        <button type="button" class="home-comment-pill" data-train-comment="${trainNo}" ${trainNo ? '' : 'disabled'} aria-label="Commentaires ${label}">
+          <span class="home-comment-pill__emoji" aria-hidden="true">💬</span>
+          <span class="home-comment-pill__count">${count}</span>
+        </button>
       </div>
     `;
   };
 
-  slot.innerHTML = buildRow('AM', am, 'Matin') + buildRow('PM', pm, 'Soir');
+  slot.innerHTML = buildRow('AM', 'Matin') + buildRow('PM', 'Soir');
 
-  // clic / clavier -> ouvre le bon favori (Matin / Soir)
   const jumpToFav = (k) => {
     location.hash = '#favTrainsWidget';
-
-    const getTopOffset = () => {
-      try{
-        const topBar = document.querySelector('.top-bar');
-        if (topBar) return Math.round(topBar.getBoundingClientRect().height) + 8;
-        const css = getComputedStyle(document.documentElement).getPropertyValue('--top-bar-height').trim();
-        if (css && css.endsWith('px')) return (parseFloat(css) || 0) + 8;
-      }catch(e){}
-      return 72;
-    };
-    const getBottomOffset = () => {
-      try{
-        const bottom = document.querySelector('.bottom-nav');
-        if (bottom) return Math.round(bottom.getBoundingClientRect().height) + 8;
-        const css = getComputedStyle(document.documentElement).getPropertyValue('--bottom-bar-height').trim();
-        if (css && css.endsWith('px')) return (parseFloat(css) || 0) + 8;
-      }catch(e){}
-      return 84;
-    };
-
     window.setTimeout(() => {
       const id = (k === 'PM') ? 'favCardPM' : 'favCardAM';
       const card = document.getElementById(id);
       if (!card) return;
-
-      const topOff = getTopOffset();
-      const botOff = getBottomOffset();
-      const vh = window.innerHeight || document.documentElement.clientHeight || 800;
-      const visibleH = Math.max(120, vh - topOff - botOff);
-      const rect = card.getBoundingClientRect();
-      const absTop = rect.top + (window.pageYOffset || document.documentElement.scrollTop || 0);
-      const targetY = absTop - topOff - Math.max(0, (visibleH - rect.height) / 2);
-
       try{
-        window.scrollTo({ top: Math.max(0, Math.round(targetY)), behavior: 'smooth' });
+        card.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }catch(e){
-        window.scrollTo(0, Math.max(0, Math.round(targetY)));
+        card.scrollIntoView();
       }
-
       card.classList.add('home-jump-highlight');
       window.setTimeout(()=>card.classList.remove('home-jump-highlight'), 1300);
     }, 80);
   };
 
-  slot.querySelectorAll('.home-fav-row').forEach(row=>{
+  slot.querySelectorAll('.home-fav-row').forEach((row) => {
     const k = row.getAttribute('data-fav-k');
-    row.addEventListener('click', ()=>jumpToFav(k));
-    row.addEventListener('keydown', (e)=>{ if(e.key==='Enter' || e.key===' '){ e.preventDefault(); jumpToFav(k);} });
+    row.addEventListener('click', () => jumpToFav(k));
+    row.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); jumpToFav(k); } });
+  });
+  slot.querySelectorAll('.home-comment-pill').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const train = String(btn.dataset.trainComment || '');
+      if (!train || typeof window.lbOpenTrainDetail !== 'function') return;
+      window.lbOpenTrainDetail(train, document.getElementById('trainDate')?.value || luxTodayYMD());
+    });
   });
 }
 
@@ -21989,7 +22350,7 @@ function ensureFavInHome(){
   const cta = document.getElementById('homeFavLoginCta');
   if (!slot) return;
 
-  const authed = (window.lbIsAuthed === true);
+  const authed = hasHomeAuthContext();
   if (cta) cta.style.display = authed ? 'none' : 'block';
 
   if (!authed){
@@ -23030,6 +23391,8 @@ async function loadAffluenceDate(dateStr){
     const statsBtn = document.getElementById('trainDetailStatsBtn');
 
     panel.hidden = false;
+    lbCurrentDetailTrain = String(trainNumber || '').trim();
+    try{ window.lbComments?.setCurrentTrain(lbCurrentDetailTrain); }catch(e){}
     titleEl.textContent = `Train ${trainNumber}`;
     nextEl.textContent = 'Chargement…';
     relEl.textContent = 'Chargement…';


### PR DESCRIPTION
### Motivation
- Provide an in-app, local comment system so users can post quick messages on the home "live wall" and on individual train detail pages without a backend integration.
- Surface comment counts in the favorites preview and allow quick navigation from favorites to the train detail comments.

### Description
- Adds UI and styles for a home "live wall" and train comments: new CSS classes (e.g. `.live-wall-*`, `.train-comments*`) and HTML blocks inserted in the home and train detail panels, including a small comment form and badges (`#homeLiveWallFeed`, `#trainDetailComments`).
- Implements a client-side comment store persisted to `localStorage` using the key `LB_COMMENTS_STORAGE_KEY` with a BroadcastChannel fallback for multi-tab sync and functions `loadCommentState`, `saveCommentState`, `addComment`, `getTrainComments`, and helpers for formatting and rendering (`renderHomeLiveWall`, `renderTrainComments`, `renderCommentsUI`, `bindCommentForms`).
- Exposes a small API `window.lbComments` with `setCurrentTrain`, `refresh`, and `count`, and wires train detail opening to set the current train (`lbCurrentDetailTrain`) so train-specific comments are shown when a train is opened.
- Integrates comments into the favorites preview flow by adding `getHomeFavoriteTrainNo` and `hasHomeAuthContext`, updating `updateFavoriteWidgetFromPrefs` and `lbRenderHomeFavPreview` to show comment counts and a clickable comment pill that opens the train detail, plus synchronisation hooks (`window.lbComments?.refresh()`) after auth/prefs load.
- Minor UI/UX tweaks in `lbRenderHomeFavPreview` such as safer string handling, fallback train resolution, and swapping manual scroll calculations for `card.scrollIntoView()`.

### Testing
- No automated tests were executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0304ae28832da4a93f5f6e21fb61)