### PR TITLE
Add in-page comment wall with localStorage-backed adapter and auth integration

### DIFF
--- a/index20.html
+++ b/index20.html
@@ -707,6 +707,27 @@ body {
 .traffic-pill--orange{ background:rgba(255,138,26,.14); border-color:rgba(255,138,26,.45); color:#ffba74; }
 .traffic-pill--red{ background:rgba(255,49,49,.14); border-color:rgba(255,49,49,.45); color:#ff8d8d; }
 .traffic-pill--loading{ background:rgba(0,240,255,.12); border-color:rgba(0,240,255,.35); color:#8ff9ff; }
+.comment-wall{ display:grid; gap:6px; }
+.comment-wall__header{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.comment-wall__status{ display:inline-flex; align-items:center; gap:5px; padding:3px 8px; border-radius:999px; border:1px solid rgba(0,240,255,.22); background:rgba(0,0,0,.14); color:#d7fbff; font-size:.64rem; font-weight:800; white-space:nowrap; }
+.comment-wall__status::before{ content:""; width:6px; height:6px; border-radius:50%; background:#00f0ff; box-shadow:0 0 6px rgba(0,240,255,.5); }
+.comment-wall__composer{ display:grid; gap:4px; }
+.comment-wall__composer-row{ display:grid; grid-template-columns:1fr auto; gap:6px; align-items:end; }
+.comment-wall__textarea{ width:100%; min-height:46px; max-height:76px; resize:vertical; border-radius:12px; border:1px solid rgba(0,240,255,.22); background:rgba(2,18,33,.72); color:#ebfbff; padding:8px 10px; font:inherit; font-size:.78rem; box-shadow: inset 0 0 10px rgba(0,240,255,.06); }
+.comment-wall__textarea:focus{ outline:none; border-color:rgba(0,240,255,.48); box-shadow: inset 0 0 12px rgba(0,240,255,.1), 0 0 0 2px rgba(0,240,255,.1); }
+.comment-wall__textarea:disabled{ opacity:.68; cursor:not-allowed; }
+.comment-wall__submit{ align-self:stretch; min-height:46px; padding:0 12px !important; font-size:.76rem !important; }
+.comment-wall__hint{ color:#9fd9df; font-size:.65rem; min-height:1em; }
+.comment-wall__list{ display:grid; gap:5px; max-height:180px; overflow-y:auto; padding-right:2px; }
+.comment-wall__list::-webkit-scrollbar{ width:6px; }
+.comment-wall__list::-webkit-scrollbar-thumb{ background:rgba(0,240,255,.28); border-radius:999px; }
+.comment-wall__item{ padding:7px 9px; border-radius:12px; border:1px solid rgba(0,240,255,.16); background:rgba(0,0,0,.18); box-shadow: inset 0 0 8px rgba(0,240,255,.05); }
+.comment-wall__meta{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.comment-wall__time{ color:#8eb8c7; font-size:.63rem; white-space:nowrap; }
+.comment-wall__body{ margin:0; color:#ecfbff; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; line-height:1.25; font-size:.76rem; }
+.comment-wall__body-pseudo{ color:#7ef7ff; font-weight:800; }
+.comment-wall__empty{ margin:0; padding:9px; border-radius:12px; border:1px dashed rgba(0,240,255,.2); background:rgba(0,0,0,.12); color:#b8d9e5; font-size:.72rem; text-align:center; }
+.comment-wall__locked{ color:#ffcf8c; }
 .quick-links{
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -8125,6 +8146,25 @@ html, body{
         <div class="traffic-split-row">
           <span class="traffic-split-line" id="homeTrafficLineSouth">Nancy - Metz</span>
           <span class="traffic-pill traffic-pill--loading" id="homeTrafficBadgeSouth">Chargement…</span>
+        </div>
+      </div>
+    </article>
+
+    <article class="home-card" aria-label="Mur de commentaires de la ligne">
+      <div class="comment-wall">
+        <div class="comment-wall__header">
+          <h2>Mur de la ligne</h2>
+          <div class="comment-wall__status" id="homeCommentStatus">Lecture seule</div>
+        </div>
+
+        <div id="homeCommentList" class="comment-wall__list" aria-live="polite"></div>
+
+        <div class="comment-wall__composer">
+          <div class="comment-wall__composer-row">
+            <textarea id="homeCommentInput" class="comment-wall__textarea" maxlength="280" placeholder="Signaler une info de ligne…" aria-label="Écrire un commentaire"></textarea>
+            <button class="home-action comment-wall__submit" id="homeCommentSubmit" type="button">Publier</button>
+          </div>
+          <div class="comment-wall__hint" id="homeCommentHint">Connecte-toi pour publier.</div>
         </div>
       </div>
     </article>
@@ -19208,6 +19248,7 @@ function scheduleWeatherAfterTableSettled(){
 
     // Rafraîchir le widget favoris
     try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
+    try { renderCommentWall(); } catch(e) {}
 
     if (!options.auto) return;
   };
@@ -20390,6 +20431,171 @@ if (statsEl){
     }
   });
 
+
+  const LB_COMMENT_STORAGE_KEY = "lb_home_comments_v1";
+  const LB_COMMENT_MAX_LENGTH = 280;
+  const LB_COMMENT_VISIBLE_COUNT = 4;
+
+  const getCommentWallElements = () => ({
+    status: $("homeCommentStatus"),
+    input: $("homeCommentInput"),
+    hint: $("homeCommentHint"),
+    submit: $("homeCommentSubmit"),
+    list: $("homeCommentList")
+  });
+
+  const formatCommentTime = (value) => {
+    const date = value ? new Date(value) : null;
+    if (!date || Number.isNaN(date.getTime())) return "À l’instant";
+    try {
+      return new Intl.DateTimeFormat('fr-FR', { dateStyle: 'short', timeStyle: 'short' }).format(date);
+    } catch(_e) {
+      return date.toLocaleString('fr-FR');
+    }
+  };
+
+  const normalizeCommentEntry = (entry = {}) => {
+    const pseudo = String(entry.pseudo || '').trim().slice(0, 24);
+    const message = String(entry.message || '').trim().slice(0, LB_COMMENT_MAX_LENGTH);
+    const createdAt = entry.createdAt || new Date().toISOString();
+    return pseudo && message ? { pseudo, message, createdAt } : null;
+  };
+
+  const defaultCommentWallAdapter = {
+    async list() {
+      try {
+        const raw = localStorage.getItem(LB_COMMENT_STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed.map(normalizeCommentEntry).filter(Boolean);
+      } catch(_e) {
+        return [];
+      }
+    },
+    async add(entry) {
+      const nextEntry = normalizeCommentEntry(entry);
+      if (!nextEntry) throw new Error('Commentaire invalide.');
+      const current = await this.list();
+      current.push(nextEntry);
+      const trimmed = current.slice(-100);
+      localStorage.setItem(LB_COMMENT_STORAGE_KEY, JSON.stringify(trimmed));
+      return nextEntry;
+    }
+  };
+
+  window.lbCommentWallAdapter = window.lbCommentWallAdapter || defaultCommentWallAdapter;
+
+  const getCommentAuthorPseudo = () => {
+    const fromPrefs = String(window.lbPrefsCache?.pseudo || '').trim();
+    if (fromPrefs) return fromPrefs.slice(0, 24);
+    const fromInput = String($("lbPseudo")?.value || '').trim();
+    return fromInput ? fromInput.slice(0, 24) : '';
+  };
+
+  const renderCommentWall = async () => {
+    const els = getCommentWallElements();
+    if (!els.list) return;
+
+    const isAuthed = !!window.lbIsAuthed;
+    const pseudo = getCommentAuthorPseudo();
+    const canPost = isAuthed && !!pseudo;
+    const adapter = window.lbCommentWallAdapter || defaultCommentWallAdapter;
+
+    if (els.status) els.status.textContent = canPost ? 'Connecté · publication active' : 'Lecture seule';
+    if (els.input) {
+      els.input.disabled = !canPost;
+      if (!canPost) {
+        els.input.value = '';
+        els.input.placeholder = isAuthed
+          ? 'Ajoute un pseudo dans Mes préférences pour publier.'
+          : 'Les visiteurs peuvent lire les messages, mais pas écrire.';
+      } else {
+        els.input.placeholder = 'Ex : 88532 supprimé à Metz, report sur le train suivant…';
+      }
+    }
+    if (els.submit) els.submit.disabled = !canPost;
+    if (els.hint) {
+      els.hint.textContent = canPost
+        ? ''
+        : (isAuthed ? 'Ajoute un pseudo dans Mes préférences.' : 'Connecte-toi pour publier.');
+      els.hint.classList.toggle('comment-wall__locked', !canPost);
+    }
+
+    let comments = [];
+    try {
+      comments = await adapter.list();
+    } catch(_e) {
+      comments = [];
+    }
+
+    const ordered = comments
+      .slice()
+      .filter(Boolean)
+      .sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0));
+
+    els.list.innerHTML = '';
+    if (!ordered.length) {
+      const empty = document.createElement('p');
+      empty.className = 'comment-wall__empty';
+      empty.textContent = 'Pas encore de message sur la ligne. Soyez la première vache à signaler une info utile.';
+      els.list.appendChild(empty);
+      return;
+    }
+
+    ordered.forEach((comment, index) => {
+      const item = document.createElement('article');
+      item.className = 'comment-wall__item';
+      if (index >= LB_COMMENT_VISIBLE_COUNT) item.setAttribute('data-comment-older', '1');
+
+      const meta = document.createElement('div');
+      meta.className = 'comment-wall__meta';
+
+      const time = document.createElement('div');
+      time.className = 'comment-wall__time';
+      time.textContent = formatCommentTime(comment.createdAt);
+
+      const body = document.createElement('p');
+      body.className = 'comment-wall__body';
+      body.innerHTML = `<span class="comment-wall__body-pseudo"></span> : <span class="comment-wall__body-message"></span>`;
+      body.querySelector('.comment-wall__body-pseudo').textContent = comment.pseudo;
+      body.querySelector('.comment-wall__body-message').textContent = comment.message;
+
+      meta.append(time);
+      item.append(meta, body);
+      els.list.appendChild(item);
+    });
+  };
+
+  const submitCommentWallMessage = async () => {
+    const els = getCommentWallElements();
+    if (!els.input) return;
+    if (!window.lbIsAuthed) return renderCommentWall();
+
+    const pseudo = getCommentAuthorPseudo();
+    const message = String(els.input.value || '').trim();
+    if (!pseudo) {
+      if (els.hint) els.hint.textContent = 'Ajoute un pseudo dans Mes préférences avant de publier.';
+      return renderCommentWall();
+    }
+    if (!message) {
+      if (els.hint) els.hint.textContent = 'Écris un message avant de publier.';
+      return;
+    }
+
+    const adapter = window.lbCommentWallAdapter || defaultCommentWallAdapter;
+    if (els.submit) els.submit.disabled = true;
+    try {
+      await adapter.add({ pseudo, message, createdAt: new Date().toISOString() });
+      els.input.value = '';
+      await renderCommentWall();
+    } catch (err) {
+      if (els.hint) els.hint.textContent = `Impossible d’enregistrer le message : ${err?.message || err}`;
+    } finally {
+      if (els.submit) els.submit.disabled = false;
+    }
+  };
+
   let lbIsAuthed = false;
   window.lbIsAuthed = false;
   const refreshAccountUI = async () => {
@@ -20423,6 +20629,7 @@ if (statsEl){
       if (deleteLinkWrap) deleteLinkWrap.style.display = "block";
       msg(`✅ Connecté : ${me?.user?.email || "utilisateur"}`);
       await loadPreferences();
+      await renderCommentWall();
       try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") await window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
     } catch {
       openBtn.textContent = "Se connecter";
@@ -20465,6 +20672,7 @@ if (statsEl){
         window.updateStatsConsoleAuth(false);
       }
       msg("ℹ️ Non connecté");
+      await renderCommentWall();
     }
     updateQuickAddButton();
     updateSelectionApplyButton();
@@ -20496,6 +20704,22 @@ if (statsEl){
   const switchBtn = $("lbAuthSwitchBtn");
 
   if (!openBtn || !closeBtn || !modal || !submitBtn || !logoutBtn) return;
+
+  const commentSubmitBtn = $("homeCommentSubmit");
+  const commentInput = $("homeCommentInput");
+  if (commentSubmitBtn) commentSubmitBtn.addEventListener("click", submitCommentWallMessage);
+  if (commentInput) {
+    commentInput.addEventListener("keydown", (event) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+        event.preventDefault();
+        submitCommentWallMessage();
+      }
+    });
+  }
+  window.addEventListener("storage", (event) => {
+    if (event.key === LB_COMMENT_STORAGE_KEY) renderCommentWall().catch(() => {});
+  });
+  renderCommentWall().catch(() => {});
 
   openBtn.addEventListener("click", openModal);
   closeBtn.addEventListener("click", closeModal);


### PR DESCRIPTION
### Motivation
- Add a lightweight in-home "comment wall" to let users read and (when authenticated and with a pseudo) post short line-specific messages. 
- Provide a simple client-side persistence and an adapter extension point so the feature works offline or can be swapped for a server-backed store. 
- Integrate posting availability with existing authentication and user preference flows so posting is enabled only when `window.lbIsAuthed` and a pseudo are present.

### Description
- Added CSS for the comment wall under `.comment-wall*` to style header, list, composer, hints, and scrollbar. 
- Injected HTML `article` for the comment wall into the home page with elements `homeCommentList`, `homeCommentInput`, `homeCommentSubmit`, `homeCommentStatus` and related UI. 
- Implemented comment wall JS including constants `LB_COMMENT_STORAGE_KEY`, helpers to format time and normalize entries, and a default adapter that persists comments to `localStorage`. 
- Added `renderCommentWall()` and `submitCommentWallMessage()` functions, wired submit button and `Ctrl/Cmd+Enter` handling, a `storage` event listener for cross-tab updates, and integration points to call `renderCommentWall()` after prefs/auth state changes; exposed `window.lbCommentWallAdapter` for overrides.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc160184e4832da548e8b7e2c4d68c)