### PR TITLE
Switch live comments to server-backed API, add polling and premium home UI harmonisation

### DIFF
--- a/index23.html
+++ b/index23.html
@@ -19610,66 +19610,26 @@ function scheduleWeatherAfterTableSettled(){
     return data;
   };
 
-  const LB_COMMENTS_STORAGE_KEY = 'lb_comments_v1';
-  const lbCommentsChannel = ('BroadcastChannel' in window) ? new BroadcastChannel('lb_comments_channel') : null;
+  const LB_COMMENTS_API = `${LB_API}/comments`;
   let lbCommentState = { wall: [], trains: {} };
+  window.lbCommentState = lbCommentState;
   let lbCurrentDetailTrain = '';
+  let lbCommentsPoller = null;
 
   const safePseudo = () => String(lbPrefsCache?.pseudo || '').trim().slice(0,24);
-  const isCommentingAllowed = () => window.lbIsAuthed === true && !!safePseudo();
+  const isCommentingAllowed = () => window.lbIsAuthed === true;
 
-  function loadCommentState(){
-    try{
-      const raw = localStorage.getItem(LB_COMMENTS_STORAGE_KEY);
-      if (!raw) return { wall: [], trains: {} };
-      const js = JSON.parse(raw);
-      if (!js || typeof js !== 'object') return { wall: [], trains: {} };
-      return {
-        wall: Array.isArray(js.wall) ? js.wall : [],
-        trains: (js.trains && typeof js.trains === 'object') ? js.trains : {}
-      };
-    }catch(e){
-      return { wall: [], trains: {} };
-    }
-  }
-
-  function saveCommentState(){
-    try{ localStorage.setItem(LB_COMMENTS_STORAGE_KEY, JSON.stringify(lbCommentState)); }catch(e){}
-    try{ lbCommentsChannel?.postMessage({ type: 'sync' }); }catch(e){}
-  }
-
-  function getTrainComments(trainNumber){
-    const key = String(trainNumber || '').trim();
-    if (!key) return [];
-    const list = lbCommentState?.trains?.[key];
-    return Array.isArray(list) ? list.slice().sort((a,b)=>(b.ts||0)-(a.ts||0)) : [];
-  }
-
-  function getTrainCommentCount(trainNumber){
-    return getTrainComments(trainNumber).length;
-  }
-
-  function addComment({ text, trainNumber = '' }){
-    const pseudo = safePseudo();
-    if (!isCommentingAllowed()) throw new Error('Connexion + pseudo requis');
-    const msg = String(text || '').trim().slice(0,180);
-    if (!msg) throw new Error('Commentaire vide');
-    const train = String(trainNumber || '').trim();
-    const item = {
-      id: `${Date.now()}_${Math.random().toString(36).slice(2,8)}`,
-      pseudo,
-      text: msg,
-      trainNumber: train,
-      ts: Date.now()
+  function normalizeCommentItem(raw){
+    if (!raw || typeof raw !== 'object') return null;
+    const createdAt = raw.created_at || raw.createdAt || raw.ts || raw.timestamp || Date.now();
+    const createdTs = Number.isFinite(Number(createdAt)) ? Number(createdAt) : Date.parse(createdAt) || Date.now();
+    return {
+      id: raw.id || `${createdTs}_${Math.random().toString(36).slice(2,8)}`,
+      pseudo: String(raw.pseudo || raw.username || raw.user_pseudo || 'Voyageur').trim().slice(0, 24),
+      text: String(raw.message || raw.text || '').trim().slice(0, 180),
+      trainNumber: String(raw.train_number || raw.trainNumber || '').trim(),
+      ts: createdTs
     };
-    lbCommentState.wall = [item, ...(lbCommentState.wall || [])].slice(0,60);
-    if (train){
-      const arr = Array.isArray(lbCommentState.trains[train]) ? lbCommentState.trains[train] : [];
-      lbCommentState.trains[train] = [item, ...arr].slice(0,120);
-    }
-    saveCommentState();
-    renderCommentsUI();
-    return item;
   }
 
   const fmtHour = (ts) => {
@@ -19677,25 +19637,16 @@ function scheduleWeatherAfterTableSettled(){
     catch(e){ return '—'; }
   };
 
-  const fmtDateHourCompact = (ts) => {
-    try{
-      return new Date(ts || Date.now()).toLocaleString('fr-FR', {
-        day:'2-digit',
-        month:'2-digit',
-        hour:'2-digit',
-        minute:'2-digit'
-      }).replace(',', '');
-    }catch(e){ return '—'; }
-  };
-
-  function renderHomeLiveWall(){
+  function renderMessages(){
     const feed = $('homeLiveWallFeed');
     const form = $('homeLiveWallForm');
+    const input = $('homeLiveWallInput');
+    const submitBtn = form?.querySelector('button[type="submit"], button:not([type]), .auth-button');
     const cta = $('homeLiveWallCta');
     const countEl = $('homeLiveWallCount');
-    if (!feed || !form || !cta || !countEl) return;
+    if (!feed || !form || !input || !countEl) return;
 
-    const wall = Array.isArray(lbCommentState.wall) ? lbCommentState.wall.slice(0,60) : [];
+    const wall = Array.isArray(lbCommentState.wall) ? lbCommentState.wall.slice(0, 50) : [];
     countEl.textContent = String(Array.isArray(lbCommentState.wall) ? lbCommentState.wall.length : 0);
 
     if (!wall.length) {
@@ -19703,81 +19654,148 @@ function scheduleWeatherAfterTableSettled(){
     } else {
       feed.innerHTML = wall.map((it) => `
         <div class="live-wall-item live-wall-item--home live-wall-item--compact">
-          <div class="live-wall-item-text"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span class="live-wall-inline-meta">${escapeHtml(fmtDateHourCompact(it.ts))}</span> : ${escapeHtml(it.text || '')}</div>
+          <div class="live-wall-item-text"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span class="live-wall-inline-meta">${escapeHtml(fmtHour(it.ts))}</span> : ${escapeHtml(it.text || '')}</div>
         </div>
       `).join('');
       feed.scrollTop = 0;
     }
+
+    form.hidden = false;
     const can = isCommentingAllowed();
-    form.hidden = !can;
+    input.disabled = !can;
+    if (submitBtn) submitBtn.disabled = !can;
+    input.placeholder = can ? 'Partager une info rapide' : 'Connectez-vous pour commenter';
     cta.hidden = can;
-    if (!window.lbIsAuthed) cta.textContent = 'Connectez-vous pour commenter en direct.';
-    else if (!safePseudo()) cta.textContent = 'Ajoutez un pseudo dans Mes préférences pour commenter.';
+    if (!can) cta.textContent = 'Connectez-vous pour commenter en direct.';
     else cta.textContent = '';
   }
 
-  window.renderHomeLiveWall = renderHomeLiveWall;
+  window.renderMessages = renderMessages;
+  window.renderHomeLiveWall = renderMessages;
 
   function renderTrainComments(trainNumber){
     const listEl = $('trainDetailCommentsList');
     const countEl = $('trainDetailCommentsCount');
     const form = $('trainDetailCommentsForm');
-    if (!listEl || !countEl || !form) return;
+    const input = $('trainDetailCommentsInput');
+    if (!listEl || !countEl || !form || !input) return;
     const train = String(trainNumber || lbCurrentDetailTrain || '').trim();
-    const comments = getTrainComments(train).slice(0,30);
+    const comments = (Array.isArray(lbCommentState.wall) ? lbCommentState.wall : [])
+      .filter((it) => !train || !it.trainNumber || it.trainNumber === train)
+      .slice(0, 30);
+
     countEl.textContent = String(comments.length);
     listEl.innerHTML = comments.length
       ? comments.map((it)=>`<div class="train-comments-item"><div class="live-wall-meta"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span>${fmtHour(it.ts)}</span></div><div>${escapeHtml(it.text || '')}</div></div>`).join('')
       : '<div class="live-wall-empty">Pas encore de commentaire sur ce train.</div>';
-    form.hidden = !isCommentingAllowed();
+
+    form.hidden = true;
+    input.disabled = true;
+    input.placeholder = 'Commentaires train bientôt synchronisés';
   }
 
   function renderCommentsUI(){
-    renderHomeLiveWall();
+    renderMessages();
     renderTrainComments(lbCurrentDetailTrain);
   }
+
+  async function checkAuth(){
+    let isAuthed = false;
+    try{
+      await api('/me', { method: 'GET' });
+      isAuthed = true;
+    }catch(_err){
+      isAuthed = false;
+    }
+    window.lbIsAuthed = isAuthed;
+
+    if (isAuthed) {
+      try {
+        const data = await api('/prefs', { method: 'GET' });
+        lbPrefsCache = data?.prefs || lbPrefsCache || {};
+        window.lbPrefsCache = lbPrefsCache;
+      } catch(_err){}
+    }
+
+    renderCommentsUI();
+    return isAuthed;
+  }
+
+  async function loadMessages(){
+    try{
+      const res = await fetch(`${LB_COMMENTS_API}?scope=wall`, { credentials: 'include' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const list = Array.isArray(data) ? data : (Array.isArray(data?.comments) ? data.comments : []);
+      lbCommentState.wall = list.map(normalizeCommentItem).filter(Boolean).slice(0, 50);
+      window.lbCommentState = lbCommentState;
+      renderCommentsUI();
+      return lbCommentState.wall;
+    }catch(err){
+      console.warn('Impossible de charger les commentaires', err);
+      if (!Array.isArray(lbCommentState.wall)) lbCommentState.wall = [];
+      window.lbCommentState = lbCommentState;
+      renderCommentsUI();
+      return lbCommentState.wall;
+    }
+  }
+
+  async function sendMessage(text){
+    const message = String(text || '').trim().slice(0, 180);
+    if (!message) throw new Error('Commentaire vide');
+    if (!isCommentingAllowed()) throw new Error('Connexion requise');
+
+    const res = await fetch(LB_COMMENTS_API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ message, scope: 'wall' })
+    });
+
+    let data = null;
+    try { data = await res.json(); } catch(_err) {}
+    if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
+
+    await loadMessages();
+    return data;
+  }
+
+  window.checkAuth = checkAuth;
+  window.loadMessages = loadMessages;
+  window.sendMessage = sendMessage;
 
   function bindCommentForms(){
     const homeForm = $('homeLiveWallForm');
     const homeInput = $('homeLiveWallInput');
     if (homeForm && !homeForm.dataset.bound){
       homeForm.dataset.bound = '1';
-      homeForm.addEventListener('submit', (e) => {
+      homeForm.addEventListener('submit', async (e) => {
         e.preventDefault();
         try{
-          addComment({ text: homeInput?.value || '' });
+          await sendMessage(homeInput?.value || '');
           if (homeInput) homeInput.value = '';
+          renderCommentsUI();
         }catch(err){
           alert(err?.message || "Impossible d'ajouter le commentaire.");
         }
       });
     }
+
     const trainForm = $('trainDetailCommentsForm');
     const trainInput = $('trainDetailCommentsInput');
     if (trainForm && !trainForm.dataset.bound){
       trainForm.dataset.bound = '1';
-      trainForm.addEventListener('submit', (e) => {
-        e.preventDefault();
-        try{
-          addComment({ text: trainInput?.value || '', trainNumber: lbCurrentDetailTrain });
-          if (trainInput) trainInput.value = '';
-        }catch(err){
-          alert(err?.message || "Impossible d'ajouter le commentaire.");
-        }
-      });
+      trainForm.hidden = true;
+      if (trainInput) {
+        trainInput.disabled = true;
+        trainInput.placeholder = 'Commentaires train bientôt synchronisés';
+      }
     }
-    try{
-      lbCommentsChannel?.addEventListener('message', (ev) => {
-        if (ev?.data?.type !== 'sync') return;
-        lbCommentState = loadCommentState();
-        renderCommentsUI();
-      });
-    }catch(e){}
-    window.addEventListener('storage', (ev) => {
-      if (ev.key !== LB_COMMENTS_STORAGE_KEY) return;
-      lbCommentState = loadCommentState();
-      renderCommentsUI();
-    });
+  }
+
+  function startCommentsPolling(){
+    if (lbCommentsPoller) clearInterval(lbCommentsPoller);
+    lbCommentsPoller = setInterval(loadMessages, 5000);
   }
 
   window.lbComments = {
@@ -19785,14 +19803,17 @@ function scheduleWeatherAfterTableSettled(){
       lbCurrentDetailTrain = String(trainNumber || '').trim();
       renderTrainComments(lbCurrentDetailTrain);
     },
-    refresh(){ renderCommentsUI(); },
-    count(trainNumber){ return getTrainCommentCount(trainNumber); }
+    refresh(){ loadMessages(); },
+    count(trainNumber){
+      const train = String(trainNumber || '').trim();
+      return (Array.isArray(lbCommentState.wall) ? lbCommentState.wall : []).filter((it) => !train || it.trainNumber === train).length;
+    }
   };
 
-  lbCommentState = loadCommentState();
   bindCommentForms();
   renderCommentsUI();
-
+  checkAuth().finally(loadMessages);
+  startCommentsPolling();
   const openModal = () => {
     const modal = $("lbAuthModal");
     if (!modal) return;
@@ -25539,6 +25560,418 @@ document.addEventListener('DOMContentLoaded', function(){
   }
 }
 </style>
+
+<style id="home-premium-harmonisation-final">
+:root{
+  --home-premium-font-base: clamp(0.95rem, 0.28vw + 0.88rem, 1.05rem);
+  --home-premium-font-small: clamp(0.78rem, 0.18vw + 0.74rem, 0.9rem);
+  --home-premium-font-title: clamp(1.02rem, 0.4vw + 0.94rem, 1.16rem);
+  --home-premium-font-display: clamp(1.55rem, 1.1vw + 1.2rem, 2.15rem);
+  --home-premium-radius: 20px;
+  --home-premium-ease: cubic-bezier(.22,.61,.36,1);
+  --home-premium-shadow: inset 0 0 18px rgba(0,240,255,.10), 0 18px 34px rgba(0,0,0,.26);
+  --bottom-bar-height: 58px !important;
+  --lb-bottomnav-h: 58px !important;
+}
+
+#homeWelcomeLine,
+.home-welcome-line,
+.home-card,
+.home-card p,
+.home-card .subtle,
+.home-card .home-action,
+.traffic-split-line,
+.traffic-pill,
+.wx-title,
+.wx-mini,
+.wx-badge,
+.live-wall-item-text,
+.live-wall-meta,
+.live-wall-inline-meta,
+.live-wall-empty,
+.live-wall-cta,
+.home-fav-train,
+.home-fav-meta,
+.home-fav-pill,
+.home-stats-item .title,
+.home-stats-item .meta,
+.ber-line1,
+.ber-context,
+.ber-metric,
+.ber-metric .value{ letter-spacing:.01em; }
+
+#homeWelcomeLine,
+.home-welcome-line{
+  font-size: clamp(1.08rem, 0.56vw + 0.96rem, 1.34rem) !important;
+  font-weight: 800 !important;
+  line-height: 1.2 !important;
+  color: #eafcff !important;
+  text-wrap: balance;
+  margin: -8px 0 2px !important;
+  padding-top: 0 !important;
+}
+.home-dashboard{ gap: 18px; margin-top: -4px !important; }
+.top-bar__logo-icon{ height: 55px !important; }
+.top-bar__logo-text{ height: 34.5px !important; max-width: min(50vw, 334px) !important; }
+body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
+
+.home-card{
+  position: relative;
+  overflow: clip;
+  border-radius: var(--home-premium-radius) !important;
+  padding: 16px !important;
+  box-shadow: var(--home-premium-shadow) !important;
+  transition: transform .22s var(--home-premium-ease), border-color .22s var(--home-premium-ease), box-shadow .22s var(--home-premium-ease), background-color .22s var(--home-premium-ease);
+  will-change: transform;
+}
+.home-card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+  background: linear-gradient(180deg, rgba(126,247,255,.09), rgba(126,247,255,0) 34%);
+  opacity:.65;
+}
+.home-card:hover,
+.home-card:focus-within{
+  transform: translateY(-2px);
+  border-color: rgba(126,247,255,.42);
+  box-shadow: inset 0 0 18px rgba(0,240,255,.12), 0 22px 38px rgba(0,0,0,.30);
+}
+.home-card h2,
+.live-wall-title{
+  font-size: var(--home-premium-font-title) !important;
+  line-height: 1.15 !important;
+  font-weight: 800 !important;
+  letter-spacing: .03em !important;
+  margin-bottom: 10px !important;
+}
+.home-card p,
+.home-card .subtle,
+.home-fav-meta,
+.ber-context,
+.live-wall-item,
+.live-wall-empty,
+.live-wall-cta,
+.home-stats-item .meta,
+.wx-mini,
+.wx-badge,
+.live-wall-form input,
+.live-wall-form button,
+.home-card .home-action{
+  font-size: var(--home-premium-font-base) !important;
+  line-height: 1.42 !important;
+}
+.home-fav-train,
+.traffic-split-line,
+.ber-line1,
+.ber-metric,
+.home-stats-item .value{
+  font-size: clamp(0.97rem, 0.24vw + 0.91rem, 1.08rem) !important;
+  line-height: 1.25 !important;
+}
+.traffic-pill,
+.home-fav-pill,
+.live-wall-badge,
+.wx-title,
+.home-stats-item .title,
+.live-wall-meta,
+.live-wall-inline-meta{
+  font-size: var(--home-premium-font-small) !important;
+  line-height: 1.18 !important;
+  font-weight: 800 !important;
+}
+.wx-title,
+.home-stats-item .title,
+.live-wall-badge,
+.traffic-pill,
+.home-fav-pill{ text-transform: uppercase; }
+.wx-now .wx-temp,
+.home-card[aria-label="Météo sur votre ligne"] #homeWxPunctuality,
+.home-card[aria-label="Météo sur votre ligne"] .wx-station--punctuality .wx-now,
+.home-card[forwarding="ber"] #homeBerPunctuality,
+.home-card[forwarding="ber"] .ber-metric .value{
+  font-size: var(--home-premium-font-display) !important;
+  line-height: .96 !important;
+  letter-spacing: 0 !important;
+}
+.wx-now .wx-icon{ font-size: clamp(1.35rem, 0.75vw + 1.1rem, 1.95rem) !important; }
+.traffic-split,
+.wx-stations,
+.home-fav-preview,
+.live-wall-feed,
+.home-stats-panel,
+.ber-lines{ gap: 10px !important; }
+.traffic-split-row,
+.wx-station,
+.home-fav-row,
+.home-stats-item,
+.ber-context,
+.ber-metric,
+.live-wall-item{ border-radius: 16px !important; }
+.traffic-split-row,
+.wx-station,
+.home-fav-row,
+.home-stats-item,
+.ber-context,
+.ber-metric,
+.live-wall-item,
+.live-wall-form input,
+.live-wall-form button,
+.home-card .home-action,
+.bottom-nav__item,
+.bottom-nav__icon,
+.bottom-nav__icon-img{
+  transition: transform .18s var(--home-premium-ease), box-shadow .18s var(--home-premium-ease), border-color .18s var(--home-premium-ease), background-color .18s var(--home-premium-ease), opacity .18s var(--home-premium-ease), filter .18s var(--home-premium-ease) !important;
+}
+.live-wall-item,
+.home-fav-row,
+.wx-station,
+.traffic-split-row,
+.ber-metric,
+.ber-context,
+.home-stats-item{ backface-visibility:hidden; transform:translateZ(0); }
+
+.bottom-nav{
+  height: auto !important;
+  min-height: 0 !important;
+  padding: 3px calc(env(safe-area-inset-right, 0px) + 10px) 1px calc(env(safe-area-inset-left, 0px) + 10px) !important;
+}
+.bottom-nav__items{ height:auto !important; align-items:stretch !important; gap:4px !important; }
+.bottom-nav__item{
+  position: relative;
+  min-height: 48px;
+  gap: 2px !important;
+  padding: 4px 3px 2px !important;
+  border-radius: 14px;
+  text-align: center !important;
+  align-self: stretch;
+  -webkit-tap-highlight-color: transparent;
+}
+.bottom-nav__item::before{
+  content:"";
+  position:absolute;
+  inset:2px;
+  border-radius:12px;
+  background: linear-gradient(180deg, rgba(126,247,255,.14), rgba(126,247,255,0));
+  opacity:0;
+  transform:scale(.94);
+  transition: opacity .16s var(--home-premium-ease), transform .16s var(--home-premium-ease);
+  pointer-events:none;
+}
+.bottom-nav__label{
+  display:block;
+  width:100%;
+  margin:0 auto;
+  line-height:1.08 !important;
+  text-align:center !important;
+  text-wrap:balance;
+  transform:translateX(0) !important;
+}
+.bottom-nav__item:hover,
+.bottom-nav__item:focus-visible{
+  transform: translateY(-1px);
+  background: rgba(126,247,255,.05) !important;
+  box-shadow: inset 0 0 0 1px rgba(126,247,255,.14), 0 8px 18px rgba(0,0,0,.22);
+}
+.bottom-nav__item:hover::before,
+.bottom-nav__item:focus-visible::before,
+.bottom-nav__item:active::before,
+.bottom-nav__item.is-pressed::before{
+  opacity:1;
+  transform:scale(1);
+}
+.bottom-nav__item:active,
+.bottom-nav__item.is-pressed{
+  transform: translateY(1px) scale(.97) !important;
+  background: rgba(0,240,255,.10) !important;
+  box-shadow: inset 0 0 0 1px rgba(126,247,255,.20), 0 4px 12px rgba(0,0,0,.20) !important;
+}
+.bottom-nav__item:active .bottom-nav__icon,
+.bottom-nav__item.is-pressed .bottom-nav__icon,
+.bottom-nav__item:active .bottom-nav__icon-img,
+.bottom-nav__item.is-pressed .bottom-nav__icon-img{
+  transform:scale(.94);
+  filter: drop-shadow(0 0 10px rgba(0,240,255,.75));
+}
+.bottom-nav__item.active,
+.bottom-nav__item[aria-current="page"],
+.bottom-nav__item.is-active{
+  background: rgba(126,247,255,.06) !important;
+  box-shadow: inset 0 0 0 1px rgba(126,247,255,.16) !important;
+}
+
+[data-home-animated].is-updating{ animation: homePremiumPulse .32s var(--home-premium-ease); }
+[data-home-animated].is-state-changed{ animation: homePremiumState .44s var(--home-premium-ease); }
+.home-card .traffic-pill.is-severity-up,
+.home-card .home-fav-pill.is-severity-up,
+.home-card .live-wall-badge.is-severity-up{ box-shadow: 0 0 0 1px rgba(255,255,255,.08), 0 0 18px rgba(255,149,0,.16); }
+
+@keyframes homePremiumPulse{
+  0%{ transform: translateZ(0) scale(1); opacity:.88; }
+  45%{ transform: translateZ(0) scale(1.018); opacity:1; }
+  100%{ transform: translateZ(0) scale(1); opacity:1; }
+}
+@keyframes homePremiumState{
+  0%{ transform: translateZ(0) translateY(0); filter:saturate(.92); }
+  35%{ transform: translateZ(0) translateY(-1px); filter:saturate(1.06); }
+  100%{ transform: translateZ(0) translateY(0); filter:none; }
+}
+
+@media (max-width: 700px){
+  :root{ --bottom-bar-height: 54px !important; --lb-bottomnav-h: 54px !important; }
+  .home-dashboard{ gap:10px !important; margin-top:-3px !important; }
+  .home-card{ padding:13px !important; }
+  #homeWelcomeLine,
+  .home-welcome-line{ margin:-10px 0 0 !important; }
+  .top-bar__logo-icon{ height:43.7px !important; }
+  .top-bar__logo-text{ height:27.6px !important; max-width:48vw !important; }
+  body{ padding-bottom: calc(var(--bottom-bar-height, 54px) + 8px) !important; }
+  .bottom-nav{ padding:2px calc(env(safe-area-inset-right, 0px) + 8px) 0 calc(env(safe-area-inset-left, 0px) + 8px) !important; }
+  .bottom-nav__items{ gap:2px !important; }
+  .bottom-nav__item{ min-height:44px; padding:3px 2px 1px !important; gap:1px !important; }
+  .bottom-nav__icon-img{ width:28px !important; height:28px !important; }
+  .bottom-nav__label{ font-size:0.62rem !important; line-height:1.02 !important; }
+  .traffic-pill,
+  .home-fav-pill,
+  .live-wall-badge,
+  .wx-title,
+  .home-stats-item .title,
+  .live-wall-meta,
+  .live-wall-inline-meta{ font-size: clamp(.68rem, .18vw + .66rem, .76rem) !important; }
+  .home-card p,
+  .home-card .subtle,
+  .home-fav-meta,
+  .ber-context,
+  .live-wall-item,
+  .live-wall-empty,
+  .live-wall-cta,
+  .home-stats-item .meta,
+  .wx-mini,
+  .wx-badge,
+  .live-wall-form input,
+  .live-wall-form button,
+  .home-card .home-action{ font-size: clamp(.82rem, .22vw + .78rem, .9rem) !important; }
+}
+
+@media (prefers-reduced-motion: reduce){
+  .home-card,
+  .traffic-split-row,
+  .wx-station,
+  .home-fav-row,
+  .home-stats-item,
+  .ber-context,
+  .ber-metric,
+  .live-wall-item,
+  .live-wall-form input,
+  .live-wall-form button,
+  .home-card .home-action,
+  .bottom-nav__item,
+  .bottom-nav__icon,
+  .bottom-nav__icon-img,
+  [data-home-animated]{
+    transition:none !important;
+    animation:none !important;
+  }
+}
+</style>
+<script id="home-premium-harmonisation-final-script">
+(() => {
+  const motionOk = !window.matchMedia || !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const selectors = [
+    '#homeTrafficBadgeNorth', '#homeTrafficBadgeSouth', '#homeWxFromNow', '#homeWxToNow', '#homeWxPunctuality', '#homeWxRisk',
+    '#homeBerLine1', '#homeBerContext', '#homeBerPunctuality', '#homeLiveWallCount', '#homeFavSlot', '#homeWelcomeLine'
+  ];
+
+  function pulse(el, changed){
+    if (!motionOk || !el) return;
+    const cls = changed ? 'is-state-changed' : 'is-updating';
+    el.classList.remove('is-updating', 'is-state-changed');
+    void el.offsetWidth;
+    requestAnimationFrame(() => {
+      el.classList.add(cls);
+      setTimeout(() => el.classList.remove(cls), changed ? 460 : 340);
+    });
+  }
+
+  function trafficSeverity(el){
+    if (!el) return 0;
+    if (el.classList.contains('traffic-pill--red')) return 4;
+    if (el.classList.contains('traffic-pill--orange')) return 3;
+    if (el.classList.contains('traffic-pill--yellow')) return 2;
+    if (el.classList.contains('traffic-pill--green')) return 1;
+    return 0;
+  }
+
+  function remember(el, value, severity = ''){
+    if (!el) return;
+    const nextValue = value == null ? '' : String(value);
+    const nextSeverity = severity == null ? '' : String(severity);
+    const changed = el.dataset.lastValue != null && el.dataset.lastValue !== '' && el.dataset.lastValue !== nextValue;
+    const severityUp = el.dataset.lastSeverity != null && el.dataset.lastSeverity !== '' && Number(nextSeverity) > Number(el.dataset.lastSeverity);
+    el.dataset.lastValue = nextValue;
+    el.dataset.lastSeverity = nextSeverity;
+    el.classList.toggle('is-severity-up', severityUp);
+    pulse(el, changed);
+  }
+
+  function syncLabels(){
+    const punctualityTitle = document.getElementById('homeWxPunctualityTitle');
+    const punctualityValue = document.getElementById('homeWxPunctuality');
+    if (punctualityTitle) punctualityTitle.textContent = 'Ponctualité (Hier)';
+    if (punctualityValue) punctualityValue.title = 'Ponctualité calculée sur les données d’hier';
+    ['homeTrafficBadgeNorth','homeTrafficBadgeSouth'].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) el.title = 'Mise à jour automatique via GTFS temps réel';
+    });
+    const risk = document.getElementById('homeWxRisk');
+    if (risk && !risk.title) risk.title = 'Météo synchronisée avec vos gares favorites quand elles sont définies';
+  }
+
+  function refreshVisualState(){
+    syncLabels();
+    selectors.forEach((selector) => {
+      const el = document.querySelector(selector);
+      if (!el) return;
+      el.setAttribute('data-home-animated', '1');
+      const value = selector === '#homeFavSlot' ? el.textContent.replace(/\s+/g, ' ').trim() : el.textContent.trim();
+      remember(el, value, selector.includes('TrafficBadge') ? trafficSeverity(el) : (selector === '#homeLiveWallCount' ? Number(el.textContent) || 0 : ''));
+    });
+  }
+
+  function wrap(name){
+    const original = window[name];
+    if (typeof original !== 'function' || original.__lbPremiumWrapped) return;
+    const wrapped = function(){
+      const result = original.apply(this, arguments);
+      Promise.resolve(result).finally(() => requestAnimationFrame(refreshVisualState));
+      return result;
+    };
+    wrapped.__lbPremiumWrapped = true;
+    window[name] = wrapped;
+  }
+
+  function installObserver(){
+    const root = document.querySelector('.home-dashboard') || document.getElementById('home');
+    if (!root || root.__lbPremiumObserver) return;
+    const observer = new MutationObserver(() => requestAnimationFrame(refreshVisualState));
+    observer.observe(root, { subtree:true, childList:true, characterData:true });
+    root.__lbPremiumObserver = observer;
+  }
+
+  function install(){
+    ['updateHomeWeather', 'updateHomeTrafficStatus', 'updateHomeBerBlock', 'updateHomePunctuality', 'lbRenderHomeFavPreview', 'renderHomeLiveWall'].forEach(wrap);
+    installObserver();
+    refreshVisualState();
+    setTimeout(refreshVisualState, 400);
+    setTimeout(refreshVisualState, 1400);
+  }
+
+  document.addEventListener('DOMContentLoaded', install);
+  window.addEventListener('load', install);
+  window.addEventListener('gtfsrt:loaded', () => requestAnimationFrame(refreshVisualState));
+})();
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace fragile localStorage/BroadcastChannel comment persistence with a centralized server API and authenticated flows for more consistent cross-device comments.
- Disable train-level commenting until server sync is available and avoid relying on user prefs stored locally for commenting gating.
- Improve home UI visual harmony with a new premium styling and animations for updated components.

### Description
- Replaced local client-only comment implementation with server-backed endpoints using `LB_COMMENTS_API` and added `loadMessages`, `sendMessage`, and `checkAuth` helper functions for fetch-based sync and auth checks.
- Removed localStorage/BroadcastChannel persistence and related helper functions and introduced `normalizeCommentItem` to normalize incoming comment payloads and maintain `lbCommentState` in-memory and on `window` for debugging.
- Updated rendering logic by renaming `renderHomeLiveWall` to `renderMessages` (kept alias), adjusted `renderTrainComments` to read from the unified `wall` feed, and disabled train comment input pending sync; form handlers now call `sendMessage` asynchronously and update UI accordingly.
- Added periodic polling via `startCommentsPolling` (5s interval), exposed `window.checkAuth`, `window.loadMessages`, and `window.sendMessage`, and updated `window.lbComments` APIs to use server-backed state and counting.
- Introduced a large new CSS block and accompanying script (`home-premium-harmonisation-final`) to harmonize home page styles, add animations, responsive rules, and visual update wrapping for several home update functions.

### Testing
- Ran the frontend build and lint/JS unit checks via `npm run build` and `npm test`, and they completed successfully without regressions.
- Performed automated linting with `eslint` which reported no new issues after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0f4bc8034832db2b62209421281b0)