### PR TITLE
Add premium harmonisation CSS and JS for home dashboard UI polish

### DIFF
--- a/index23.html
+++ b/index23.html
@@ -25540,5 +25540,412 @@ document.addEventListener('DOMContentLoaded', function(){
 }
 </style>
 
+<style id="home-premium-harmonisation-final">
+:root{
+  --home-premium-font-base: clamp(0.95rem, 0.28vw + 0.88rem, 1.05rem);
+  --home-premium-font-small: clamp(0.78rem, 0.18vw + 0.74rem, 0.9rem);
+  --home-premium-font-title: clamp(1.02rem, 0.4vw + 0.94rem, 1.16rem);
+  --home-premium-font-display: clamp(1.55rem, 1.1vw + 1.2rem, 2.15rem);
+  --home-premium-radius: 20px;
+  --home-premium-ease: cubic-bezier(.22,.61,.36,1);
+  --home-premium-shadow: inset 0 0 18px rgba(0,240,255,.10), 0 18px 34px rgba(0,0,0,.26);
+  --bottom-bar-height: 72px !important;
+}
+
+#homeWelcomeLine,
+.home-welcome-line,
+.home-card,
+.home-card p,
+.home-card .subtle,
+.home-card .home-action,
+.traffic-split-line,
+.traffic-pill,
+.wx-title,
+.wx-mini,
+.wx-badge,
+.live-wall-item-text,
+.live-wall-meta,
+.live-wall-inline-meta,
+.live-wall-empty,
+.live-wall-cta,
+.home-fav-train,
+.home-fav-meta,
+.home-fav-pill,
+.home-stats-item .title,
+.home-stats-item .meta,
+.ber-line1,
+.ber-context,
+.ber-metric,
+.ber-metric .value{ letter-spacing:.01em; }
+
+#homeWelcomeLine,
+.home-welcome-line{
+  font-size: clamp(1.08rem, 0.56vw + 0.96rem, 1.34rem) !important;
+  font-weight: 800 !important;
+  line-height: 1.2 !important;
+  color: #eafcff !important;
+  text-wrap: balance;
+  margin: -8px 0 2px !important;
+  padding-top: 0 !important;
+}
+.home-dashboard{ gap: 18px; margin-top: -4px !important; }
+.top-bar__logo-icon{ height: 55px !important; }
+.top-bar__logo-text{ height: 34.5px !important; max-width: min(50vw, 334px) !important; }
+
+.home-card{
+  position: relative;
+  overflow: clip;
+  border-radius: var(--home-premium-radius) !important;
+  padding: 16px !important;
+  box-shadow: var(--home-premium-shadow) !important;
+  transition: transform .22s var(--home-premium-ease), border-color .22s var(--home-premium-ease), box-shadow .22s var(--home-premium-ease), background-color .22s var(--home-premium-ease);
+  will-change: transform;
+}
+.home-card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+  background: linear-gradient(180deg, rgba(126,247,255,.09), rgba(126,247,255,0) 34%);
+  opacity:.65;
+}
+.home-card:hover,
+.home-card:focus-within{
+  transform: translateY(-2px);
+  border-color: rgba(126,247,255,.42);
+  box-shadow: inset 0 0 18px rgba(0,240,255,.12), 0 22px 38px rgba(0,0,0,.30);
+}
+.home-card h2,
+.live-wall-title{
+  font-size: var(--home-premium-font-title) !important;
+  line-height: 1.15 !important;
+  font-weight: 800 !important;
+  letter-spacing: .03em !important;
+  margin-bottom: 10px !important;
+}
+.home-card p,
+.home-card .subtle,
+.home-fav-meta,
+.ber-context,
+.live-wall-item,
+.live-wall-empty,
+.live-wall-cta,
+.home-stats-item .meta,
+.wx-mini,
+.wx-badge,
+.live-wall-form input,
+.live-wall-form button,
+.home-card .home-action{
+  font-size: var(--home-premium-font-base) !important;
+  line-height: 1.42 !important;
+}
+.home-fav-train,
+.traffic-split-line,
+.ber-line1,
+.ber-metric,
+.home-stats-item .value{
+  font-size: clamp(0.97rem, 0.24vw + 0.91rem, 1.08rem) !important;
+  line-height: 1.25 !important;
+}
+.traffic-pill,
+.home-fav-pill,
+.live-wall-badge,
+.wx-title,
+.home-stats-item .title,
+.live-wall-meta,
+.live-wall-inline-meta{
+  font-size: var(--home-premium-font-small) !important;
+  line-height: 1.18 !important;
+  font-weight: 800 !important;
+}
+.wx-title,
+.home-stats-item .title,
+.live-wall-badge,
+.traffic-pill,
+.home-fav-pill{ text-transform: uppercase; }
+.wx-now .wx-temp,
+.home-card[aria-label="Météo sur votre ligne"] #homeWxPunctuality,
+.home-card[aria-label="Météo sur votre ligne"] .wx-station--punctuality .wx-now,
+.home-card[forwarding="ber"] #homeBerPunctuality,
+.home-card[forwarding="ber"] .ber-metric .value{
+  font-size: var(--home-premium-font-display) !important;
+  line-height: .96 !important;
+  letter-spacing: 0 !important;
+}
+.wx-now .wx-icon{ font-size: clamp(1.35rem, 0.75vw + 1.1rem, 1.95rem) !important; }
+.traffic-split,
+.wx-stations,
+.home-fav-preview,
+.live-wall-feed,
+.home-stats-panel,
+.ber-lines{ gap: 10px !important; }
+.traffic-split-row,
+.wx-station,
+.home-fav-row,
+.home-stats-item,
+.ber-context,
+.ber-metric,
+.live-wall-item{ border-radius: 16px !important; }
+.traffic-split-row,
+.wx-station,
+.home-fav-row,
+.home-stats-item,
+.ber-context,
+.ber-metric,
+.live-wall-item,
+.live-wall-form input,
+.live-wall-form button,
+.home-card .home-action,
+.bottom-nav__item,
+.bottom-nav__icon,
+.bottom-nav__icon-img{
+  transition: transform .18s var(--home-premium-ease), box-shadow .18s var(--home-premium-ease), border-color .18s var(--home-premium-ease), background-color .18s var(--home-premium-ease), opacity .18s var(--home-premium-ease), filter .18s var(--home-premium-ease) !important;
+}
+.live-wall-item,
+.home-fav-row,
+.wx-station,
+.traffic-split-row,
+.ber-metric,
+.ber-context,
+.home-stats-item{ backface-visibility:hidden; transform:translateZ(0); }
+
+.bottom-nav{
+  padding: 4px calc(env(safe-area-inset-right, 0px) + 10px) calc(env(safe-area-inset-bottom) + 4px) calc(env(safe-area-inset-left, 0px) + 10px) !important;
+}
+.bottom-nav__items{ align-items:stretch !important; gap:4px !important; }
+.bottom-nav__item{
+  position: relative;
+  min-height: 60px;
+  gap: 3px !important;
+  padding: 5px 3px 4px !important;
+  border-radius: 14px;
+  text-align: center !important;
+  align-self: stretch;
+  -webkit-tap-highlight-color: transparent;
+}
+.bottom-nav__item::before{
+  content:"";
+  position:absolute;
+  inset:2px;
+  border-radius:12px;
+  background: linear-gradient(180deg, rgba(126,247,255,.14), rgba(126,247,255,0));
+  opacity:0;
+  transform:scale(.94);
+  transition: opacity .16s var(--home-premium-ease), transform .16s var(--home-premium-ease);
+  pointer-events:none;
+}
+.bottom-nav__label{
+  display:block;
+  width:100%;
+  margin:0 auto;
+  line-height:1.08 !important;
+  text-align:center !important;
+  text-wrap:balance;
+  transform:translateX(0) !important;
+}
+.bottom-nav__item:hover,
+.bottom-nav__item:focus-visible{
+  transform: translateY(-1px);
+  background: rgba(126,247,255,.05) !important;
+  box-shadow: inset 0 0 0 1px rgba(126,247,255,.14), 0 8px 18px rgba(0,0,0,.22);
+}
+.bottom-nav__item:hover::before,
+.bottom-nav__item:focus-visible::before,
+.bottom-nav__item:active::before,
+.bottom-nav__item.is-pressed::before{
+  opacity:1;
+  transform:scale(1);
+}
+.bottom-nav__item:active,
+.bottom-nav__item.is-pressed{
+  transform: translateY(1px) scale(.97) !important;
+  background: rgba(0,240,255,.10) !important;
+  box-shadow: inset 0 0 0 1px rgba(126,247,255,.20), 0 4px 12px rgba(0,0,0,.20) !important;
+}
+.bottom-nav__item:active .bottom-nav__icon,
+.bottom-nav__item.is-pressed .bottom-nav__icon,
+.bottom-nav__item:active .bottom-nav__icon-img,
+.bottom-nav__item.is-pressed .bottom-nav__icon-img{
+  transform:scale(.94);
+  filter: drop-shadow(0 0 10px rgba(0,240,255,.75));
+}
+.bottom-nav__item.active,
+.bottom-nav__item[aria-current="page"],
+.bottom-nav__item.is-active{
+  background: rgba(126,247,255,.06) !important;
+  box-shadow: inset 0 0 0 1px rgba(126,247,255,.16) !important;
+}
+
+[data-home-animated].is-updating{ animation: homePremiumPulse .32s var(--home-premium-ease); }
+[data-home-animated].is-state-changed{ animation: homePremiumState .44s var(--home-premium-ease); }
+.home-card .traffic-pill.is-severity-up,
+.home-card .home-fav-pill.is-severity-up,
+.home-card .live-wall-badge.is-severity-up{ box-shadow: 0 0 0 1px rgba(255,255,255,.08), 0 0 18px rgba(255,149,0,.16); }
+
+@keyframes homePremiumPulse{
+  0%{ transform: translateZ(0) scale(1); opacity:.88; }
+  45%{ transform: translateZ(0) scale(1.018); opacity:1; }
+  100%{ transform: translateZ(0) scale(1); opacity:1; }
+}
+@keyframes homePremiumState{
+  0%{ transform: translateZ(0) translateY(0); filter:saturate(.92); }
+  35%{ transform: translateZ(0) translateY(-1px); filter:saturate(1.06); }
+  100%{ transform: translateZ(0) translateY(0); filter:none; }
+}
+
+@media (max-width: 700px){
+  :root{ --bottom-bar-height: 64px !important; }
+  .home-dashboard{ gap:10px !important; margin-top:-3px !important; }
+  .home-card{ padding:13px !important; }
+  #homeWelcomeLine,
+  .home-welcome-line{ margin:-10px 0 0 !important; }
+  .top-bar__logo-icon{ height:43.7px !important; }
+  .top-bar__logo-text{ height:27.6px !important; max-width:48vw !important; }
+  .bottom-nav{ padding:3px calc(env(safe-area-inset-right, 0px) + 8px) calc(env(safe-area-inset-bottom) + 3px) calc(env(safe-area-inset-left, 0px) + 8px) !important; }
+  .bottom-nav__items{ gap:2px !important; }
+  .bottom-nav__item{ min-height:54px; padding:4px 2px 3px !important; gap:2px !important; }
+  .bottom-nav__icon-img{ width:28px !important; height:28px !important; }
+  .bottom-nav__label{ font-size:0.64rem !important; line-height:1.04 !important; }
+  .traffic-pill,
+  .home-fav-pill,
+  .live-wall-badge,
+  .wx-title,
+  .home-stats-item .title,
+  .live-wall-meta,
+  .live-wall-inline-meta{ font-size: clamp(.68rem, .18vw + .66rem, .76rem) !important; }
+  .home-card p,
+  .home-card .subtle,
+  .home-fav-meta,
+  .ber-context,
+  .live-wall-item,
+  .live-wall-empty,
+  .live-wall-cta,
+  .home-stats-item .meta,
+  .wx-mini,
+  .wx-badge,
+  .live-wall-form input,
+  .live-wall-form button,
+  .home-card .home-action{ font-size: clamp(.82rem, .22vw + .78rem, .9rem) !important; }
+}
+
+@media (prefers-reduced-motion: reduce){
+  .home-card,
+  .traffic-split-row,
+  .wx-station,
+  .home-fav-row,
+  .home-stats-item,
+  .ber-context,
+  .ber-metric,
+  .live-wall-item,
+  .live-wall-form input,
+  .live-wall-form button,
+  .home-card .home-action,
+  .bottom-nav__item,
+  .bottom-nav__icon,
+  .bottom-nav__icon-img,
+  [data-home-animated]{
+    transition:none !important;
+    animation:none !important;
+  }
+}
+</style>
+<script id="home-premium-harmonisation-final-script">
+(() => {
+  const motionOk = !window.matchMedia || !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const selectors = [
+    '#homeTrafficBadgeNorth', '#homeTrafficBadgeSouth', '#homeWxFromNow', '#homeWxToNow', '#homeWxPunctuality', '#homeWxRisk',
+    '#homeBerLine1', '#homeBerContext', '#homeBerPunctuality', '#homeLiveWallCount', '#homeFavSlot', '#homeWelcomeLine'
+  ];
+
+  function pulse(el, changed){
+    if (!motionOk || !el) return;
+    const cls = changed ? 'is-state-changed' : 'is-updating';
+    el.classList.remove('is-updating', 'is-state-changed');
+    void el.offsetWidth;
+    requestAnimationFrame(() => {
+      el.classList.add(cls);
+      setTimeout(() => el.classList.remove(cls), changed ? 460 : 340);
+    });
+  }
+
+  function trafficSeverity(el){
+    if (!el) return 0;
+    if (el.classList.contains('traffic-pill--red')) return 4;
+    if (el.classList.contains('traffic-pill--orange')) return 3;
+    if (el.classList.contains('traffic-pill--yellow')) return 2;
+    if (el.classList.contains('traffic-pill--green')) return 1;
+    return 0;
+  }
+
+  function remember(el, value, severity = ''){
+    if (!el) return;
+    const nextValue = value == null ? '' : String(value);
+    const nextSeverity = severity == null ? '' : String(severity);
+    const changed = el.dataset.lastValue != null && el.dataset.lastValue !== '' && el.dataset.lastValue !== nextValue;
+    const severityUp = el.dataset.lastSeverity != null && el.dataset.lastSeverity !== '' && Number(nextSeverity) > Number(el.dataset.lastSeverity);
+    el.dataset.lastValue = nextValue;
+    el.dataset.lastSeverity = nextSeverity;
+    el.classList.toggle('is-severity-up', severityUp);
+    pulse(el, changed);
+  }
+
+  function syncLabels(){
+    const punctualityTitle = document.getElementById('homeWxPunctualityTitle');
+    const punctualityValue = document.getElementById('homeWxPunctuality');
+    if (punctualityTitle) punctualityTitle.textContent = 'Ponctualité (Hier)';
+    if (punctualityValue) punctualityValue.title = 'Ponctualité calculée sur les données d’hier';
+    ['homeTrafficBadgeNorth','homeTrafficBadgeSouth'].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) el.title = 'Mise à jour automatique via GTFS temps réel';
+    });
+    const risk = document.getElementById('homeWxRisk');
+    if (risk && !risk.title) risk.title = 'Météo synchronisée avec vos gares favorites quand elles sont définies';
+  }
+
+  function refreshVisualState(){
+    syncLabels();
+    selectors.forEach((selector) => {
+      const el = document.querySelector(selector);
+      if (!el) return;
+      el.setAttribute('data-home-animated', '1');
+      const value = selector === '#homeFavSlot' ? el.textContent.replace(/\s+/g, ' ').trim() : el.textContent.trim();
+      remember(el, value, selector.includes('TrafficBadge') ? trafficSeverity(el) : (selector === '#homeLiveWallCount' ? Number(el.textContent) || 0 : ''));
+    });
+  }
+
+  function wrap(name){
+    const original = window[name];
+    if (typeof original !== 'function' || original.__lbPremiumWrapped) return;
+    const wrapped = function(){
+      const result = original.apply(this, arguments);
+      Promise.resolve(result).finally(() => requestAnimationFrame(refreshVisualState));
+      return result;
+    };
+    wrapped.__lbPremiumWrapped = true;
+    window[name] = wrapped;
+  }
+
+  function installObserver(){
+    const root = document.querySelector('.home-dashboard') || document.getElementById('home');
+    if (!root || root.__lbPremiumObserver) return;
+    const observer = new MutationObserver(() => requestAnimationFrame(refreshVisualState));
+    observer.observe(root, { subtree:true, childList:true, characterData:true });
+    root.__lbPremiumObserver = observer;
+  }
+
+  function install(){
+    ['updateHomeWeather', 'updateHomeTrafficStatus', 'updateHomeBerBlock', 'updateHomePunctuality', 'lbRenderHomeFavPreview', 'renderHomeLiveWall'].forEach(wrap);
+    installObserver();
+    refreshVisualState();
+    setTimeout(refreshVisualState, 400);
+    setTimeout(refreshVisualState, 1400);
+  }
+
+  document.addEventListener('DOMContentLoaded', install);
+  window.addEventListener('load', install);
+  window.addEventListener('gtfsrt:loaded', () => requestAnimationFrame(refreshVisualState));
+})();
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Bring a coherent "premium" look and feel to the home dashboard by standardising typography, spacing, radii, shadows and interactive states. 
- Provide subtle animations and visual feedback for live updates while respecting `prefers-reduced-motion`. 
- Ensure a few textual labels and tooltips are synchronized for clarity about punctuality and real-time GTFS updates.

### Description
- Adds a new stylesheet `home-premium-harmonisation-final` that defines CSS variables, typography clamps, card and bottom-nav visuals, hover/focus states, gradients, keyframe animations and responsive adjustments for mobile. 
- Adds reduced-motion handling via `@media (prefers-reduced-motion: reduce)` to disable transitions/animations where appropriate. 
- Adds a script `home-premium-harmonisation-final-script` that pulses elements on updates, tracks and compares last values and severity, synchronises a few labels and tooltips, and exposes `pulse`/`remember` helpers to highlight state changes. 
- The script wraps specific updater functions (`updateHomeWeather`, `updateHomeTrafficStatus`, `updateHomeBerBlock`, `updateHomePunctuality`, `lbRenderHomeFavPreview`, `renderHomeLiveWall`), installs a `MutationObserver` on the home root, and listens to `DOMContentLoaded`, `load` and `gtfsrt:loaded` to trigger visual refreshes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0f4bc8034832db2b62209421281b0)