### PR TITLE
Add local live comments (home & train) and mobile layout / UI improvements

### DIFF
--- a/index20.html
+++ b/index20.html
@@ -387,6 +387,131 @@ body {
   .home-dashboard{ grid-template-columns: 1fr; }
 }
 
+@media (max-width: 700px){
+  .home-dashboard{
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, .95fr);
+    grid-template-areas:
+      "welcome welcome"
+      "traffic weather"
+      "ber ber"
+      "comments comments";
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+  .home-dashboard > *{ min-width: 0; }
+  #homeWelcomeLine{ grid-area: welcome; margin-bottom: 0; }
+  .home-card[aria-label="Info trafic"]{ grid-area: traffic; }
+  .home-card[aria-label="Météo sur votre ligne"]{ grid-area: weather; }
+  .home-card[forwarding="ber"]{ grid-area: ber; }
+  .live-wall-card--home{ grid-area: comments; }
+
+  .home-card[aria-label="Info trafic"]{
+    padding-left: 9px;
+    padding-right: 9px;
+  }
+  .home-card{
+    padding: 10px 10px;
+    border-radius: 16px;
+  }
+  .home-card h2{
+    font-size: .96rem;
+    margin-bottom: 6px;
+  }
+
+  .traffic-split{ gap: 6px; }
+  .traffic-split-row{
+    display:grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items:center;
+    gap: 7px;
+    padding: 7px 8px;
+    min-width: 0;
+    overflow: hidden;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+  }
+  .traffic-split-line{
+    min-width: 0;
+    font-size: .80rem;
+    line-height: 1.1;
+  }
+  .traffic-pill{
+    flex: 0 0 auto;
+    max-width: 68px;
+    font-size: .56rem;
+    padding: 4px 7px;
+    line-height: 1.05;
+    white-space: normal;
+    text-align: center;
+  }
+
+  .home-card[aria-label="Météo sur votre ligne"] .wx-stations{
+    grid-template-columns: 1fr;
+    gap: 6px;
+    margin-top: 4px;
+  }
+  .home-card[aria-label="Météo sur votre ligne"] .wx-station{
+    padding: 7px 8px;
+    min-height: 64px;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+  }
+  .home-card[aria-label="Météo sur votre ligne"] .wx-row{
+    gap: 4px;
+    align-items: center;
+    text-align: center;
+  }
+  .home-card[aria-label="Météo sur votre ligne"] .wx-now{
+    justify-content: center;
+    width: 100%;
+    font-size: .95rem;
+  }
+  .home-card[aria-label="Météo sur votre ligne"] .wx-title{
+    margin-top: 0;
+    font-size: .62rem;
+    line-height: 1.1;
+    white-space: normal;
+  }
+  .wx-station--punctuality .wx-row{
+    gap: 3px;
+  }
+  .wx-station--punctuality .wx-title{
+    order: -1;
+    font-size: .60rem;
+  }
+  .wx-station--punctuality .wx-now{
+    font-size: 1rem;
+  }
+
+  .home-card[forwarding="ber"]{
+    padding-top: 9px !important;
+    padding-bottom: 9px !important;
+  }
+  .home-card[forwarding="ber"] .ber-metric{
+    display:none !important;
+  }
+  .home-card[forwarding="ber"] .ber-line1{
+    font-size: .96rem;
+    line-height: 1.1;
+  }
+  .home-stats-panel{
+    gap: 8px;
+  }
+  .home-stats-item{
+    padding: 8px 10px;
+  }
+
+  .live-wall-card--home{
+    margin-top: -2px;
+    gap: 6px;
+  }
+  .live-wall-feed--home{
+    max-height: 148px;
+  }
+}
+
 .home-card .subtle{
   color: rgba(224, 240, 255, 0.78);
   font-size: 0.95rem;
@@ -707,6 +832,110 @@ body {
 .traffic-pill--orange{ background:rgba(255,138,26,.14); border-color:rgba(255,138,26,.45); color:#ffba74; }
 .traffic-pill--red{ background:rgba(255,49,49,.14); border-color:rgba(255,49,49,.45); color:#ff8d8d; }
 .traffic-pill--loading{ background:rgba(0,240,255,.12); border-color:rgba(0,240,255,.35); color:#8ff9ff; }
+
+.live-wall-card{
+  border: 1px solid rgba(0,240,255,.25);
+  background: linear-gradient(135deg, rgba(6,16,30,.92), rgba(6,20,36,.86));
+}
+.live-wall-card--home{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.live-wall-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  margin-bottom:2px;
+}
+.live-wall-title{ margin:0; font-size:1rem; letter-spacing:.04em; color:#7ef7ff; }
+.live-wall-badge{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:38px;
+  padding:4px 9px;
+  border-radius:999px;
+  border:1px solid rgba(0,240,255,.32);
+  background:rgba(0,14,26,.58);
+  color:#dffbff;
+  font-size:.72rem;
+  font-weight:800;
+}
+.live-wall-feed{
+  display:grid;
+  gap:6px;
+}
+.live-wall-feed--home{
+  max-height: 196px;
+  overflow:auto;
+  padding-right:2px;
+}
+.live-wall-item{
+  border:1px solid rgba(0,240,255,.2);
+  border-radius:12px;
+  padding:6px 8px;
+  background:rgba(0,8,18,.45);
+  font-size:.84rem;
+}
+.live-wall-item--home{
+  padding:6px 8px;
+}
+.live-wall-item-text{
+  line-height:1.22;
+  display:-webkit-box;
+  -webkit-line-clamp:2;
+  -webkit-box-orient:vertical;
+  overflow:hidden;
+}
+.live-wall-meta{ font-size:.72rem; opacity:.78; margin-bottom:3px; display:flex; gap:8px; flex-wrap:wrap; }
+.live-wall-form{ margin-top:2px; display:flex; gap:6px; }
+.live-wall-form input{ flex:1; min-width:0; }
+.live-wall-empty,
+.live-wall-cta{ opacity:.7; font-size:.82rem; }
+
+.fav-comments-row{ margin-top:8px; display:flex; justify-content:flex-end; }
+.fav-comment-btn{
+  border:1px solid rgba(0,240,255,.45);
+  border-radius:999px;
+  background:rgba(0,14,26,.58);
+  color:#dffbff;
+  padding:5px 10px;
+  font-size:.78rem;
+  cursor:pointer;
+}
+
+.train-comments{
+  margin-top:10px;
+  border:1px solid rgba(0,240,255,.2);
+  border-radius:10px;
+  background:rgba(0,10,20,.35);
+  padding:10px;
+}
+.train-comments-head{ display:flex; justify-content:space-between; align-items:center; margin-bottom:6px; }
+.train-comments-list{ max-height:170px; overflow:auto; display:grid; gap:6px; }
+.train-comments-item{ border-bottom:1px dashed rgba(0,240,255,.14); padding-bottom:6px; }
+.train-comments-item:last-child{ border-bottom:none; padding-bottom:0; }
+.train-comments-form{ margin-top:8px; display:flex; gap:6px; }
+.train-comments-form input{ flex:1; min-width:0; }
+
+@media (max-width: 820px){
+  .live-wall-card--home{ order: 2; }
+}
+
+@media (max-width: 600px){
+  .live-wall-card--home{
+    padding: 10px 12px !important;
+    gap: 6px;
+  }
+  .live-wall-title{ font-size: .94rem; }
+  .live-wall-badge{ font-size:.68rem; padding:3px 8px; min-width:34px; }
+  .live-wall-feed--home{ max-height: 176px; gap:5px; }
+  .live-wall-item--home{ padding:5px 7px; }
+  .live-wall-item--home .live-wall-meta{ font-size:.68rem; margin-bottom:2px; gap:6px; }
+  .live-wall-item--home .live-wall-item-text{ font-size:.76rem; }
+}
 .quick-links{
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -8129,8 +8358,23 @@ html, body{
       </div>
     </article>
 
+    <article class="home-card live-wall-card live-wall-card--home" aria-label="Mur de commentaires">
+      <div class="live-wall-head">
+        <h2 class="live-wall-title">Commentaires</h2>
+        <span class="live-wall-badge" id="homeLiveWallCount">0</span>
+      </div>
+      <div id="homeLiveWallFeed" class="live-wall-feed live-wall-feed--home">
+        <div class="live-wall-empty">Aucun commentaire pour le moment.</div>
+      </div>
+      <div id="homeLiveWallCta" class="live-wall-cta" hidden>Connectez-vous pour commenter en direct.</div>
+      <form id="homeLiveWallForm" class="live-wall-form" autocomplete="off" hidden>
+        <input id="homeLiveWallInput" type="text" maxlength="180" placeholder="Partager une info rapide">
+        <button type="submit" class="auth-button">Envoyer</button>
+      </form>
+    </article>
+
     <article class="home-card" aria-label="Météo sur votre ligne">
-      <h2>Météo sur votre ligne</h2>
+      <h2>Météo</h2>
 
       <div class="wx-stations">
         <div class="wx-station">
@@ -8144,6 +8388,13 @@ html, body{
           <div class="wx-row">
             <div class="wx-now" id="homeWxToNow">—</div>
 			<div class="wx-title" id="homeWxToTitle">Luxembourg</div>
+          </div>
+        </div>
+
+        <div class="wx-station wx-station--punctuality">
+          <div class="wx-row">
+            <div class="wx-title">Ponctualité hier</div>
+            <div class="wx-now" id="homeWxPunctuality">—</div>
           </div>
         </div>
       </div>
@@ -8679,6 +8930,17 @@ html, body{
     <div class="aff-chart" style="margin-top:8px"><canvas id="trainDetailAffluenceChart" height="92"></canvas></div>
   </div>
   <div class="train-detail-route" id="trainDetailStops"></div>
+  <div class="train-comments" id="trainDetailComments">
+    <div class="train-comments-head">
+      <strong>Commentaires</strong>
+      <span id="trainDetailCommentsCount">0</span>
+    </div>
+    <div id="trainDetailCommentsList" class="train-comments-list"></div>
+    <form id="trainDetailCommentsForm" class="train-comments-form" autocomplete="off" hidden>
+      <input id="trainDetailCommentsInput" type="text" maxlength="180" placeholder="Ajouter un commentaire sur ce train">
+      <button type="submit" class="auth-button">Envoyer</button>
+    </form>
+  </div>
   <div class="train-detail-actions">
     <a id="trainDetailAffBtn" class="train-detail-btn" href="#affluence">🚆 Ouvrir dans Affluence</a>
     <a id="trainDetailStatsBtn" class="train-detail-btn" href="#stats">📊 Voir schéma stats du train</a>
@@ -19127,6 +19389,174 @@ function scheduleWeatherAfterTableSettled(){
     return data;
   };
 
+  const LB_COMMENTS_STORAGE_KEY = 'lb_comments_v1';
+  const lbCommentsChannel = ('BroadcastChannel' in window) ? new BroadcastChannel('lb_comments_channel') : null;
+  let lbCommentState = { wall: [], trains: {} };
+  let lbCurrentDetailTrain = '';
+
+  const safePseudo = () => String(lbPrefsCache?.pseudo || '').trim().slice(0,24);
+  const isCommentingAllowed = () => window.lbIsAuthed === true && !!safePseudo();
+
+  function loadCommentState(){
+    try{
+      const raw = localStorage.getItem(LB_COMMENTS_STORAGE_KEY);
+      if (!raw) return { wall: [], trains: {} };
+      const js = JSON.parse(raw);
+      if (!js || typeof js !== 'object') return { wall: [], trains: {} };
+      return {
+        wall: Array.isArray(js.wall) ? js.wall : [],
+        trains: (js.trains && typeof js.trains === 'object') ? js.trains : {}
+      };
+    }catch(e){
+      return { wall: [], trains: {} };
+    }
+  }
+
+  function saveCommentState(){
+    try{ localStorage.setItem(LB_COMMENTS_STORAGE_KEY, JSON.stringify(lbCommentState)); }catch(e){}
+    try{ lbCommentsChannel?.postMessage({ type: 'sync' }); }catch(e){}
+  }
+
+  function getTrainComments(trainNumber){
+    const key = String(trainNumber || '').trim();
+    if (!key) return [];
+    const list = lbCommentState?.trains?.[key];
+    return Array.isArray(list) ? list.slice().sort((a,b)=>(b.ts||0)-(a.ts||0)) : [];
+  }
+
+  function getTrainCommentCount(trainNumber){
+    return getTrainComments(trainNumber).length;
+  }
+
+  function addComment({ text, trainNumber = '' }){
+    const pseudo = safePseudo();
+    if (!isCommentingAllowed()) throw new Error('Connexion + pseudo requis');
+    const msg = String(text || '').trim().slice(0,180);
+    if (!msg) throw new Error('Commentaire vide');
+    const train = String(trainNumber || '').trim();
+    const item = {
+      id: `${Date.now()}_${Math.random().toString(36).slice(2,8)}`,
+      pseudo,
+      text: msg,
+      trainNumber: train,
+      ts: Date.now()
+    };
+    lbCommentState.wall = [item, ...(lbCommentState.wall || [])].slice(0,60);
+    if (train){
+      const arr = Array.isArray(lbCommentState.trains[train]) ? lbCommentState.trains[train] : [];
+      lbCommentState.trains[train] = [item, ...arr].slice(0,120);
+    }
+    saveCommentState();
+    renderCommentsUI();
+    return item;
+  }
+
+  const fmtHour = (ts) => {
+    try{ return new Date(ts || Date.now()).toLocaleTimeString('fr-FR', { hour:'2-digit', minute:'2-digit' }); }
+    catch(e){ return '—'; }
+  };
+
+  function renderHomeLiveWall(){
+    const feed = $('homeLiveWallFeed');
+    const form = $('homeLiveWallForm');
+    const cta = $('homeLiveWallCta');
+    const countEl = $('homeLiveWallCount');
+    if (!feed || !form || !cta || !countEl) return;
+    const wall = Array.isArray(lbCommentState.wall) ? lbCommentState.wall.slice(0,4) : [];
+    countEl.textContent = String(wall.length);
+    if (!wall.length) {
+      feed.innerHTML = '<div class="live-wall-empty">Aucun commentaire pour le moment.</div>';
+    } else {
+      feed.innerHTML = wall.map((it) => `
+        <div class="live-wall-item live-wall-item--home">
+          <div class="live-wall-meta"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span>${fmtHour(it.ts)}</span>${it.trainNumber ? `<span>#${escapeHtml(it.trainNumber)}</span>` : ''}</div>
+          <div class="live-wall-item-text">${escapeHtml(it.text || '')}</div>
+        </div>
+      `).join('');
+    }
+    const can = isCommentingAllowed();
+    form.hidden = !can;
+    cta.hidden = can;
+    if (!window.lbIsAuthed) cta.textContent = 'Connectez-vous pour commenter en direct.';
+    else if (!safePseudo()) cta.textContent = 'Ajoutez un pseudo dans Mes préférences pour commenter.';
+    else cta.textContent = '';
+  }
+
+  function renderTrainComments(trainNumber){
+    const listEl = $('trainDetailCommentsList');
+    const countEl = $('trainDetailCommentsCount');
+    const form = $('trainDetailCommentsForm');
+    if (!listEl || !countEl || !form) return;
+    const train = String(trainNumber || lbCurrentDetailTrain || '').trim();
+    const comments = getTrainComments(train).slice(0,30);
+    countEl.textContent = String(comments.length);
+    listEl.innerHTML = comments.length
+      ? comments.map((it)=>`<div class="train-comments-item"><div class="live-wall-meta"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span>${fmtHour(it.ts)}</span></div><div>${escapeHtml(it.text || '')}</div></div>`).join('')
+      : '<div class="live-wall-empty">Pas encore de commentaire sur ce train.</div>';
+    form.hidden = !isCommentingAllowed();
+  }
+
+  function renderCommentsUI(){
+    renderHomeLiveWall();
+    renderTrainComments(lbCurrentDetailTrain);
+  }
+
+  function bindCommentForms(){
+    const homeForm = $('homeLiveWallForm');
+    const homeInput = $('homeLiveWallInput');
+    if (homeForm && !homeForm.dataset.bound){
+      homeForm.dataset.bound = '1';
+      homeForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        try{
+          addComment({ text: homeInput?.value || '' });
+          if (homeInput) homeInput.value = '';
+        }catch(err){
+          alert(err?.message || "Impossible d'ajouter le commentaire.");
+        }
+      });
+    }
+    const trainForm = $('trainDetailCommentsForm');
+    const trainInput = $('trainDetailCommentsInput');
+    if (trainForm && !trainForm.dataset.bound){
+      trainForm.dataset.bound = '1';
+      trainForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        try{
+          addComment({ text: trainInput?.value || '', trainNumber: lbCurrentDetailTrain });
+          if (trainInput) trainInput.value = '';
+        }catch(err){
+          alert(err?.message || "Impossible d'ajouter le commentaire.");
+        }
+      });
+    }
+    try{
+      lbCommentsChannel?.addEventListener('message', (ev) => {
+        if (ev?.data?.type !== 'sync') return;
+        lbCommentState = loadCommentState();
+        renderCommentsUI();
+      });
+    }catch(e){}
+    window.addEventListener('storage', (ev) => {
+      if (ev.key !== LB_COMMENTS_STORAGE_KEY) return;
+      lbCommentState = loadCommentState();
+      renderCommentsUI();
+    });
+  }
+
+  window.lbComments = {
+    setCurrentTrain(trainNumber){
+      lbCurrentDetailTrain = String(trainNumber || '').trim();
+      renderTrainComments(lbCurrentDetailTrain);
+    },
+    refresh(){ renderCommentsUI(); },
+    count(trainNumber){ return getTrainCommentCount(trainNumber); }
+  };
+
+  lbCommentState = loadCommentState();
+  bindCommentForms();
+  renderCommentsUI();
+
   const openModal = () => {
     const modal = $("lbAuthModal");
     if (!modal) return;
@@ -19204,7 +19634,7 @@ function scheduleWeatherAfterTableSettled(){
       const wx = getUserWxPrefsOrDefault();
       updateHomeWeather(wx.from, wx.to).catch(()=>{});
     }catch(e){}
-
+    try{ window.lbComments?.refresh(); }catch(e){}
 
     // Rafraîchir le widget favoris
     try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
@@ -20424,6 +20854,7 @@ if (statsEl){
       msg(`✅ Connecté : ${me?.user?.email || "utilisateur"}`);
       await loadPreferences();
       try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") await window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
+      try{ window.lbComments?.refresh(); }catch(e){}
     } catch {
       openBtn.textContent = "Se connecter";
       logoutBtn.style.display = "none";
@@ -20465,6 +20896,7 @@ if (statsEl){
         window.updateStatsConsoleAuth(false);
       }
       msg("ℹ️ Non connecté");
+      try{ window.lbComments?.refresh(); }catch(e){}
     }
     updateQuickAddButton();
     updateSelectionApplyButton();
@@ -21678,32 +22110,39 @@ function __lbUpdateHomeTrafficUI(payload){
 }
 
 async function updateHomeTrafficStatus(){
-  // Si on a déjà les données GTFS-RT chargées, on les exploite.
-  // Sinon, on refetch juste le dataset SNCF Nancy/Metz/Lux.
-  try{
-    // (1) cas déjà chargé
-    if (window.retardsGTFS_RAW){
-      // si window.retardsGTFS_RAW est un rawByDataset, on passe tel quel
-      __lbUpdateHomeTrafficUI({ rawByDataset: window.retardsGTFS_RAW?.['sncf-nml'] ? window.retardsGTFS_RAW : null, raw: window.retardsGTFS_RAW });
-      return;
-    }
-  }catch{}
+  let hadImmediateData = false;
 
-  // (2) fetch du dataset SNCF (réutilise tes sources/fallbacks)
+  try{
+    if (window.retardsGTFS_RAW){
+      __lbUpdateHomeTrafficUI({
+        rawByDataset: window.retardsGTFS_RAW?.['sncf-nml'] ? window.retardsGTFS_RAW : null,
+        raw: window.retardsGTFS_RAW
+      });
+      hadImmediateData = true;
+    } else if (typeof hydrateGtfsRetardsFromCache === 'function' && hydrateGtfsRetardsFromCache()) {
+      __lbUpdateHomeTrafficUI({
+        rawByDataset: window.retardsGTFS_RAW?.['sncf-nml'] ? window.retardsGTFS_RAW : null,
+        raw: window.retardsGTFS_RAW
+      });
+      hadImmediateData = true;
+    }
+  }catch(_){}
+
   try{
     const dataset = (window.GTFS_RT_DATASETS || []).find(d => d.id === 'sncf-nml');
     if (!dataset) throw new Error('Dataset sncf-nml introuvable');
-    const result = await fetchGtfsDataset(dataset, { forceFresh: true });
+    const result = await fetchGtfsDataset(dataset, { forceFresh: false });
     __lbUpdateHomeTrafficUI({ raw: result?.raw, normalized: result?.normalized });
   }catch(e){
+    if (hadImmediateData) return;
     const lineNorth = document.getElementById('homeTrafficLineNorth');
     const lineSouth = document.getElementById('homeTrafficLineSouth');
     const badgeNorth = document.getElementById('homeTrafficBadgeNorth');
     const badgeSouth = document.getElementById('homeTrafficBadgeSouth');
     if (lineNorth) lineNorth.textContent = 'Metz - Luxembourg';
     if (lineSouth) lineSouth.textContent = 'Nancy - Metz';
-    __lbSetTrafficBadge(badgeNorth, { level:'loading', label:'Données indisponibles' });
-    __lbSetTrafficBadge(badgeSouth, { level:'loading', label:'Données indisponibles' });
+    __lbSetTrafficBadge(badgeNorth, { level:'loading', label:'Chargement…' });
+    __lbSetTrafficBadge(badgeSouth, { level:'loading', label:'Chargement…' });
   }
 }
 
@@ -21760,9 +22199,10 @@ async function fetchBerDailyMessage(dateStr){
 }
 
 function updateHomePunctuality(pct, label){
-  const el = document.getElementById('homeBerPunctuality');
-  if (!el) return;
-  el.textContent = fmtPct(pct);
+  ['homeBerPunctuality', 'homeWxPunctuality'].forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = fmtPct(pct);
+  });
 }
 
 
@@ -21791,8 +22231,10 @@ async function ensureYesterdayPunctuality(){
   const want = __luxYesterdayISO();
   if (window.__LB_LAST_YESTERDAY_DATE === want && typeof window.__LB_LAST_YESTERDAY_PCT === 'number') return window.__LB_LAST_YESTERDAY_PCT;
 
-  const el = document.getElementById('homeBerPunctuality');
-  if (el) el.textContent = '…';
+  ['homeBerPunctuality', 'homeWxPunctuality'].forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = '…';
+  });
 
   try{
     // on réutilise les helpers existants des stats si présents
@@ -21906,7 +22348,6 @@ function lbRenderHomeFavPreview(){
     try{
       if (typeof buildWidgetStateBadge === 'function') return buildWidgetStateBadge(key);
     }catch(e){}
-    // fallback (au cas où)
     const label = (key === 'after') ? 'ARRIVÉ' : (key === 'running') ? 'Live' : (key === 'before') ? 'A VENIR' : '—';
     return `<span class="fav-state-badge fav-state-${key}">${escapeHtml(label)}</span>`;
   };
@@ -21929,7 +22370,6 @@ function lbRenderHomeFavPreview(){
 
   slot.innerHTML = buildRow('AM', am, 'Matin') + buildRow('PM', pm, 'Soir');
 
-  // clic / clavier -> ouvre le bon favori (Matin / Soir)
   const jumpToFav = (k) => {
     location.hash = '#favTrainsWidget';
 
@@ -23030,6 +23470,8 @@ async function loadAffluenceDate(dateStr){
     const statsBtn = document.getElementById('trainDetailStatsBtn');
 
     panel.hidden = false;
+    lbCurrentDetailTrain = String(trainNumber || '').trim();
+    try{ window.lbComments?.setCurrentTrain(lbCurrentDetailTrain); }catch(e){}
     titleEl.textContent = `Train ${trainNumber}`;
     nextEl.textContent = 'Chargement…';
     relEl.textContent = 'Chargement…';


### PR DESCRIPTION
### Motivation
- Provide a lightweight in-app commenting feature for the home feed and per-train detail without requiring a server backend, and improve small-screen layout/usability for the dashboard and live feed components.
- Improve the home traffic fetch resilience and reduce visual noise by reusing cached GTFS-RT when available and adjusting loading behavior and labels.
- Surface punctuality metrics at more places in the UI and keep them synchronized.

### Description
- Added responsive CSS for the home dashboard and new styles for a `live-wall` widget, train comments, and several mobile optimizations (grid areas, paddings, font sizing, and max-heights).
- Injected a home live-wall HTML block and a train comments block in the train detail panel, and renamed the weather card header to `Météo` while adding a punctuality tile.
- Implemented a client-side comments system using `localStorage` and optional `BroadcastChannel` synchronization with functions to load/save state, `addComment`, getters, rendering (`renderHomeLiveWall`, `renderTrainComments`), and form bindings; exposed `window.lbComments` with `setCurrentTrain`, `refresh`, and `count` methods.
- Hooked comments refresh into auth/preferences lifecycle (`applyPreferences`, auth success/failure) and set the current train when opening the train detail panel.
- Updated `updateHomeTrafficStatus` to prefer immediate/cached GTFS-RT, use `hydrateGtfsRetardsFromCache` fallback, changed `fetchGtfsDataset` to avoid forcing fresh fetches, and adjusted loading badge labels; changed punctuality updates to write to both `homeBerPunctuality` and `homeWxPunctuality` elements.

### Testing
- No automated tests were added or modified for this change; the existing automated test suite was not altered as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0304ae28832da4a93f5f6e21fb61)