### PR TITLE
Home UI & comments: admin delete UX, 30-day punctuality, fav widget and visual tweaks

### DIFF
--- a/index28.html
+++ b/index28.html
@@ -885,15 +885,19 @@ body {
 .live-wall-empty,
 .live-wall-cta{ opacity:.7; font-size:.82rem; }
 
-.fav-comments-row{ margin-top:8px; display:flex; justify-content:flex-end; }
+.fav-comments-row{ display:inline; }
 .fav-comment-btn{
-  border:1px solid rgba(0,240,255,.45);
-  border-radius:999px;
-  background:rgba(0,14,26,.58);
-  color:#dffbff;
-  padding:5px 10px;
-  font-size:.78rem;
+  display:inline-block;
+  margin-left:6px;
+  border:none;
+  background:none;
+  color:#ff3b30;
+  padding:0;
+  font-size:.9rem;
+  font-weight:700;
+  line-height:1;
   cursor:pointer;
+  vertical-align:middle;
 }
 
 .train-comments{
@@ -8597,7 +8601,6 @@ html, body{
 <section id="favTrainsWidget" class="fav-widget app-page" data-page="favoris" style="display:none; position:relative; z-index:2;">
   <div class="fav-head">
     <div class="fav-title">⭐ Mes bétaillères favorites</div>
-    <button id="favOpenPrefs" class="fav-btn" type="button">Modifier</button>
   </div>
 
   <div class="fav-grid">
@@ -8896,17 +8899,6 @@ html, body{
     <div class="aff-chart" style="margin-top:8px"><canvas id="trainDetailAffluenceChart" height="92"></canvas></div>
   </div>
   <div class="train-detail-route" id="trainDetailStops"></div>
-  <div class="train-comments" id="trainDetailComments">
-    <div class="train-comments-head">
-      <strong>Commentaires</strong>
-      <span id="trainDetailCommentsCount">0</span>
-    </div>
-    <div id="trainDetailCommentsList" class="train-comments-list"></div>
-    <form id="trainDetailCommentsForm" class="train-comments-form" autocomplete="off" hidden>
-      <input id="trainDetailCommentsInput" type="text" maxlength="180" placeholder="Ajouter un commentaire sur ce train">
-      <button type="submit" class="auth-button">Envoyer</button>
-    </form>
-  </div>
   <div class="train-detail-actions">
     <a id="trainDetailAffBtn" class="train-detail-btn" href="#affluence">🚆 Ouvrir dans Affluence</a>
     <a id="trainDetailStatsBtn" class="train-detail-btn" href="#stats">📊 Voir schéma stats du train</a>
@@ -18749,7 +18741,10 @@ document.addEventListener('DOMContentLoaded', () => {
     ];
     chDonutYesterday.update();
 
-    try { window.__LB_LAST_YESTERDAY_PCT = dayOnTimePct; window.__LB_LAST_YESTERDAY_LABEL = dayLabel; if (typeof updateHomePunctuality === 'function') updateHomePunctuality(dayOnTimePct, dayLabel); } catch(e){}
+    try {
+      window.__LB_STATS_LAST_YESTERDAY_PCT = dayOnTimePct;
+      window.__LB_STATS_LAST_YESTERDAY_LABEL = dayLabel;
+    } catch(e){}
 
     const legend = $("statsExpressLegend");
     if (legend){
@@ -19678,8 +19673,7 @@ function scheduleWeatherAfterTableSettled(){
     } else {
       feed.innerHTML = wall.map((it) => `
         <div class="live-wall-item live-wall-item--home live-wall-item--compact">
-          <div class="live-wall-item-text"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span class="live-wall-inline-meta">${escapeHtml(fmtHour(it.ts))}</span> : ${escapeHtml(it.text || '')}</div>
-		  ${currentUser?.role === 'admin' && it.id ? `<div class="fav-comments-row"><button class="fav-comment-btn" type="button" data-comment-delete="${escapeHtml(String(it.id))}">Supprimer</button></div>` : ''}
+          <div class="live-wall-item-text"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span class="live-wall-inline-meta">${escapeHtml(fmtHour(it.ts))}</span> : ${escapeHtml(it.text || '')}${currentUser?.role === 'admin' && it.id ? `<span class="fav-comments-row"><span class="fav-comment-btn" role="button" tabindex="0" data-comment-delete="${escapeHtml(String(it.id))}" aria-label="Supprimer le commentaire" title="Supprimer le commentaire">❌</span></span>` : ''}</div>
         </div>
       `).join('');
       feed.scrollTop = 0;
@@ -19758,7 +19752,11 @@ function scheduleWeatherAfterTableSettled(){
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       const list = Array.isArray(data) ? data : (Array.isArray(data?.comments) ? data.comments : []);
-      lbCommentState.wall = list.map(normalizeCommentItem).filter(Boolean).slice(0, 50);
+      lbCommentState.wall = list
+        .map(normalizeCommentItem)
+        .filter(Boolean)
+        .sort((a, b) => Number(b?.ts || 0) - Number(a?.ts || 0))
+        .slice(0, 50);
       window.lbCommentState = lbCommentState;
       renderCommentsUI();
       return lbCommentState.wall;
@@ -19795,8 +19793,9 @@ function scheduleWeatherAfterTableSettled(){
     if (!commentId) throw new Error('Commentaire introuvable');
     if (currentUser?.role !== 'admin') throw new Error('Action réservée aux admins');
 
-    const res = await fetchCommentsApi(`/${encodeURIComponent(commentId)}`, {
-      method: 'DELETE'
+    const res = await fetch(`https://vps.labetaillere.fr/api/comments/${encodeURIComponent(commentId)}`, {
+      method: 'DELETE',
+      credentials: 'include'
     });
 
     let data = null;
@@ -19835,6 +19834,16 @@ function scheduleWeatherAfterTableSettled(){
       feed.addEventListener('click', async (e) => {
         const btn = e.target.closest('[data-comment-delete]');
         if (!btn) return;
+        try{
+          await deleteComment(btn.getAttribute('data-comment-delete'));
+        }catch(err){
+          alert(err?.message || "Impossible de supprimer le commentaire.");
+        }
+      });
+      feed.addEventListener('keydown', async (e) => {
+        const btn = e.target.closest('[data-comment-delete]');
+        if (!btn || (e.key !== 'Enter' && e.key !== ' ')) return;
+        e.preventDefault();
         try{
           await deleteComment(btn.getAttribute('data-comment-delete'));
         }catch(err){
@@ -20868,7 +20877,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
 	  if (badgeEl) badgeEl.innerHTML = `${buildWidgetStateBadge(canceledState)} <span class="fav-cancel-badge">✖ SUPPRIMÉ</span>`;
       meta.innerHTML = `
         <div style="display:flex;align-items:center;justify-content:space-between;gap:10px;">
-          <div style="font-size:1.18rem;font-weight:900;opacity:.96">${escapeHtml(origin)} → ${escapeHtml(dest)}</div>
+          <div style="font-size:1.02rem;font-weight:900;opacity:.96;line-height:1.08">${escapeHtml(origin)} → ${escapeHtml(dest)}</div>
         </div>
         <div class="fav-times" style="opacity:.9;">${escapeHtml(depTxt)} → ${escapeHtml(arrTxt)}</div>
       `;
@@ -20915,7 +20924,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
 
     meta.innerHTML = `
       <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;">
-        <div style="font-size:1.18rem;font-weight:900;opacity:.96;">${escapeHtml(origin)} → ${escapeHtml(dest)}</div>
+        <div style="font-size:1.02rem;font-weight:900;opacity:.96;line-height:1.08;">${escapeHtml(origin)} → ${escapeHtml(dest)}</div>
         ${isPartialAny ? `<span style="padding:4px 10px;border-radius:999px;border:1px solid rgba(255,80,80,.40); background:rgba(255,80,80,.12); color:#ff9a9a; font-weight:900;">SUPPRESSION PARTIELLE</span>` : ''}
       </div>
       <div class="fav-times">${timesHtml}</div>
@@ -20925,7 +20934,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
     const isDelayed = (maxDelay != null && Number.isFinite(maxDelay) && maxDelay >= 1);
     let causeHtml = '';
     if ((isDelayed || isPartialAny) && causeText){
-      causeHtml = `<div class="fav-box fav-box-warn" style="margin-top:10px;"><div class="fav-box-body" style="color:#ffb36b;font-weight:800;">${escapeHtml(causeText)}</div></div>`;
+      causeHtml = `<div class="fav-box fav-box-warn" style="margin-top:6px;"><div class="fav-box-body" style="color:#ffb36b;font-weight:800;">${escapeHtml(causeText)}</div></div>`;
     }
     if (causeEl){
       // on garde le noeud pour compat mais on le vide (la cause est rendue dans fav-line)
@@ -20936,8 +20945,8 @@ function getGtfsDelayForStop(trainNumber, stopName){
     // Progression (visuel)
     const pct = (widgetState === 'before') ? 0 : (widgetState === 'after' ? 100 : computeProgressPct(effectiveDepMin, effectiveArrLast, st.now));
     const progressHtml = `
-      <div style="margin:12px 0 10px 0;">
-        <div style="height:6px;border-radius:999px;overflow:hidden;background:rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(0,255,255,.12);">
+      <div style="margin:8px 0 6px 0;">
+        <div style="height:5px;border-radius:999px;overflow:hidden;background:rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(0,255,255,.12);">
           <div style="height:100%;width:${pct}%;background:rgba(0,255,255,.85);box-shadow:0 0 12px rgba(0,255,255,.35);border-radius:999px;transition:width .6s ease;"></div>
         </div>
       </div>
@@ -20990,7 +20999,6 @@ function getGtfsDelayForStop(trainNumber, stopName){
           <div class="fav-box-body fav-aff-body">
             ${stops.length ? `<div class="fav-aff-stops">${stopsHtml}</div>` : `<div class="fav-aff-empty">Pas de détail d’affluence disponible pour ce train ce jour-là.</div>`}
             ${affInfo.spark || ''}
-            <a class="fav-aff-open" href="#affluence" data-train="${escapeHtml(trainId)}">Ouvrir dans Affluence</a>
           </div>
         </details>
       `;
@@ -22684,10 +22692,10 @@ async function updateHomeBerBlock(){
     }
   }
 
-  // ponctualité hier — si déjà calculée par les stats express, on l’utilise
+  // ponctualité moyenne J-1 → J-30 (publique)
   try{
-    if (typeof window.__LB_LAST_YESTERDAY_PCT === 'number') updateHomePunctuality(window.__LB_LAST_YESTERDAY_PCT, window.__LB_LAST_YESTERDAY_LABEL);
-    else await ensureYesterdayPunctuality();
+    if (typeof window.__LB_LAST_30D_PCT === 'number') updateHomePunctuality(window.__LB_LAST_30D_PCT, window.__LB_LAST_30D_KEY || '30d');
+    else if (typeof ensure30DayPunctuality === 'function') await ensure30DayPunctuality();
   }catch(e){}
 }
 
@@ -22817,7 +22825,7 @@ function ensureFavInHome(){
   if (cta) cta.style.display = authed ? 'none' : 'block';
 
   if (!authed){
-    slot.innerHTML = '<div style="opacity:.7">⭐ Connectez-vous pour afficher vos favoris.</div>';
+    slot.innerHTML = '';
     return;
   }
 
@@ -22879,10 +22887,10 @@ function getUserWxPrefsOrDefault(){
 
 async function initHomePublicBlocks(){
   const prefs = getUserWxPrefsOrDefault();
-  // météo (public) + ponctualité hier (public) + bloc BER
+  // météo (public) + ponctualité moyenne 30 jours (public) + bloc BER
   await Promise.all([
     updateHomeWeather(prefs.from, prefs.to),
-    ensureYesterdayPunctuality()
+    (typeof ensure30DayPunctuality === 'function' ? ensure30DayPunctuality() : Promise.resolve(null))
   ]);
   await updateHomeBerBlock();
 }
@@ -24866,33 +24874,122 @@ document.addEventListener('DOMContentLoaded', function(){
     d.setUTCDate(d.getUTCDate() - days);
     return d.toISOString().slice(0,10);
   }
+  const __LB_30D_CACHE_KEY = 'lb_home_30d_punctuality_v1';
+  function read30DayPunctualityCache(){
+    try{
+      const raw = localStorage.getItem(__LB_30D_CACHE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      const pct = Number(parsed?.pct);
+      const key = String(parsed?.key || '').trim();
+      if (!key || !Number.isFinite(pct)) return null;
+      return { key, pct: Math.max(0, Math.min(100, pct)), from: parsed?.from || '', to: parsed?.to || '' };
+    }catch(e){
+      return null;
+    }
+  }
+  function write30DayPunctualityCache(key, pct, from, to){
+    try{
+      const num = Number(pct);
+      if (!key || !Number.isFinite(num)) return;
+      localStorage.setItem(__LB_30D_CACHE_KEY, JSON.stringify({
+        key: String(key),
+        pct: Math.max(0, Math.min(100, num)),
+        from: String(from || ''),
+        to: String(to || ''),
+        savedAt: Date.now()
+      }));
+    }catch(e){}
+  }
+  async function fetchPublicRawRange(from, to){
+    const qs = `from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
+    const urls = [
+      `${STATS_API_BASE}/api/stats/gtfs/rawrange?${qs}`,
+      `${STATS_API_BASE}/stats/gtfs/rawrange?${qs}`
+    ];
+    let lastErr = null;
+    for (const url of urls){
+      try{
+        const res = await fetch(url, { cache:'no-store', credentials:'omit' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.json();
+      }catch(e){
+        lastErr = e;
+      }
+    }
+    throw lastErr || new Error('rawrange indisponible');
+  }
   async function ensure30DayPunctuality(){
     const to = dateMinusDays(luxTodayISO(), 1);
     const from = dateMinusDays(to, 29);
     const key = `${from}_${to}`;
+    const cached = read30DayPunctualityCache();
+
+    if (window.__LB_LAST_30D_KEY === key && Number.isFinite(Number(window.__LB_LAST_30D_PCT))) {
+      if (typeof updateHomePunctuality === 'function') updateHomePunctuality(window.__LB_LAST_30D_PCT, key);
+      return Number(window.__LB_LAST_30D_PCT);
+    }
+
+    if (cached?.key === key && Number.isFinite(Number(cached.pct))) {
+      window.__LB_LAST_30D_KEY = key;
+      window.__LB_LAST_30D_PCT = Number(cached.pct);
+      if (typeof updateHomePunctuality === 'function') updateHomePunctuality(cached.pct, key);
+    } else {
+      ['homeBerPunctuality','homeWxPunctuality'].forEach((id)=>{
+        const el = document.getElementById(id);
+        if (el && (!el.textContent || /^[-–—.\s%]*$/.test(el.textContent))) el.textContent = '…';
+      });
+    }
+
+    const dailyPctFromSummary = (day) => {
+      const total = Number(day?.total_trains || 0);
+      const pctNot = Number(day?.pct_not_on_time);
+      if (total > 0 && Number.isFinite(pctNot)) return 100 - pctNot;
+      return null;
+    };
+
     ['homeBerPunctuality','homeWxPunctuality'].forEach((id)=>{
       const el = document.getElementById(id);
-      if (el) el.textContent = '…';
+      if (el && (!el.textContent || /^[-–—.\s%]*$/.test(el.textContent))) el.textContent = '…';
     });
     try{
-      let range = null;
-      if (typeof loadRangeAPI === 'function') range = await loadRangeAPI(from, to);
-      else if (typeof apiFetch === 'function') range = await apiFetch(`/api/stats/gtfs/range?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`);
-      else {
-        const r = await fetch(`/api/stats/gtfs/range?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`, { cache:'no-store' });
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        range = await r.json();
+      let rawPayload = null;
+      try{
+        rawPayload = await fetchPublicRawRange(from, to);
+      }catch(_publicErr){
+        if (typeof loadRawRangeAPI === 'function') rawPayload = await loadRawRangeAPI(from, to);
+        else throw _publicErr;
       }
-      const series = Array.isArray(range?.series) ? range.series : [];
-      const values = series
-        .map(d => 100 - Number(d?.pct_not_on_time ?? NaN))
+
+      const rawDays = (typeof normalizeRawRangePayload === 'function')
+        ? normalizeRawRangePayload(rawPayload)
+        : (Array.isArray(rawPayload) ? rawPayload : (Array.isArray(rawPayload?.days) ? rawPayload.days : []));
+
+      const values = rawDays
+        .filter(day => day && day.date >= from && day.date <= to)
+        .map(day => {
+          if (typeof computeDaySummaryFromRaw === 'function') return dailyPctFromSummary(computeDaySummaryFromRaw(day));
+          return dailyPctFromSummary(day);
+        })
         .filter(v => Number.isFinite(v));
+
       const pct = values.length ? (values.reduce((a,b)=>a+b,0) / values.length) : null;
+      if (!Number.isFinite(Number(pct))) throw new Error('Moyenne 30 jours invalide');
+
       window.__LB_LAST_30D_KEY = key;
-      window.__LB_LAST_30D_PCT = pct;
+      window.__LB_LAST_30D_PCT = Math.max(0, Math.min(100, Number(pct)));
+      write30DayPunctualityCache(key, window.__LB_LAST_30D_PCT, from, to);
       if (pct != null && typeof updateHomePunctuality === 'function') updateHomePunctuality(pct, key);
       return pct;
     }catch(e){
+      if (window.__LB_LAST_30D_KEY === key && Number.isFinite(Number(window.__LB_LAST_30D_PCT))) {
+        if (typeof updateHomePunctuality === 'function') updateHomePunctuality(window.__LB_LAST_30D_PCT, key);
+        return Number(window.__LB_LAST_30D_PCT);
+      }
+      if (cached?.key === key && Number.isFinite(Number(cached.pct))) {
+        if (typeof updateHomePunctuality === 'function') updateHomePunctuality(cached.pct, key);
+        return Number(cached.pct);
+      }
       ['homeBerPunctuality','homeWxPunctuality'].forEach((id)=>{
         const el = document.getElementById(id);
         if (el) el.textContent = '—';
@@ -24977,7 +25074,7 @@ document.addEventListener('DOMContentLoaded', function(){
   function forceYesterdayPunctuality(){
     try{
       const title = document.querySelector('[data-home-punctuality-title], #homeWxPunctualityTitle, #homeBerPunctualityTitle');
-      if (title) title.textContent = 'Ponctualité hier';
+      if (title) title.textContent = 'Ponctualité (30 jours)';
     }catch(e){}
   }
 
@@ -25154,7 +25251,7 @@ document.addEventListener('DOMContentLoaded', function(){
   function syncPunctualityLayout(){
     try{
       var title = document.querySelector('[data-home-punctuality-title], #homeWxPunctualityTitle, #homeBerPunctualityTitle');
-      if(title) title.textContent = 'Ponctualité hier';
+      if(title) title.textContent = 'Ponctualité (30 jours)';
     }catch(e){}
   }
 
@@ -25178,7 +25275,7 @@ document.addEventListener('DOMContentLoaded', function(){
       feed.innerHTML = wall.map(function(it){
         var commentId = String(it && it.id != null ? it.id : '').trim();
         var deleteBtn = (isAdmin && commentId)
-          ? '<div class="fav-comments-row"><button class="fav-comment-btn" type="button" data-comment-delete="' + escapeHtml(commentId) + '">Supprimer</button></div>'
+          ? '<span class="fav-comments-row"><span class="fav-comment-btn" role="button" tabindex="0" data-comment-delete="' + escapeHtml(commentId) + '" aria-label="Supprimer le commentaire" title="Supprimer le commentaire">❌</span></span>'
           : '';
         return '<div class="live-wall-item live-wall-item--home live-wall-item--compact"><div class="live-wall-item-text"><strong>' + escapeHtml(it.pseudo || 'Voyageur') + '</strong><span class="live-wall-inline-meta">' + escapeHtml((typeof fmtDateHourCompact === 'function' ? fmtDateHourCompact(it.ts) : '')) + '</span> : ' + escapeHtml(it.text || '') + '</div>' + deleteBtn + '</div>';
       }).join('');
@@ -25600,6 +25697,168 @@ document.addEventListener('DOMContentLoaded', function(){
 .ber-metric,
 .ber-metric .value{ letter-spacing:.01em; }
 
+.live-wall-item-text,
+.live-wall-form input,
+.train-comments-item,
+#homeLiveWallInput,
+#trainDetailCommentsInput{
+  font-family: 'Orbitron', 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif !important;
+}
+
+.top-bar__social-link svg{
+  width: 19px !important;
+  height: 19px !important;
+}
+
+#favTrainsWidget{
+  background:
+    linear-gradient(180deg, rgba(126,247,255,.12), rgba(126,247,255,0) 16%),
+    linear-gradient(145deg, rgba(13,24,43,.98), rgba(8,15,28,.96)) !important;
+  border-color: rgba(126,247,255,.32) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(240,255,255,.10),
+    inset 0 0 30px rgba(0,240,255,.08),
+    0 20px 46px rgba(0,0,0,.34) !important;
+  padding: 16px !important;
+}
+#favTrainsWidget .fav-head{
+  margin-bottom: 5px !important;
+  padding-bottom: 2px !important;
+}
+#favTrainsWidget .fav-title{
+  font-size: .98rem !important;
+  letter-spacing: .015em !important;
+}
+#favTrainsWidget .fav-grid{
+  gap: 6px !important;
+}
+#favTrainsWidget .fav-card{
+  position: relative;
+  overflow: hidden;
+  padding: 10px 11px !important;
+  border-radius: 15px !important;
+  border-color: rgba(126,247,255,.24) !important;
+  background:
+    linear-gradient(180deg, rgba(126,247,255,.08), rgba(126,247,255,0) 38%),
+    linear-gradient(135deg, rgba(8,20,36,.96), rgba(5,12,24,.94)) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(240,255,255,.08),
+    inset 0 0 18px rgba(0,240,255,.05),
+    0 12px 24px rgba(0,0,0,.22) !important;
+}
+#favTrainsWidget .fav-card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+  background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0) 44%);
+}
+#favTrainsWidget .fav-card-head{ gap: 8px !important; }
+#favTrainsWidget .fav-tag{
+  font-size: .66rem !important;
+  padding: 3px 7px !important;
+}
+#favTrainsWidget .fav-train{
+  font-size: .9rem !important;
+  line-height: 1.05 !important;
+}
+#favTrainsWidget .fav-meta{
+  margin-top: 4px !important;
+  font-size: .79rem !important;
+  line-height: 1.12 !important;
+}
+#favTrainsWidget .fav-line{
+  margin-top: 4px !important;
+  font-size: .79rem !important;
+  line-height: 1.12 !important;
+}
+#favTrainsWidget .fav-times{
+  margin-top: 3px !important;
+  gap: 3px !important;
+  font-size: clamp(.8rem, .22vw + .78rem, .94rem) !important;
+  line-height: 1 !important;
+}
+#favTrainsWidget .fav-cause,
+#favTrainsWidget .fav-cause-inline{
+  margin: 4px 0 5px 0 !important;
+  padding: 4px 6px !important;
+  font-size: .69rem !important;
+}
+#favTrainsWidget .fav-details{
+  margin-top: 5px !important;
+  border-radius: 10px !important;
+}
+#favTrainsWidget .fav-details-summary{
+  padding: 5px 8px !important;
+  font-size: .71rem !important;
+}
+#favTrainsWidget .fav-box-head,
+#favTrainsWidget .fav-box-body{
+  padding: 6px 7px !important;
+}
+#favTrainsWidget .fav-box-body{
+  font-size: .8rem !important;
+  line-height: 1.14 !important;
+}
+#favTrainsWidget .fav-aff-summary{
+  gap: 4px !important;
+}
+#favTrainsWidget .fav-aff-top{
+  gap: 6px !important;
+}
+#favTrainsWidget .fav-aff-title{
+  font-size: .76rem !important;
+}
+#favTrainsWidget .fav-aff-meta{
+  font-size: .74rem !important;
+  gap: 6px !important;
+  line-height: 1.08 !important;
+}
+#favTrainsWidget .fav-aff-max{
+  font-size: .68rem !important;
+}
+#favTrainsWidget .fav-aff-schema{
+  gap: 6px !important;
+  min-height: 20px !important;
+}
+#favTrainsWidget .fav-aff-toggleline{
+  font-size: .72rem !important;
+  min-height: 0 !important;
+}
+#favTrainsWidget .fav-aff-body{
+  gap: 6px !important;
+}
+#favTrainsWidget .fav-aff-stops{
+  gap: 5px !important;
+}
+#favTrainsWidget .fav-aff-stop{
+  padding: 7px 8px !important;
+  border-radius: 10px !important;
+}
+#favTrainsWidget .fav-aff-stop-head{
+  gap: 8px !important;
+}
+#favTrainsWidget .fav-aff-stop-title{
+  gap: 4px !important;
+}
+#favTrainsWidget .fav-aff-stop-name{
+  font-size: .74rem !important;
+}
+#favTrainsWidget .fav-aff-stop-time{
+  font-size: .68rem !important;
+}
+#favTrainsWidget .fav-aff-stop-pct{
+  min-width: 34px !important;
+  font-size: .78rem !important;
+}
+#favTrainsWidget .fav-aff-stop-schema{
+  margin-top: 4px !important;
+}
+#favTrainsWidget .fav-aff-empty{
+  padding: 8px 9px !important;
+  font-size: .74rem !important;
+}
+
 #homeWelcomeLine,
 .home-welcome-line{
   font-size: clamp(1.08rem, 0.56vw + 0.96rem, 1.34rem) !important;
@@ -25732,6 +25991,49 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 .ber-context,
 .home-stats-item{ backface-visibility:hidden; transform:translateZ(0); }
 
+.home-fav-row{
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(126,247,255,.10), rgba(126,247,255,0) 42%),
+    linear-gradient(135deg, rgba(10,24,42,.94), rgba(7,16,30,.92)) !important;
+  border: 1px solid rgba(126,247,255,.24) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(220,255,255,.10),
+    inset 0 0 18px rgba(0,240,255,.05),
+    0 10px 22px rgba(0,0,0,.22) !important;
+}
+.home-fav-row::before{
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,0) 45%);
+  opacity: .85;
+}
+.home-fav-row:hover,
+.home-fav-row:focus-visible{
+  transform: translateY(-1px) scale(1.01) !important;
+  border-color: rgba(126,247,255,.42) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(235,255,255,.14),
+    inset 0 0 20px rgba(0,240,255,.08),
+    0 14px 28px rgba(0,0,0,.28),
+    0 0 0 1px rgba(126,247,255,.08) !important;
+}
+.home-fav-row:active{
+  transform: translateY(1px) scale(.985) !important;
+  box-shadow:
+    inset 0 2px 12px rgba(0,0,0,.30),
+    inset 0 0 16px rgba(0,240,255,.06),
+    0 6px 14px rgba(0,0,0,.20) !important;
+}
+.home-fav-row .fav-state-badge{
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.08),
+    0 0 14px rgba(0,240,255,.10);
+}
+
 .bottom-nav{
   height: auto !important;
   min-height: 0 !important;
@@ -25826,6 +26128,30 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   .home-welcome-line{ margin:-10px 0 0 !important; }
   .top-bar__logo-icon{ height:43.7px !important; }
   .top-bar__logo-text{ height:27.6px !important; max-width:48vw !important; }
+  .top-bar__social-link svg{ width: 17px !important; height: 17px !important; }
+  #favTrainsWidget{ padding: 11px !important; border-radius: 16px !important; }
+  #favTrainsWidget .fav-head{ margin-bottom: 4px !important; }
+  #favTrainsWidget .fav-title{ font-size: .88rem !important; }
+  #favTrainsWidget .fav-grid{ gap: 6px !important; }
+  #favTrainsWidget .fav-card{ padding: 9px 9px !important; border-radius: 13px !important; }
+  #favTrainsWidget .fav-tag{ font-size: .62rem !important; padding: 3px 6px !important; }
+  #favTrainsWidget .fav-train{ font-size: .82rem !important; }
+  #favTrainsWidget .fav-meta,
+  #favTrainsWidget .fav-line{ font-size: .72rem !important; line-height: 1.08 !important; }
+  #favTrainsWidget .fav-times{ font-size: .8rem !important; gap: 2px !important; }
+  #favTrainsWidget .fav-details-summary{ padding: 4px 7px !important; font-size: .68rem !important; }
+  #favTrainsWidget .fav-box-head,
+  #favTrainsWidget .fav-box-body{ padding: 5px 6px !important; }
+  #favTrainsWidget .fav-aff-title{ font-size: .72rem !important; }
+  #favTrainsWidget .fav-aff-meta{ font-size: .7rem !important; gap: 4px !important; }
+  #favTrainsWidget .fav-aff-max{ font-size: .64rem !important; }
+  #favTrainsWidget .fav-aff-body{ gap: 5px !important; }
+  #favTrainsWidget .fav-aff-stops{ gap: 4px !important; }
+  #favTrainsWidget .fav-aff-stop{ padding: 6px 7px !important; }
+  #favTrainsWidget .fav-aff-stop-name{ font-size: .7rem !important; }
+  #favTrainsWidget .fav-aff-stop-time{ font-size: .64rem !important; }
+  #favTrainsWidget .fav-aff-stop-pct{ min-width: 30px !important; font-size: .74rem !important; }
+  #favTrainsWidget .fav-aff-empty{ padding: 7px 8px !important; font-size: .7rem !important; }
   body{ padding-bottom: calc(var(--bottom-bar-height, 54px) + 8px) !important; }
   .bottom-nav{ padding:2px calc(env(safe-area-inset-right, 0px) + 8px) 0 calc(env(safe-area-inset-left, 0px) + 8px) !important; }
   .bottom-nav__items{ gap:2px !important; }
@@ -25852,6 +26178,29 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   .live-wall-form input,
   .live-wall-form button,
   .home-card .home-action{ font-size: clamp(.82rem, .22vw + .78rem, .9rem) !important; }
+
+  .home-fav-row{
+    gap: 7px !important;
+    padding: 7px 8px !important;
+  }
+  .home-fav-train{
+    font-size: clamp(.74rem, .18vw + .7rem, .82rem) !important;
+    letter-spacing: .02em !important;
+  }
+  .home-fav-meta{
+    font-size: clamp(.66rem, .14vw + .64rem, .74rem) !important;
+    white-space: normal !important;
+    overflow: visible !important;
+    text-overflow: clip !important;
+    line-height: 1.25 !important;
+  }
+  .home-fav-badge,
+  .home-fav-row .fav-state-badge,
+  .home-fav-pill{
+    font-size: clamp(.58rem, .12vw + .56rem, .66rem) !important;
+    padding: 4px 7px !important;
+    letter-spacing: .03em !important;
+  }
 }
 
 @media (prefers-reduced-motion: reduce){
@@ -25878,6 +26227,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 <script id="home-premium-harmonisation-final-script">
 (() => {
   const motionOk = !window.matchMedia || !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let refreshQueued = false;
   const selectors = [
     '#homeTrafficBadgeNorth', '#homeTrafficBadgeSouth', '#homeWxFromNow', '#homeWxToNow', '#homeWxPunctuality', '#homeWxRisk',
     '#homeBerLine1', '#homeBerContext', '#homeBerPunctuality', '#homeLiveWallCount', '#homeFavSlot', '#homeWelcomeLine'
@@ -25918,8 +26268,8 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   function syncLabels(){
     const punctualityTitle = document.getElementById('homeWxPunctualityTitle');
     const punctualityValue = document.getElementById('homeWxPunctuality');
-    if (punctualityTitle) punctualityTitle.textContent = 'Ponctualité (Hier)';
-    if (punctualityValue) punctualityValue.title = 'Ponctualité calculée sur les données d’hier';
+    if (punctualityTitle) punctualityTitle.textContent = 'Ponctualité (30 jours)';
+    if (punctualityValue) punctualityValue.title = 'Moyenne de ponctualité calculée du J-1 au J-30';
     ['homeTrafficBadgeNorth','homeTrafficBadgeSouth'].forEach((id) => {
       const el = document.getElementById(id);
       if (el) el.title = 'Mise à jour automatique via GTFS temps réel';
@@ -25939,12 +26289,21 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     });
   }
 
+  function scheduleRefresh(){
+    if (refreshQueued) return;
+    refreshQueued = true;
+    requestAnimationFrame(() => {
+      refreshQueued = false;
+      refreshVisualState();
+    });
+  }
+
   function wrap(name){
     const original = window[name];
     if (typeof original !== 'function' || original.__lbPremiumWrapped) return;
     const wrapped = function(){
       const result = original.apply(this, arguments);
-      Promise.resolve(result).finally(() => requestAnimationFrame(refreshVisualState));
+      Promise.resolve(result).finally(scheduleRefresh);
       return result;
     };
     wrapped.__lbPremiumWrapped = true;
@@ -25954,8 +26313,8 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   function installObserver(){
     const root = document.querySelector('.home-dashboard') || document.getElementById('home');
     if (!root || root.__lbPremiumObserver) return;
-    const observer = new MutationObserver(() => requestAnimationFrame(refreshVisualState));
-    observer.observe(root, { subtree:true, childList:true, characterData:true });
+    const observer = new MutationObserver(scheduleRefresh);
+    observer.observe(root, { subtree:true, childList:true, characterData:false });
     root.__lbPremiumObserver = observer;
   }
 
@@ -25969,7 +26328,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 
   document.addEventListener('DOMContentLoaded', install);
   window.addEventListener('load', install);
-  window.addEventListener('gtfsrt:loaded', () => requestAnimationFrame(refreshVisualState));
+  window.addEventListener('gtfsrt:loaded', scheduleRefresh);
 })();
 </script>
 


### PR DESCRIPTION
### Motivation
- Improve the home feed and favorites UX with better visuals and accessibility for admin comment deletion. 
- Replace a fragile “yesterday” punctuality metric with a cached, public 30-day punctuality average and resilient fetching. 
- Harmonize premium UI styling for favorites and home cards and reduce noisy DOM mutation updates.

### Description
- Reworked comments UI: replaced the inline admin delete button with an inline ❌ role=button element, added keyboard support (Enter / Space) and updated click handler; `loadMessages` now sorts comments by timestamp (newest first) and `renderMessages` builds accessible delete controls. 
- Updated delete flow to call the comments API via an absolute URL with `credentials: 'include'` in `deleteComment`, and preserved JSON error handling; added keyboard handler to trigger deletion. 
- Removed the train detail comments block from the DOM (train detail comments markup was removed/hidden). 
- Implemented a 30-day punctuality feature: introduced `ensure30DayPunctuality`, public raw-range fetch with fallbacks, localStorage cache (`lb_home_30d_punctuality_v1`), normalization of raw payloads and safe averaging, and replaced many globals/labels (e.g. `__LB_LAST_30D_PCT`, new cache read/write). 
- Updated home initialization to call 30-day punctuality routine and switched visual labels from “Ponctualité hier” to “Ponctualité (30 jours)”. 
- Numerous CSS and theme changes: fav/favourite widget restyling (`#favTrainsWidget`, `.home-fav-row`, various fav card classes), typography tweaks, social icon sizing, smaller progress bar and spacing adjustments in favorites, and other UI harmonizations. 
- Performance / behavior tweaks: improved mutation observer to avoid characterData notifications, added a queued visual refresh (`scheduleRefresh`) to debounce requestAnimationFrame updates, and wrapped several window functions to trigger the refresh logic. 

### Testing
- No automated tests were added for these changes. 
- Existing automated test suites were not modified by this PR. 
- Manual verification performed by loading the updated page and exercising: comment listing order, admin delete via mouse and keyboard, 30-day punctuality display with/without cached data, and basic favorites widget visuals (no automated failures observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11e7148c0832da5d0d974ce1c196a)