### PR TITLE
Home: add 7-day punctuality chart, refine mobile layout and comments UX

### DIFF
--- a/index28.html
+++ b/index28.html
@@ -389,25 +389,29 @@ body {
 
 @media (max-width: 700px){
   .home-dashboard{
-    grid-template-columns: minmax(0, 1.05fr) minmax(0, .95fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     grid-template-areas:
       "welcome welcome"
       "traffic weather"
-      "ber ber"
-      "comments comments";
-    gap: 8px;
-    margin-bottom: 8px;
+      "traffic punct"
+      "comments comments"
+      "ber ber";
+    gap: 10px;
+    margin-bottom: 10px;
+    align-items: start;
   }
   .home-dashboard > *{ min-width: 0; }
   #homeWelcomeLine{ grid-area: welcome; margin-bottom: 0; }
   .home-card[aria-label="Info trafic"]{ grid-area: traffic; }
   .home-card[aria-label="Météo sur votre ligne"]{ grid-area: weather; }
+  .home-punct-card{ grid-area: punct; }
   .home-card[forwarding="ber"]{ grid-area: ber; }
   .live-wall-card--home{ grid-area: comments; }
 
   .home-card[aria-label="Info trafic"]{
     padding-left: 9px;
     padding-right: 9px;
+    align-self: stretch;
   }
   .home-card{
     padding: 10px 10px;
@@ -446,14 +450,19 @@ body {
     text-align: center;
   }
 
+  .home-card[aria-label="Météo sur votre ligne"]{
+    align-self: start;
+    min-height: 92px;
+    padding: 9px 9px 8px;
+  }
   .home-card[aria-label="Météo sur votre ligne"] .wx-stations{
     grid-template-columns: 1fr;
-    gap: 6px;
-    margin-top: 4px;
+    gap: 2px;
+    margin-top: 0;
   }
   .home-card[aria-label="Météo sur votre ligne"] .wx-station{
-    padding: 7px 8px;
-    min-height: 64px;
+    padding: 2px 4px;
+    min-height: 32px;
     border: none;
     background: transparent;
     box-shadow: none;
@@ -494,7 +503,7 @@ body {
   }
 
   .live-wall-card--home{
-    margin-top: -2px;
+    margin-top: 0;
     gap: 6px;
   }
   .live-wall-feed--home{
@@ -885,15 +894,19 @@ body {
 .live-wall-empty,
 .live-wall-cta{ opacity:.7; font-size:.82rem; }
 
-.fav-comments-row{ margin-top:8px; display:flex; justify-content:flex-end; }
+.fav-comments-row{ display:inline; }
 .fav-comment-btn{
-  border:1px solid rgba(0,240,255,.45);
-  border-radius:999px;
-  background:rgba(0,14,26,.58);
-  color:#dffbff;
-  padding:5px 10px;
-  font-size:.78rem;
+  display:inline-block;
+  margin-left:6px;
+  border:none;
+  background:none;
+  color:#ff3b30;
+  padding:0;
+  font-size:.9rem;
+  font-weight:700;
+  line-height:1;
   cursor:pointer;
+  vertical-align:middle;
 }
 
 .train-comments{
@@ -8380,13 +8393,13 @@ html, body{
 			<div class="wx-title" id="homeWxToTitle">Luxembourg</div>
           </div>
         </div>
-
-        <div class="wx-station wx-station--punctuality">
-          <div class="wx-title" id="homeWxPunctualityTitle">Ponctualité</div>
-          <div class="wx-now" id="homeWxPunctuality">--%</div>
-        </div>
       </div>
 </article>
+
+    <article class="home-card home-punct-card" aria-label="Ponctualité sur 7 jours">
+      <h2 id="homePunctCardTitle">Ponctualité 7 jours</h2>
+      <div id="homePunctualityChartHost" class="home-punct-chart-host"></div>
+    </article>
   </div>
 
   <article class="home-card" aria-label="Mes Bétaillères favorites">
@@ -8597,7 +8610,6 @@ html, body{
 <section id="favTrainsWidget" class="fav-widget app-page" data-page="favoris" style="display:none; position:relative; z-index:2;">
   <div class="fav-head">
     <div class="fav-title">⭐ Mes bétaillères favorites</div>
-    <button id="favOpenPrefs" class="fav-btn" type="button">Modifier</button>
   </div>
 
   <div class="fav-grid">
@@ -8896,17 +8908,6 @@ html, body{
     <div class="aff-chart" style="margin-top:8px"><canvas id="trainDetailAffluenceChart" height="92"></canvas></div>
   </div>
   <div class="train-detail-route" id="trainDetailStops"></div>
-  <div class="train-comments" id="trainDetailComments">
-    <div class="train-comments-head">
-      <strong>Commentaires</strong>
-      <span id="trainDetailCommentsCount">0</span>
-    </div>
-    <div id="trainDetailCommentsList" class="train-comments-list"></div>
-    <form id="trainDetailCommentsForm" class="train-comments-form" autocomplete="off" hidden>
-      <input id="trainDetailCommentsInput" type="text" maxlength="180" placeholder="Ajouter un commentaire sur ce train">
-      <button type="submit" class="auth-button">Envoyer</button>
-    </form>
-  </div>
   <div class="train-detail-actions">
     <a id="trainDetailAffBtn" class="train-detail-btn" href="#affluence">🚆 Ouvrir dans Affluence</a>
     <a id="trainDetailStatsBtn" class="train-detail-btn" href="#stats">📊 Voir schéma stats du train</a>
@@ -18749,7 +18750,10 @@ document.addEventListener('DOMContentLoaded', () => {
     ];
     chDonutYesterday.update();
 
-    try { window.__LB_LAST_YESTERDAY_PCT = dayOnTimePct; window.__LB_LAST_YESTERDAY_LABEL = dayLabel; if (typeof updateHomePunctuality === 'function') updateHomePunctuality(dayOnTimePct, dayLabel); } catch(e){}
+    try {
+      window.__LB_STATS_LAST_YESTERDAY_PCT = dayOnTimePct;
+      window.__LB_STATS_LAST_YESTERDAY_LABEL = dayLabel;
+    } catch(e){}
 
     const legend = $("statsExpressLegend");
     if (legend){
@@ -19678,8 +19682,7 @@ function scheduleWeatherAfterTableSettled(){
     } else {
       feed.innerHTML = wall.map((it) => `
         <div class="live-wall-item live-wall-item--home live-wall-item--compact">
-          <div class="live-wall-item-text"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span class="live-wall-inline-meta">${escapeHtml(fmtHour(it.ts))}</span> : ${escapeHtml(it.text || '')}</div>
-		  ${currentUser?.role === 'admin' && it.id ? `<div class="fav-comments-row"><button class="fav-comment-btn" type="button" data-comment-delete="${escapeHtml(String(it.id))}">Supprimer</button></div>` : ''}
+          <div class="live-wall-item-text"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span class="live-wall-inline-meta">${escapeHtml(fmtHour(it.ts))}</span> : ${escapeHtml(it.text || '')}${currentUser?.role === 'admin' && it.id ? `<span class="fav-comments-row"><span class="fav-comment-btn" role="button" tabindex="0" data-comment-delete="${escapeHtml(String(it.id))}" aria-label="Supprimer le commentaire" title="Supprimer le commentaire">❌</span></span>` : ''}</div>
         </div>
       `).join('');
       feed.scrollTop = 0;
@@ -19758,7 +19761,11 @@ function scheduleWeatherAfterTableSettled(){
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       const list = Array.isArray(data) ? data : (Array.isArray(data?.comments) ? data.comments : []);
-      lbCommentState.wall = list.map(normalizeCommentItem).filter(Boolean).slice(0, 50);
+      lbCommentState.wall = list
+        .map(normalizeCommentItem)
+        .filter(Boolean)
+        .sort((a, b) => Number(b?.ts || 0) - Number(a?.ts || 0))
+        .slice(0, 50);
       window.lbCommentState = lbCommentState;
       renderCommentsUI();
       return lbCommentState.wall;
@@ -19795,8 +19802,9 @@ function scheduleWeatherAfterTableSettled(){
     if (!commentId) throw new Error('Commentaire introuvable');
     if (currentUser?.role !== 'admin') throw new Error('Action réservée aux admins');
 
-    const res = await fetchCommentsApi(`/${encodeURIComponent(commentId)}`, {
-      method: 'DELETE'
+    const res = await fetch(`https://vps.labetaillere.fr/api/comments/${encodeURIComponent(commentId)}`, {
+      method: 'DELETE',
+      credentials: 'include'
     });
 
     let data = null;
@@ -19835,6 +19843,16 @@ function scheduleWeatherAfterTableSettled(){
       feed.addEventListener('click', async (e) => {
         const btn = e.target.closest('[data-comment-delete]');
         if (!btn) return;
+        try{
+          await deleteComment(btn.getAttribute('data-comment-delete'));
+        }catch(err){
+          alert(err?.message || "Impossible de supprimer le commentaire.");
+        }
+      });
+      feed.addEventListener('keydown', async (e) => {
+        const btn = e.target.closest('[data-comment-delete]');
+        if (!btn || (e.key !== 'Enter' && e.key !== ' ')) return;
+        e.preventDefault();
         try{
           await deleteComment(btn.getAttribute('data-comment-delete'));
         }catch(err){
@@ -20868,7 +20886,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
 	  if (badgeEl) badgeEl.innerHTML = `${buildWidgetStateBadge(canceledState)} <span class="fav-cancel-badge">✖ SUPPRIMÉ</span>`;
       meta.innerHTML = `
         <div style="display:flex;align-items:center;justify-content:space-between;gap:10px;">
-          <div style="font-size:1.18rem;font-weight:900;opacity:.96">${escapeHtml(origin)} → ${escapeHtml(dest)}</div>
+          <div style="font-size:1.02rem;font-weight:900;opacity:.96;line-height:1.08">${escapeHtml(origin)} → ${escapeHtml(dest)}</div>
         </div>
         <div class="fav-times" style="opacity:.9;">${escapeHtml(depTxt)} → ${escapeHtml(arrTxt)}</div>
       `;
@@ -20915,7 +20933,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
 
     meta.innerHTML = `
       <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;">
-        <div style="font-size:1.18rem;font-weight:900;opacity:.96;">${escapeHtml(origin)} → ${escapeHtml(dest)}</div>
+        <div style="font-size:1.02rem;font-weight:900;opacity:.96;line-height:1.08;">${escapeHtml(origin)} → ${escapeHtml(dest)}</div>
         ${isPartialAny ? `<span style="padding:4px 10px;border-radius:999px;border:1px solid rgba(255,80,80,.40); background:rgba(255,80,80,.12); color:#ff9a9a; font-weight:900;">SUPPRESSION PARTIELLE</span>` : ''}
       </div>
       <div class="fav-times">${timesHtml}</div>
@@ -20925,7 +20943,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
     const isDelayed = (maxDelay != null && Number.isFinite(maxDelay) && maxDelay >= 1);
     let causeHtml = '';
     if ((isDelayed || isPartialAny) && causeText){
-      causeHtml = `<div class="fav-box fav-box-warn" style="margin-top:10px;"><div class="fav-box-body" style="color:#ffb36b;font-weight:800;">${escapeHtml(causeText)}</div></div>`;
+      causeHtml = `<div class="fav-box fav-box-warn" style="margin-top:6px;"><div class="fav-box-body" style="color:#ffb36b;font-weight:800;">${escapeHtml(causeText)}</div></div>`;
     }
     if (causeEl){
       // on garde le noeud pour compat mais on le vide (la cause est rendue dans fav-line)
@@ -20936,8 +20954,8 @@ function getGtfsDelayForStop(trainNumber, stopName){
     // Progression (visuel)
     const pct = (widgetState === 'before') ? 0 : (widgetState === 'after' ? 100 : computeProgressPct(effectiveDepMin, effectiveArrLast, st.now));
     const progressHtml = `
-      <div style="margin:12px 0 10px 0;">
-        <div style="height:6px;border-radius:999px;overflow:hidden;background:rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(0,255,255,.12);">
+      <div style="margin:8px 0 6px 0;">
+        <div style="height:5px;border-radius:999px;overflow:hidden;background:rgba(255,255,255,.08);box-shadow:inset 0 0 0 1px rgba(0,255,255,.12);">
           <div style="height:100%;width:${pct}%;background:rgba(0,255,255,.85);box-shadow:0 0 12px rgba(0,255,255,.35);border-radius:999px;transition:width .6s ease;"></div>
         </div>
       </div>
@@ -20990,7 +21008,6 @@ function getGtfsDelayForStop(trainNumber, stopName){
           <div class="fav-box-body fav-aff-body">
             ${stops.length ? `<div class="fav-aff-stops">${stopsHtml}</div>` : `<div class="fav-aff-empty">Pas de détail d’affluence disponible pour ce train ce jour-là.</div>`}
             ${affInfo.spark || ''}
-            <a class="fav-aff-open" href="#affluence" data-train="${escapeHtml(trainId)}">Ouvrir dans Affluence</a>
           </div>
         </details>
       `;
@@ -22684,10 +22701,10 @@ async function updateHomeBerBlock(){
     }
   }
 
-  // ponctualité hier — si déjà calculée par les stats express, on l’utilise
+  // ponctualité moyenne J-1 → J-30 (publique)
   try{
-    if (typeof window.__LB_LAST_YESTERDAY_PCT === 'number') updateHomePunctuality(window.__LB_LAST_YESTERDAY_PCT, window.__LB_LAST_YESTERDAY_LABEL);
-    else await ensureYesterdayPunctuality();
+    if (typeof window.__LB_LAST_30D_PCT === 'number') updateHomePunctuality(window.__LB_LAST_30D_PCT, window.__LB_LAST_30D_KEY || '30d');
+    else if (typeof window.ensure30DayPunctuality === 'function') await window.ensure30DayPunctuality();
   }catch(e){}
 }
 
@@ -22817,7 +22834,7 @@ function ensureFavInHome(){
   if (cta) cta.style.display = authed ? 'none' : 'block';
 
   if (!authed){
-    slot.innerHTML = '<div style="opacity:.7">⭐ Connectez-vous pour afficher vos favoris.</div>';
+    slot.innerHTML = '';
     return;
   }
 
@@ -22879,10 +22896,10 @@ function getUserWxPrefsOrDefault(){
 
 async function initHomePublicBlocks(){
   const prefs = getUserWxPrefsOrDefault();
-  // météo (public) + ponctualité hier (public) + bloc BER
+  // météo (public) + ponctualité moyenne 30 jours (public) + bloc BER
   await Promise.all([
     updateHomeWeather(prefs.from, prefs.to),
-    ensureYesterdayPunctuality()
+    (typeof window.ensure30DayPunctuality === 'function' ? window.ensure30DayPunctuality() : Promise.resolve(null))
   ]);
   await updateHomeBerBlock();
 }
@@ -24471,385 +24488,6 @@ async function loadAffluenceDate(dateStr){
 </script>
 
 
-<style id="home-mobile-final-fix">
-@media (max-width: 700px){
-  .home-dashboard{
-    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-    grid-template-areas:
-      "welcome welcome"
-      "traffic weather"
-      "comments comments" !important;
-    gap: 8px !important;
-    margin-bottom: 8px !important;
-    align-items: stretch !important;
-  }
-  #homeWelcomeLine{
-    grid-area: welcome !important;
-    text-align: center !important;
-    justify-self: center !important;
-    width: 100% !important;
-    margin: 0 0 6px 0 !important;
-  }
-  .home-card[aria-label="Info trafic"]{ grid-area: traffic !important; }
-  .home-card[aria-label="Météo sur votre ligne"]{ grid-area: weather !important; }
-  .live-wall-card--home{ grid-area: comments !important; }
-  .home-card[forwarding="ber"]{ display: none !important; }
-
-  .home-card[aria-label="Info trafic"],
-  .home-card[aria-label="Météo sur votre ligne"]{
-    min-height: 0 !important;
-    height: 100% !important;
-    padding: 12px 12px !important;
-  }
-
-  .home-card[aria-label="Info trafic"] .traffic-split{
-    display: flex !important;
-    flex-direction: column !important;
-    gap: 8px !important;
-    margin-top: 4px !important;
-  }
-  .home-card[aria-label="Info trafic"] .traffic-split-row{
-    display: flex !important;
-    flex-direction: column !important;
-    align-items: flex-start !important;
-    gap: 4px !important;
-    padding: 0 !important;
-    border: none !important;
-    background: transparent !important;
-    box-shadow: none !important;
-  }
-  .home-card[aria-label="Info trafic"] .traffic-split-line{
-    font-size: .82rem !important;
-    line-height: 1.1 !important;
-    margin: 0 !important;
-  }
-  .home-card[aria-label="Info trafic"] .traffic-pill{
-    margin: 0 !important;
-    max-width: none !important;
-    font-size: .58rem !important;
-    line-height: 1.05 !important;
-    padding: 5px 10px !important;
-  }
-
-  .home-card[aria-label="Météo sur votre ligne"] .wx-stations{
-    display: grid !important;
-    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-    gap: 8px !important;
-    margin-top: 4px !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-station{
-    padding: 6px 6px !important;
-    min-height: 0 !important;
-    border: none !important;
-    background: transparent !important;
-    box-shadow: none !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-row{
-    display: flex !important;
-    flex-direction: column !important;
-    align-items: center !important;
-    gap: 4px !important;
-    text-align: center !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-now{
-    width: 100% !important;
-    justify-content: center !important;
-    font-size: .95rem !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-title{
-    margin-top: 0 !important;
-    font-size: .62rem !important;
-    line-height: 1.05 !important;
-    white-space: normal !important;
-    word-break: normal !important;
-    overflow-wrap: anywhere !important;
-    text-align: center !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] 
-  .home-card[aria-label="Météo sur votre ligne"] 
-  .home-card[aria-label="Météo sur votre ligne"] 
-  .home-card[aria-label="Météo sur votre ligne"] 
-}
-</style>
-<script id="home-mobile-final-script">
-document.addEventListener('DOMContentLoaded', function(){
-  try{
-    var north = document.getElementById('homeTrafficLineNorth');
-    if (north) north.textContent = 'Metz - Lux';
-    var ber = document.querySelector('.home-card[forwarding="ber"]');
-    if (ber) ber.remove();
-  }catch(e){}
-});
-</script>
-
-
-<style id="home-mobile-final-fix-v11">
-@media (max-width: 768px){
-  #homeWelcomeLine,
-  .home-welcome-line{
-    font-size: .94rem !important;
-    line-height: 1.12 !important;
-    padding: 4px 10px !important;
-    margin: 0 0 8px 0 !important;
-    text-align: center !important;
-    white-space: nowrap !important;
-    overflow: hidden !important;
-    text-overflow: ellipsis !important;
-  }
-
-  .home-dashboard{
-    row-gap: 6px !important;
-    column-gap: 8px !important;
-    grid-template-columns: repeat(2, minmax(0,1fr)) !important;
-  }
-
-  .home-card[aria-label="Info trafic"],
-  .home-card[aria-label="Météo sur votre ligne"]{
-    width: 100% !important;
-    min-width: 0 !important;
-    padding: 12px 14px 10px !important;
-  }
-
-  .home-card[aria-label="Info trafic"] h2,
-  .home-card[aria-label="Météo sur votre ligne"] h2{
-    margin: 0 0 8px 0 !important;
-  }
-
-  .home-card[aria-label="Info trafic"] .traffic-split{
-    gap: 6px !important;
-    margin-top: 2px !important;
-  }
-
-  .home-card[aria-label="Info trafic"] .traffic-split-row{
-    gap: 1px !important;
-    padding: 2px 0 3px 6px !important;
-    margin: 0 !important;
-    border: none !important;
-    background: transparent !important;
-    box-shadow: none !important;
-  }
-
-  .home-card[aria-label="Info trafic"] .traffic-split-line{
-    font-size: .92rem !important;
-    line-height: 1.08 !important;
-    margin: 0 !important;
-    padding-left: 0 !important;
-  }
-
-  .home-card[aria-label="Info trafic"] .traffic-pill{
-    margin: 0 !important;
-    padding: 4px 12px !important;
-    font-size: .72rem !important;
-  }
-
-  .home-card[aria-label="Météo sur votre ligne"] .wx-stations{
-    display: grid !important;
-    grid-template-columns: repeat(2, minmax(0,1fr)) !important;
-    gap: 8px !important;
-    margin-top: 2px !important;
-  }
-
-  .home-card[aria-label="Météo sur votre ligne"] .wx-station{
-    min-width: 0 !important;
-  }
-
-  .home-card[aria-label="Météo sur votre ligne"] .wx-row{
-    display: flex !important;
-    flex-direction: column !important;
-    align-items: center !important;
-    text-align: center !important;
-    gap: 4px !important;
-  }
-
-  .home-card[aria-label="Météo sur votre ligne"] .wx-title{
-    text-align: center !important;
-    font-size: .72rem !important;
-    line-height: 1.02 !important;
-    white-space: normal !important;
-    word-break: break-word !important;
-    overflow-wrap: anywhere !important;
-  }
-
-  .home-card[aria-label="Météo sur votre ligne"] 
-
-  .home-card[aria-label="Météo sur votre ligne"] 
-
-  .home-card[aria-label="Mur de commentaires"]{
-    padding: 12px 12px 10px !important;
-  }
-
-  .home-card[aria-label="Mur de commentaires"] .live-wall-head{
-    margin-bottom: 2px !important;
-  }
-
-  .home-card[aria-label="Mur de commentaires"] .live-wall-feed--home{
-    max-height: 138px !important;
-    overflow-y: auto !important;
-    overflow-x: hidden !important;
-    margin-top: 0 !important;
-    padding-right: 2px !important;
-    gap: 1px !important;
-  }
-
-  .home-card[aria-label="Mur de commentaires"] .live-wall-item,
-  .home-card[aria-label="Mur de commentaires"] .live-wall-item--home,
-  .home-card[aria-label="Mur de commentaires"] .live-wall-item--compact{
-    margin: 0 0 2px 0 !important;
-    line-height: 1.18 !important;
-  }
-
-  .home-card[aria-label="Mur de commentaires"] .live-wall-form{
-    margin-top: 2px !important;
-    gap: 6px !important;
-    align-items: center !important;
-  }
-
-  .home-card[aria-label="Mur de commentaires"] .live-wall-form input{
-    height: 32px !important;
-    min-height: 32px !important;
-    padding: 6px 10px !important;
-    font-size: .80rem !important;
-    border-radius: 12px !important;
-    transition: all .18s ease !important;
-  }
-
-  .home-card[aria-label="Mur de commentaires"] .live-wall-form input:focus{
-    height: 40px !important;
-    min-height: 40px !important;
-  }
-
-  .home-card[aria-label="Mur de commentaires"] .live-wall-form .auth-button,
-  .home-card[aria-label="Mur de commentaires"] .live-wall-form button{
-    min-width: 92px !important;
-    height: 32px !important;
-    min-height: 32px !important;
-    padding: 0 14px !important;
-    border-radius: 13px !important;
-    font-size: .80rem !important;
-  }
-}
-</style>
-<script id="home-mobile-final-script-v11">
-document.addEventListener('DOMContentLoaded', function(){
-  try {
-    var north = document.getElementById('homeTrafficLineNorth');
-    if (north) north.textContent = 'Metz - Lux';
-  } catch(e) {}
-});
-</script>
-
-
-<style id="home-v13-fixes">
-@media (max-width: 768px){
-  .home-dashboard{
-    column-gap: 10px !important;
-    row-gap: 10px !important;
-    align-items: stretch !important;
-  }
-  .home-card[aria-label="Info trafic"],
-  .home-card[aria-label="Météo sur votre ligne"]{
-    width: 100% !important;
-    min-height: 0 !important;
-    padding: 14px 14px 12px !important;
-    display: flex !important;
-    flex-direction: column !important;
-    justify-content: flex-start !important;
-  }
-  .home-card[aria-label="Info trafic"] h2,
-  .home-card[aria-label="Météo sur votre ligne"] h2{
-    margin: 0 0 10px 0 !important;
-  }
-  .home-card[aria-label="Info trafic"] .traffic-split{
-    display: flex !important;
-    flex-direction: column !important;
-    gap: 12px !important;
-    margin-top: 0 !important;
-  }
-  .home-card[aria-label="Info trafic"] .traffic-split-row{
-    display: flex !important;
-    flex-direction: column !important;
-    align-items: flex-start !important;
-    gap: 6px !important;
-    padding: 0 0 0 10px !important;
-    margin: 0 !important;
-    border: none !important;
-    background: transparent !important;
-    box-shadow: none !important;
-  }
-  .home-card[aria-label="Info trafic"] .traffic-split-line{
-    display: block !important;
-    width: 100% !important;
-    padding-left: 0 !important;
-    margin: 0 !important;
-    font-size: .98rem !important;
-    line-height: 1.08 !important;
-  }
-  .home-card[aria-label="Info trafic"] .traffic-pill{
-    margin: 0 !important;
-    max-width: none !important;
-    width: auto !important;
-    min-width: 0 !important;
-    padding: 5px 14px !important;
-    font-size: .70rem !important;
-    line-height: 1.02 !important;
-    white-space: nowrap !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-stations{
-    display: grid !important;
-    grid-template-columns: 1fr 1fr !important;
-    grid-template-areas: "from to" "punct punct" !important;
-    gap: 6px 10px !important;
-    margin-top: 0 !important;
-    align-items: start !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-station{
-    padding: 0 !important;
-    min-height: 0 !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-station:nth-child(1){ grid-area: from; }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-station:nth-child(2){ grid-area: to; }
-  .home-card[aria-label="Météo sur votre ligne"] 
-  .home-card[aria-label="Météo sur votre ligne"] .wx-row{
-    display: flex !important;
-    flex-direction: column !important;
-    align-items: center !important;
-    text-align: center !important;
-    gap: 3px !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-now{
-    width: auto !important;
-    font-size: .98rem !important;
-    justify-content: center !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-title{
-    font-size: .58rem !important;
-    line-height: 1.0 !important;
-    white-space: nowrap !important;
-    word-break: normal !important;
-    overflow-wrap: normal !important;
-    hyphens: none !important;
-    text-align: center !important;
-    max-width: 100% !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] #homeWxToTitle{
-    font-size: .50rem !important;
-    letter-spacing: 0 !important;
-  }
-  .home-card[aria-label="Météo sur votre ligne"] 
-  .home-card[aria-label="Météo sur votre ligne"] 
-  .home-card[aria-label="Mur de commentaires"] .live-wall-feed--home{
-    max-height: 112px !important;
-    overflow-y: auto !important;
-    padding-right: 4px !important;
-    scroll-behavior: smooth !important;
-  }
-  .home-card[aria-label="Mur de commentaires"] .live-wall-item,
-  .home-card[aria-label="Mur de commentaires"] .live-wall-item--home,
-  .home-card[aria-label="Mur de commentaires"] .live-wall-item--compact{
-    margin: 0 0 3px 0 !important;
-  }
-}
-</style>
 <script id="home-v13-script">
 (function(){
   function luxTodayISO(){
@@ -24866,33 +24504,173 @@ document.addEventListener('DOMContentLoaded', function(){
     d.setUTCDate(d.getUTCDate() - days);
     return d.toISOString().slice(0,10);
   }
-  async function ensure30DayPunctuality(){
-    const to = dateMinusDays(luxTodayISO(), 1);
-    const from = dateMinusDays(to, 29);
-    const key = `${from}_${to}`;
-    ['homeBerPunctuality','homeWxPunctuality'].forEach((id)=>{
-      const el = document.getElementById(id);
-      if (el) el.textContent = '…';
-    });
+  const __LB_30D_CACHE_KEY = 'lb_home_30d_punctuality_v1';
+  function read30DayPunctualityCache(){
     try{
-      let range = null;
-      if (typeof loadRangeAPI === 'function') range = await loadRangeAPI(from, to);
-      else if (typeof apiFetch === 'function') range = await apiFetch(`/api/stats/gtfs/range?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`);
-      else {
-        const r = await fetch(`/api/stats/gtfs/range?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`, { cache:'no-store' });
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        range = await r.json();
+      const raw = localStorage.getItem(__LB_30D_CACHE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      const pct = Number(parsed?.pct);
+      const key = String(parsed?.key || '').trim();
+      if (!key || !Number.isFinite(pct)) return null;
+      return { key, pct: Math.max(0, Math.min(100, pct)), from: parsed?.from || '', to: parsed?.to || '' };
+    }catch(e){
+      return null;
+    }
+  }
+  function write30DayPunctualityCache(key, pct, from, to){
+    try{
+      const num = Number(pct);
+      if (!key || !Number.isFinite(num)) return;
+      localStorage.setItem(__LB_30D_CACHE_KEY, JSON.stringify({
+        key: String(key),
+        pct: Math.max(0, Math.min(100, num)),
+        from: String(from || ''),
+        to: String(to || ''),
+        savedAt: Date.now()
+      }));
+    }catch(e){}
+  }
+  async function fetchPublicRawRange(from, to){
+    const qs = `from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
+    const urls = [
+      `${STATS_API_BASE}/api/stats/gtfs/rawrange?${qs}`,
+      `${STATS_API_BASE}/stats/gtfs/rawrange?${qs}`
+    ];
+    let lastErr = null;
+    for (const url of urls){
+      try{
+        const res = await fetch(url, { cache:'no-store', credentials:'include' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.json();
+      }catch(e){
+        lastErr = e;
       }
+    }
+    throw lastErr || new Error('rawrange indisponible');
+  }
+  async function fetchPublicRange(from, to){
+    const qs = `from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
+    const urls = [
+      `${STATS_API_BASE}/api/stats/gtfs/range?${qs}`,
+      `${STATS_API_BASE}/stats/gtfs/range?${qs}`
+    ];
+    let lastErr = null;
+    for (const url of urls){
+      try{
+        const res = await fetch(url, { cache:'no-store', credentials:'include' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.json();
+      }catch(e){
+        lastErr = e;
+      }
+    }
+    throw lastErr || new Error('range indisponible');
+  }
+  async function ensure30DayPunctuality(){
+    const fallbackTo = dateMinusDays(luxTodayISO(), 1);
+    const fallbackFrom = dateMinusDays(fallbackTo, 29);
+    const period = (typeof getLastDaysRange === 'function')
+      ? getLastDaysRange(30)
+      : { from: fallbackFrom, to: fallbackTo };
+    const from = String(period?.from || fallbackFrom);
+    const to = String(period?.to || fallbackTo);
+    const key = `${from}_${to}`;
+    const cached = read30DayPunctualityCache();
+
+    if (window.__LB_LAST_30D_KEY === key && Number.isFinite(Number(window.__LB_LAST_30D_PCT))) {
+      if (typeof updateHomePunctuality === 'function') updateHomePunctuality(window.__LB_LAST_30D_PCT, key);
+      return Number(window.__LB_LAST_30D_PCT);
+    }
+
+    if (cached?.key === key && Number.isFinite(Number(cached.pct))) {
+      window.__LB_LAST_30D_KEY = key;
+      window.__LB_LAST_30D_PCT = Number(cached.pct);
+      if (typeof updateHomePunctuality === 'function') updateHomePunctuality(cached.pct, key);
+    } else {
+      ['homeBerPunctuality','homeWxPunctuality'].forEach((id)=>{
+        const el = document.getElementById(id);
+        if (el && (!el.textContent || /^[-–—.\s%]*$/.test(el.textContent))) el.textContent = '…';
+      });
+    }
+
+    const dailyPctFromSummary = (day) => {
+      const total = Number(day?.total_trains || 0);
+      const pctNot = Number(day?.pct_not_on_time);
+      if (total > 0 && Number.isFinite(pctNot)) return 100 - pctNot;
+      return null;
+    };
+    const avgFromRangeSeries = (range) => {
       const series = Array.isArray(range?.series) ? range.series : [];
       const values = series
-        .map(d => 100 - Number(d?.pct_not_on_time ?? NaN))
+        .filter(x => x && x.date >= from && x.date <= to)
+        .map(x => 100 - Number(x?.pct_not_on_time ?? NaN))
         .filter(v => Number.isFinite(v));
-      const pct = values.length ? (values.reduce((a,b)=>a+b,0) / values.length) : null;
+      return values.length ? (values.reduce((a, b) => a + b, 0) / values.length) : null;
+    };
+
+    ['homeBerPunctuality','homeWxPunctuality'].forEach((id)=>{
+      const el = document.getElementById(id);
+      if (el && (!el.textContent || /^[-–—.\s%]*$/.test(el.textContent))) el.textContent = '…';
+    });
+    try{
+      let pct = null;
+
+      try{
+        if (typeof loadRangeAPI === 'function'){
+          const range = await loadRangeAPI(from, to);
+          pct = avgFromRangeSeries(range);
+        } else {
+          throw new Error('loadRangeAPI indisponible');
+        }
+      }catch(_statsRangeErr){
+        try{
+          const range = await fetchPublicRange(from, to);
+          pct = avgFromRangeSeries(range);
+        }catch(_publicRangeErr){
+          let rawPayload = null;
+          try{
+            if (typeof loadRawRangeAPI === 'function') rawPayload = await loadRawRangeAPI(from, to);
+            else throw _publicRangeErr;
+          }catch(_statsRawErr){
+            try{
+              rawPayload = await fetchPublicRawRange(from, to);
+            }catch(_publicErr){
+              throw _publicErr;
+            }
+          }
+
+          const rawDays = (typeof normalizeRawRangePayload === 'function')
+            ? normalizeRawRangePayload(rawPayload)
+            : (Array.isArray(rawPayload) ? rawPayload : (Array.isArray(rawPayload?.days) ? rawPayload.days : []));
+
+          const values = rawDays
+            .filter(day => day && day.date >= from && day.date <= to)
+            .map(day => {
+              if (typeof computeDaySummaryFromRaw === 'function') return dailyPctFromSummary(computeDaySummaryFromRaw(day));
+              return dailyPctFromSummary(day);
+            })
+            .filter(v => Number.isFinite(v));
+
+          pct = values.length ? (values.reduce((a,b)=>a+b,0) / values.length) : null;
+        }
+      }
+      if (!Number.isFinite(Number(pct))) throw new Error('Moyenne 30 jours invalide');
+
       window.__LB_LAST_30D_KEY = key;
-      window.__LB_LAST_30D_PCT = pct;
+      window.__LB_LAST_30D_PCT = Math.max(0, Math.min(100, Number(pct)));
+      write30DayPunctualityCache(key, window.__LB_LAST_30D_PCT, from, to);
       if (pct != null && typeof updateHomePunctuality === 'function') updateHomePunctuality(pct, key);
       return pct;
     }catch(e){
+      if (window.__LB_LAST_30D_KEY === key && Number.isFinite(Number(window.__LB_LAST_30D_PCT))) {
+        if (typeof updateHomePunctuality === 'function') updateHomePunctuality(window.__LB_LAST_30D_PCT, key);
+        return Number(window.__LB_LAST_30D_PCT);
+      }
+      if (cached?.key === key && Number.isFinite(Number(cached.pct))) {
+        if (typeof updateHomePunctuality === 'function') updateHomePunctuality(cached.pct, key);
+        return Number(cached.pct);
+      }
       ['homeBerPunctuality','homeWxPunctuality'].forEach((id)=>{
         const el = document.getElementById(id);
         if (el) el.textContent = '—';
@@ -24905,12 +24683,22 @@ document.addEventListener('DOMContentLoaded', function(){
     const north = document.getElementById('homeTrafficLineNorth');
     if (north) north.textContent = 'Metz - Lux';
   }
+  function kickHomePunctuality(){
+    try{
+      ensure30DayPunctuality().catch(()=>{});
+    }catch(e){}
+  }
 
   if (document.readyState === 'loading'){
     document.addEventListener('DOMContentLoaded', applyHomeV13Tweaks);
+    document.addEventListener('DOMContentLoaded', kickHomePunctuality);
   } else {
     applyHomeV13Tweaks();
+    kickHomePunctuality();
   }
+  window.addEventListener('load', kickHomePunctuality);
+  setTimeout(kickHomePunctuality, 400);
+  setTimeout(kickHomePunctuality, 1400);
   window.ensure30DayPunctuality = ensure30DayPunctuality;
 })();
 </script>
@@ -24977,7 +24765,7 @@ document.addEventListener('DOMContentLoaded', function(){
   function forceYesterdayPunctuality(){
     try{
       const title = document.querySelector('[data-home-punctuality-title], #homeWxPunctualityTitle, #homeBerPunctualityTitle');
-      if (title) title.textContent = 'Ponctualité hier';
+      if (title) title.textContent = 'Ponctualité 7 jours';
     }catch(e){}
   }
 
@@ -25154,7 +24942,7 @@ document.addEventListener('DOMContentLoaded', function(){
   function syncPunctualityLayout(){
     try{
       var title = document.querySelector('[data-home-punctuality-title], #homeWxPunctualityTitle, #homeBerPunctualityTitle');
-      if(title) title.textContent = 'Ponctualité hier';
+      if(title) title.textContent = 'Ponctualité 7 jours';
     }catch(e){}
   }
 
@@ -25178,7 +24966,7 @@ document.addEventListener('DOMContentLoaded', function(){
       feed.innerHTML = wall.map(function(it){
         var commentId = String(it && it.id != null ? it.id : '').trim();
         var deleteBtn = (isAdmin && commentId)
-          ? '<div class="fav-comments-row"><button class="fav-comment-btn" type="button" data-comment-delete="' + escapeHtml(commentId) + '">Supprimer</button></div>'
+          ? '<span class="fav-comments-row"><span class="fav-comment-btn" role="button" tabindex="0" data-comment-delete="' + escapeHtml(commentId) + '" aria-label="Supprimer le commentaire" title="Supprimer le commentaire">❌</span></span>'
           : '';
         return '<div class="live-wall-item live-wall-item--home live-wall-item--compact"><div class="live-wall-item-text"><strong>' + escapeHtml(it.pseudo || 'Voyageur') + '</strong><span class="live-wall-inline-meta">' + escapeHtml((typeof fmtDateHourCompact === 'function' ? fmtDateHourCompact(it.ts) : '')) + '</span> : ' + escapeHtml(it.text || '') + '</div>' + deleteBtn + '</div>';
       }).join('');
@@ -25339,90 +25127,169 @@ document.addEventListener('DOMContentLoaded', function(){
 
 
 <style id="home-punctuality-visual-fix">
-.home-card[aria-label="Météo sur votre ligne"] .wx-station--punctuality{
-  grid-column: 1 / -1 !important;
+
+.home-punct-card{
+  padding-top: 9px !important;
+  padding-bottom: 10px !important;
+}
+.home-punct-card #homePunctCardTitle{
+  text-align:center;
+  font-size:.9rem !important;
+  margin:0 0 4px 0 !important;
+}
+.home-card[aria-label="Météo sur votre ligne"] .wx-stations{
+  grid-template-columns: 1fr 1fr !important;
+  gap: 10px !important;
+}
+.home-card[aria-label="Météo sur votre ligne"] .wx-station{
+  min-height: 0 !important;
+}
+.home-punct-card{
+  align-self: start;
+}
+.home-punct-card #homePunctCardTitle{
+  margin-bottom: 6px !important;
+}
+#homePunctualityChartHost.home-punct-chart-host{
   display:flex !important;
-  flex-direction:column !important;
   align-items:center !important;
   justify-content:center !important;
-  text-align:center !important;
-  padding: 6px 6px 2px !important;
   min-height: 96px !important;
+  margin-top: 0 !important;
 }
-.home-card[aria-label="Météo sur votre ligne"] .wx-station--punctuality .wx-title,
-.home-card[aria-label="Météo sur votre ligne"] #homeWxPunctualityTitle{
-  display:block !important;
-  width:100% !important;
-  margin: 2px 0 10px 0 !important;
-  text-align:center !important;
-  font-size: 1.02rem !important;
-  line-height: 1.05 !important;
-  font-weight: 700 !important;
-  color: #8df3ff !important;
-  white-space: nowrap !important;
-  letter-spacing: .01em !important;
-}
-.home-card[aria-label="Météo sur votre ligne"] .wx-station--punctuality .wx-now,
-.home-card[aria-label="Météo sur votre ligne"] #homeWxPunctuality{
-  display:block !important;
-  width:100% !important;
-  text-align:center !important;
-  justify-content:center !important;
-  margin: 6px 0 0 0 !important;
-  font-size: 1.55rem !important;
-  line-height: .95 !important;
-  font-weight: 800 !important;
-  letter-spacing: .01em !important;
+.home-punct-chart-wrap{
+  width: 104px;
+  height: 104px;
+  margin: 0 auto;
 }
 @media (max-width: 768px){
-  .home-card[aria-label="Météo sur votre ligne"] .wx-stations{
-    grid-template-columns: 1fr 1fr !important;
-    grid-template-areas: "from to" "punct punct" !important;
-    row-gap: 10px !important;
+  .home-punct-chart-wrap{
+    width: 92px;
+    height: 92px;
   }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-station:nth-child(1){ grid-area: from !important; }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-station:nth-child(2){ grid-area: to !important; }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-station--punctuality{
-    grid-area: punct !important;
-    min-height: 88px !important;
-    padding-top: 4px !important;
+}
+@media (max-width: 700px){
+  .home-punct-card{
+    align-self: start !important;
+    min-height: 92px;
+    padding: 9px 9px 8px !important;
   }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-station--punctuality .wx-title,
-  .home-card[aria-label="Météo sur votre ligne"] #homeWxPunctualityTitle{
-    font-size: .95rem !important;
-    margin-bottom: 10px !important;
+  .home-punct-card #homePunctCardTitle{
+    font-size: .86rem !important;
+    line-height: 1.05 !important;
+    margin-bottom: 2px !important;
   }
-  .home-card[aria-label="Météo sur votre ligne"] .wx-station--punctuality .wx-now,
-  .home-card[aria-label="Météo sur votre ligne"] #homeWxPunctuality{
-    font-size: 1.75rem !important;
+  #homePunctualityChartHost.home-punct-chart-host{
+    min-height: 68px !important;
+  }
+  .home-punct-chart-wrap{
+    width: 72px;
+    height: 72px;
   }
 }
 </style>
 <script id="home-punctuality-visual-fix-script">
 (function(){
-  function colorForHomePunctuality(score){
+  var homePunctChart = null;
+  var HOME_RING_REST_COLOR = 'rgba(125,217,255,0.18)';
+
+  function homeFmtPctShort(x){
+    var n = Number(x);
+    if (!Number.isFinite(n)) return '—';
+    return Math.round(n) + '%';
+  }
+
+  function homeColorForPunctuality(score){
     var n = Number(score);
-    if (!Number.isFinite(n)) return '#eaf6ff';
-    if (n >= 95) return '#16a34a';
+    if (!Number.isFinite(n)) return '#f97316';
+    if (window.__lbStats && typeof window.__lbStats.colorForPunctuality === 'function') return window.__lbStats.colorForPunctuality(n);
     if (n >= 90) return '#22c55e';
-    if (n >= 85) return '#facc15';
-    if (n >= 80) return '#fb923c';
-    if (n >= 75) return '#f97316';
-    return '#ef4444';
+    if (n >= 85) return '#84cc16';
+    if (n >= 80) return '#facc15';
+    if (n >= 75) return '#fb923c';
+    return '#f97316';
+  }
+
+  function ensureHomePunctualityChart(){
+    var host = document.getElementById('homePunctualityChartHost');
+    if (!host) return null;
+    host.classList.add('home-punct-chart-host');
+    if (!document.getElementById('homeWxPunctualityChart')){
+      host.innerHTML = '<div class="home-punct-chart-wrap"><canvas id="homeWxPunctualityChart"></canvas></div>';
+    }
+    var canvas = document.getElementById('homeWxPunctualityChart');
+    if (!canvas || typeof Chart !== 'function') return null;
+    if (!homePunctChart){
+      homePunctChart = new Chart(canvas, {
+        type: 'doughnut',
+        data: {
+          labels: ['Ponctualité', 'Reste'],
+          datasets: [{
+            data: [0, 100],
+            backgroundColor: ['#22c55e', HOME_RING_REST_COLOR],
+            borderWidth: 0,
+            cutout: '74%'
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: { enabled: false },
+            centerText: { lineGap: 12, lines: [] }
+          }
+        }
+      });
+    }
+    return homePunctChart;
+  }
+
+  function renderHomePunctualityChart(pct){
+    var chart = ensureHomePunctualityChart();
+    if (!chart) return;
+    var value = Number(pct);
+    if (!Number.isFinite(value)) value = 0;
+    value = Math.max(0, Math.min(100, value));
+    var ringColor = homeColorForPunctuality(value);
+    chart.data.datasets[0].data = [value, Math.max(0, 100 - value)];
+    chart.data.datasets[0].backgroundColor = [ringColor, HOME_RING_REST_COLOR];
+    chart.options.plugins.centerText.lines = [
+      { text: homeFmtPctShort(value), font: '900 16px Orbitron, system-ui', color: '#e8fbff' }
+    ];
+    chart.update();
+  }
+
+  async function loadHomePunctualityChart(){
+    try{
+      var title = document.getElementById('homePunctCardTitle');
+      if (title) title.textContent = 'Ponctualité 7 jours';
+      var statsApi = window.__lbStats || {};
+      if (typeof statsApi.getLastDaysRange !== 'function') return;
+      var rangeInfo = statsApi.getLastDaysRange(7);
+      var range = null;
+      if (typeof loadRangeAPI === 'function') range = await loadRangeAPI(rangeInfo.from, rangeInfo.to);
+      else {
+        var qs = 'from=' + encodeURIComponent(rangeInfo.from) + '&to=' + encodeURIComponent(rangeInfo.to);
+        var res = await fetch('https://vps.labetaillere.fr/api/stats/gtfs/range?' + qs, { credentials: 'include', cache: 'no-store' });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        range = await res.json();
+      }
+      var series = Array.isArray(range?.series) ? range.series : [];
+      var values = series.map(function(x){ return 100 - Number(x && x.pct_not_on_time || 0); }).filter(function(v){ return Number.isFinite(v); });
+      if (!values.length) throw new Error('Aucune ponctualité 7 jours');
+      var avg = values.reduce(function(a, b){ return a + b; }, 0) / values.length;
+      renderHomePunctualityChart(avg);
+    }catch(e){
+      renderHomePunctualityChart(0);
+    }
   }
 
   function applyHomePunctualityVisual(){
     try{
-      var title = document.getElementById('homeWxPunctualityTitle');
-      if (title) title.textContent = 'Ponctualité';
-
-      var value = document.getElementById('homeWxPunctuality');
-      if (!value) return;
-      var raw = String(value.textContent || '').replace(',', '.');
-      var match = raw.match(/(\d+(?:\.\d+)?)/);
-      var num = match ? Number(match[1]) : NaN;
-      value.style.color = colorForHomePunctuality(num);
-      value.style.textShadow = Number.isFinite(num) ? '0 0 10px rgba(255,255,255,.08)' : 'none';
+      var title = document.getElementById('homePunctCardTitle');
+      if (title) title.textContent = 'Ponctualité 7 jours';
+      ensureHomePunctualityChart();
     }catch(e){}
   }
 
@@ -25430,16 +25297,16 @@ document.addEventListener('DOMContentLoaded', function(){
   if (typeof _orig === 'function' && !_orig.__lbHomePunctWrapped){
     window.updateHomePunctuality = function(pct, label){
       var out = _orig.apply(this, arguments);
-      applyHomePunctualityVisual();
+      renderHomePunctualityChart(pct);
       return out;
     };
     window.updateHomePunctuality.__lbHomePunctWrapped = true;
   }
 
-  document.addEventListener('DOMContentLoaded', applyHomePunctualityVisual);
-  window.addEventListener('load', applyHomePunctualityVisual);
-  setTimeout(applyHomePunctualityVisual, 250);
-  setTimeout(applyHomePunctualityVisual, 1200);
+  document.addEventListener('DOMContentLoaded', function(){ applyHomePunctualityVisual(); loadHomePunctualityChart(); });
+  window.addEventListener('load', loadHomePunctualityChart);
+  setTimeout(loadHomePunctualityChart, 250);
+  setTimeout(loadHomePunctualityChart, 1200);
 })();
 </script>
 
@@ -25600,6 +25467,168 @@ document.addEventListener('DOMContentLoaded', function(){
 .ber-metric,
 .ber-metric .value{ letter-spacing:.01em; }
 
+.live-wall-item-text,
+.live-wall-form input,
+.train-comments-item,
+#homeLiveWallInput,
+#trainDetailCommentsInput{
+  font-family: 'Orbitron', 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif !important;
+}
+
+.top-bar__social-link svg{
+  width: 19px !important;
+  height: 19px !important;
+}
+
+#favTrainsWidget{
+  background:
+    linear-gradient(180deg, rgba(126,247,255,.12), rgba(126,247,255,0) 16%),
+    linear-gradient(145deg, rgba(13,24,43,.98), rgba(8,15,28,.96)) !important;
+  border-color: rgba(126,247,255,.32) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(240,255,255,.10),
+    inset 0 0 30px rgba(0,240,255,.08),
+    0 20px 46px rgba(0,0,0,.34) !important;
+  padding: 16px !important;
+}
+#favTrainsWidget .fav-head{
+  margin-bottom: 5px !important;
+  padding-bottom: 2px !important;
+}
+#favTrainsWidget .fav-title{
+  font-size: .98rem !important;
+  letter-spacing: .015em !important;
+}
+#favTrainsWidget .fav-grid{
+  gap: 6px !important;
+}
+#favTrainsWidget .fav-card{
+  position: relative;
+  overflow: hidden;
+  padding: 10px 11px !important;
+  border-radius: 15px !important;
+  border-color: rgba(126,247,255,.24) !important;
+  background:
+    linear-gradient(180deg, rgba(126,247,255,.08), rgba(126,247,255,0) 38%),
+    linear-gradient(135deg, rgba(8,20,36,.96), rgba(5,12,24,.94)) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(240,255,255,.08),
+    inset 0 0 18px rgba(0,240,255,.05),
+    0 12px 24px rgba(0,0,0,.22) !important;
+}
+#favTrainsWidget .fav-card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+  background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0) 44%);
+}
+#favTrainsWidget .fav-card-head{ gap: 8px !important; }
+#favTrainsWidget .fav-tag{
+  font-size: .66rem !important;
+  padding: 3px 7px !important;
+}
+#favTrainsWidget .fav-train{
+  font-size: .9rem !important;
+  line-height: 1.05 !important;
+}
+#favTrainsWidget .fav-meta{
+  margin-top: 4px !important;
+  font-size: .79rem !important;
+  line-height: 1.12 !important;
+}
+#favTrainsWidget .fav-line{
+  margin-top: 4px !important;
+  font-size: .79rem !important;
+  line-height: 1.12 !important;
+}
+#favTrainsWidget .fav-times{
+  margin-top: 3px !important;
+  gap: 3px !important;
+  font-size: clamp(.8rem, .22vw + .78rem, .94rem) !important;
+  line-height: 1 !important;
+}
+#favTrainsWidget .fav-cause,
+#favTrainsWidget .fav-cause-inline{
+  margin: 4px 0 5px 0 !important;
+  padding: 4px 6px !important;
+  font-size: .69rem !important;
+}
+#favTrainsWidget .fav-details{
+  margin-top: 5px !important;
+  border-radius: 10px !important;
+}
+#favTrainsWidget .fav-details-summary{
+  padding: 5px 8px !important;
+  font-size: .71rem !important;
+}
+#favTrainsWidget .fav-box-head,
+#favTrainsWidget .fav-box-body{
+  padding: 6px 7px !important;
+}
+#favTrainsWidget .fav-box-body{
+  font-size: .8rem !important;
+  line-height: 1.14 !important;
+}
+#favTrainsWidget .fav-aff-summary{
+  gap: 4px !important;
+}
+#favTrainsWidget .fav-aff-top{
+  gap: 6px !important;
+}
+#favTrainsWidget .fav-aff-title{
+  font-size: .76rem !important;
+}
+#favTrainsWidget .fav-aff-meta{
+  font-size: .74rem !important;
+  gap: 6px !important;
+  line-height: 1.08 !important;
+}
+#favTrainsWidget .fav-aff-max{
+  font-size: .68rem !important;
+}
+#favTrainsWidget .fav-aff-schema{
+  gap: 6px !important;
+  min-height: 20px !important;
+}
+#favTrainsWidget .fav-aff-toggleline{
+  font-size: .72rem !important;
+  min-height: 0 !important;
+}
+#favTrainsWidget .fav-aff-body{
+  gap: 6px !important;
+}
+#favTrainsWidget .fav-aff-stops{
+  gap: 5px !important;
+}
+#favTrainsWidget .fav-aff-stop{
+  padding: 7px 8px !important;
+  border-radius: 10px !important;
+}
+#favTrainsWidget .fav-aff-stop-head{
+  gap: 8px !important;
+}
+#favTrainsWidget .fav-aff-stop-title{
+  gap: 4px !important;
+}
+#favTrainsWidget .fav-aff-stop-name{
+  font-size: .74rem !important;
+}
+#favTrainsWidget .fav-aff-stop-time{
+  font-size: .68rem !important;
+}
+#favTrainsWidget .fav-aff-stop-pct{
+  min-width: 34px !important;
+  font-size: .78rem !important;
+}
+#favTrainsWidget .fav-aff-stop-schema{
+  margin-top: 4px !important;
+}
+#favTrainsWidget .fav-aff-empty{
+  padding: 8px 9px !important;
+  font-size: .74rem !important;
+}
+
 #homeWelcomeLine,
 .home-welcome-line{
   font-size: clamp(1.08rem, 0.56vw + 0.96rem, 1.34rem) !important;
@@ -25732,6 +25761,49 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 .ber-context,
 .home-stats-item{ backface-visibility:hidden; transform:translateZ(0); }
 
+.home-fav-row{
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(126,247,255,.10), rgba(126,247,255,0) 42%),
+    linear-gradient(135deg, rgba(10,24,42,.94), rgba(7,16,30,.92)) !important;
+  border: 1px solid rgba(126,247,255,.24) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(220,255,255,.10),
+    inset 0 0 18px rgba(0,240,255,.05),
+    0 10px 22px rgba(0,0,0,.22) !important;
+}
+.home-fav-row::before{
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,0) 45%);
+  opacity: .85;
+}
+.home-fav-row:hover,
+.home-fav-row:focus-visible{
+  transform: translateY(-1px) scale(1.01) !important;
+  border-color: rgba(126,247,255,.42) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(235,255,255,.14),
+    inset 0 0 20px rgba(0,240,255,.08),
+    0 14px 28px rgba(0,0,0,.28),
+    0 0 0 1px rgba(126,247,255,.08) !important;
+}
+.home-fav-row:active{
+  transform: translateY(1px) scale(.985) !important;
+  box-shadow:
+    inset 0 2px 12px rgba(0,0,0,.30),
+    inset 0 0 16px rgba(0,240,255,.06),
+    0 6px 14px rgba(0,0,0,.20) !important;
+}
+.home-fav-row .fav-state-badge{
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.08),
+    0 0 14px rgba(0,240,255,.10);
+}
+
 .bottom-nav{
   height: auto !important;
   min-height: 0 !important;
@@ -25826,6 +25898,30 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   .home-welcome-line{ margin:-10px 0 0 !important; }
   .top-bar__logo-icon{ height:43.7px !important; }
   .top-bar__logo-text{ height:27.6px !important; max-width:48vw !important; }
+  .top-bar__social-link svg{ width: 17px !important; height: 17px !important; }
+  #favTrainsWidget{ padding: 11px !important; border-radius: 16px !important; }
+  #favTrainsWidget .fav-head{ margin-bottom: 4px !important; }
+  #favTrainsWidget .fav-title{ font-size: .88rem !important; }
+  #favTrainsWidget .fav-grid{ gap: 6px !important; }
+  #favTrainsWidget .fav-card{ padding: 9px 9px !important; border-radius: 13px !important; }
+  #favTrainsWidget .fav-tag{ font-size: .62rem !important; padding: 3px 6px !important; }
+  #favTrainsWidget .fav-train{ font-size: .82rem !important; }
+  #favTrainsWidget .fav-meta,
+  #favTrainsWidget .fav-line{ font-size: .72rem !important; line-height: 1.08 !important; }
+  #favTrainsWidget .fav-times{ font-size: .8rem !important; gap: 2px !important; }
+  #favTrainsWidget .fav-details-summary{ padding: 4px 7px !important; font-size: .68rem !important; }
+  #favTrainsWidget .fav-box-head,
+  #favTrainsWidget .fav-box-body{ padding: 5px 6px !important; }
+  #favTrainsWidget .fav-aff-title{ font-size: .72rem !important; }
+  #favTrainsWidget .fav-aff-meta{ font-size: .7rem !important; gap: 4px !important; }
+  #favTrainsWidget .fav-aff-max{ font-size: .64rem !important; }
+  #favTrainsWidget .fav-aff-body{ gap: 5px !important; }
+  #favTrainsWidget .fav-aff-stops{ gap: 4px !important; }
+  #favTrainsWidget .fav-aff-stop{ padding: 6px 7px !important; }
+  #favTrainsWidget .fav-aff-stop-name{ font-size: .7rem !important; }
+  #favTrainsWidget .fav-aff-stop-time{ font-size: .64rem !important; }
+  #favTrainsWidget .fav-aff-stop-pct{ min-width: 30px !important; font-size: .74rem !important; }
+  #favTrainsWidget .fav-aff-empty{ padding: 7px 8px !important; font-size: .7rem !important; }
   body{ padding-bottom: calc(var(--bottom-bar-height, 54px) + 8px) !important; }
   .bottom-nav{ padding:2px calc(env(safe-area-inset-right, 0px) + 8px) 0 calc(env(safe-area-inset-left, 0px) + 8px) !important; }
   .bottom-nav__items{ gap:2px !important; }
@@ -25852,6 +25948,29 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   .live-wall-form input,
   .live-wall-form button,
   .home-card .home-action{ font-size: clamp(.82rem, .22vw + .78rem, .9rem) !important; }
+
+  .home-fav-row{
+    gap: 7px !important;
+    padding: 7px 8px !important;
+  }
+  .home-fav-train{
+    font-size: clamp(.74rem, .18vw + .7rem, .82rem) !important;
+    letter-spacing: .02em !important;
+  }
+  .home-fav-meta{
+    font-size: clamp(.66rem, .14vw + .64rem, .74rem) !important;
+    white-space: normal !important;
+    overflow: visible !important;
+    text-overflow: clip !important;
+    line-height: 1.25 !important;
+  }
+  .home-fav-badge,
+  .home-fav-row .fav-state-badge,
+  .home-fav-pill{
+    font-size: clamp(.58rem, .12vw + .56rem, .66rem) !important;
+    padding: 4px 7px !important;
+    letter-spacing: .03em !important;
+  }
 }
 
 @media (prefers-reduced-motion: reduce){
@@ -25878,6 +25997,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 <script id="home-premium-harmonisation-final-script">
 (() => {
   const motionOk = !window.matchMedia || !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let refreshQueued = false;
   const selectors = [
     '#homeTrafficBadgeNorth', '#homeTrafficBadgeSouth', '#homeWxFromNow', '#homeWxToNow', '#homeWxPunctuality', '#homeWxRisk',
     '#homeBerLine1', '#homeBerContext', '#homeBerPunctuality', '#homeLiveWallCount', '#homeFavSlot', '#homeWelcomeLine'
@@ -25918,8 +26038,8 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   function syncLabels(){
     const punctualityTitle = document.getElementById('homeWxPunctualityTitle');
     const punctualityValue = document.getElementById('homeWxPunctuality');
-    if (punctualityTitle) punctualityTitle.textContent = 'Ponctualité (Hier)';
-    if (punctualityValue) punctualityValue.title = 'Ponctualité calculée sur les données d’hier';
+    if (punctualityTitle) punctualityTitle.textContent = 'Ponctualité 7 jours';
+    if (punctualityValue) punctualityValue.title = 'Moyenne de ponctualité calculée sur les 7 derniers jours clos';
     ['homeTrafficBadgeNorth','homeTrafficBadgeSouth'].forEach((id) => {
       const el = document.getElementById(id);
       if (el) el.title = 'Mise à jour automatique via GTFS temps réel';
@@ -25939,12 +26059,21 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     });
   }
 
+  function scheduleRefresh(){
+    if (refreshQueued) return;
+    refreshQueued = true;
+    requestAnimationFrame(() => {
+      refreshQueued = false;
+      refreshVisualState();
+    });
+  }
+
   function wrap(name){
     const original = window[name];
     if (typeof original !== 'function' || original.__lbPremiumWrapped) return;
     const wrapped = function(){
       const result = original.apply(this, arguments);
-      Promise.resolve(result).finally(() => requestAnimationFrame(refreshVisualState));
+      Promise.resolve(result).finally(scheduleRefresh);
       return result;
     };
     wrapped.__lbPremiumWrapped = true;
@@ -25954,8 +26083,8 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   function installObserver(){
     const root = document.querySelector('.home-dashboard') || document.getElementById('home');
     if (!root || root.__lbPremiumObserver) return;
-    const observer = new MutationObserver(() => requestAnimationFrame(refreshVisualState));
-    observer.observe(root, { subtree:true, childList:true, characterData:true });
+    const observer = new MutationObserver(scheduleRefresh);
+    observer.observe(root, { subtree:true, childList:true, characterData:false });
     root.__lbPremiumObserver = observer;
   }
 
@@ -25969,9 +26098,127 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 
   document.addEventListener('DOMContentLoaded', install);
   window.addEventListener('load', install);
-  window.addEventListener('gtfsrt:loaded', () => requestAnimationFrame(refreshVisualState));
+  window.addEventListener('gtfsrt:loaded', scheduleRefresh);
 })();
 </script>
+
+<style id="home-mobile-schema-force">
+@media (max-width: 700px){
+  .home-dashboard{
+    display:grid !important;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) !important;
+    grid-template-areas:
+      "welcome welcome"
+      "traffic weather"
+      "traffic punct"
+      "comments comments" !important;
+    gap: 10px !important;
+    align-items: start !important;
+  }
+  #homeWelcomeLine{
+    grid-area: welcome !important;
+  }
+  .home-card[aria-label="Info trafic"]{
+    grid-area: traffic !important;
+    grid-column: 1 !important;
+    grid-row: 2 / 4 !important;
+    align-self: stretch !important;
+  }
+  .home-card[aria-label="Météo sur votre ligne"]{
+    grid-area: weather !important;
+    grid-column: 2 !important;
+    grid-row: 2 !important;
+    align-self: start !important;
+    min-height: 82px !important;
+    padding-top: 8px !important;
+    padding-bottom: 7px !important;
+  }
+  .home-card[aria-label="Météo sur votre ligne"] .wx-now{
+    font-size: .82rem !important;
+    line-height: .92 !important;
+  }
+  .home-card[aria-label="Météo sur votre ligne"] .wx-now .wx-temp{
+    font-size: .84rem !important;
+    line-height: .9 !important;
+  }
+  .home-card[aria-label="Météo sur votre ligne"] .wx-now .wx-icon{
+    font-size: .92rem !important;
+    line-height: .9 !important;
+  }
+  .home-punct-card{
+    grid-area: punct !important;
+    grid-column: 2 !important;
+    grid-row: 3 !important;
+    align-self: start !important;
+    min-height: 82px !important;
+    padding-top: 8px !important;
+    padding-bottom: 7px !important;
+  }
+  #homePunctualityChartHost.home-punct-chart-host{
+    min-height: 56px !important;
+  }
+  .home-punct-chart-wrap{
+    width: 58px !important;
+    height: 58px !important;
+  }
+  .live-wall-card--home,
+  .home-card[aria-label="Mur de commentaires"]{
+    grid-area: comments !important;
+    grid-column: 1 / -1 !important;
+    grid-row: 4 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    justify-self: stretch !important;
+    align-self: start !important;
+    margin: 0 !important;
+    padding-bottom: 8px !important;
+  }
+  .home-card[aria-label="Mur de commentaires"] .live-wall-feed--home{
+    max-height: 96px !important;
+    margin-bottom: 2px !important;
+  }
+  .home-card[aria-label="Mur de commentaires"] .live-wall-form{
+    margin-top: 2px !important;
+  }
+  .home-card[aria-label="Mur de commentaires"] .live-wall-form input,
+  .home-card[aria-label="Mur de commentaires"] .live-wall-form button{
+    height: 30px !important;
+    min-height: 30px !important;
+  }
+  .home-card[aria-label="Mes Bétaillères favorites"]{
+    padding-top: 9px !important;
+    padding-bottom: 8px !important;
+  }
+  .home-card[aria-label="Mes Bétaillères favorites"] h2{
+    margin-bottom: 5px !important;
+  }
+  .home-fav-preview{
+    gap: 5px !important;
+    margin-top: 4px !important;
+  }
+  .home-fav-row{
+    padding: 5px 7px !important;
+    gap: 6px !important;
+    border-radius: 12px !important;
+  }
+  .home-fav-train{
+    font-size: .7rem !important;
+  }
+  .home-fav-meta{
+    font-size: .62rem !important;
+    line-height: 1.12 !important;
+  }
+  .home-fav-badge,
+  .home-fav-row .fav-state-badge,
+  .home-fav-pill{
+    font-size: .54rem !important;
+    padding: 3px 6px !important;
+  }
+  .home-card[forwarding="ber"]{
+    display: none !important;
+  }
+}
+</style>
 
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Improve the mobile home layout and visual harmony for the dashboard and favorites widget. 
- Surface a compact 7‑day punctuality summary on the home page and reuse public stats when possible. 
- Make the live comment feed and admin delete action more accessible and robust. 

### Description
- Adjusted mobile CSS grid/areas and card sizing/spacing to harmonize the home dashboard and favorites preview, including many style refinements for `.home-dashboard`, `.home-card`, `.home-fav-row` and `#favTrainsWidget`. 
- Added a new punctuality card (`<article class="home-card home-punct-card" aria-label="Ponctualité sur 7 jours">`) and host `#homePunctualityChartHost` to display a doughnut chart. 
- Implemented client logic to compute/load cached 30‑day/7‑day punctuality averages: `ensure30DayPunctuality`, cache helpers (`read30DayPunctualityCache`, `write30DayPunctualityCache`) and fallbacks that try local `loadRangeAPI/loadRawRangeAPI` before calling public endpoints. 
- Added chart rendering and visual logic in `home-punctuality-visual-fix` script that creates/updates a Chart.js doughnut and styling helpers (`homeColorForPunctuality`, `renderHomePunctualityChart`). 
- Reworked comments flow: `loadMessages` now sorts messages by timestamp, comment render markup changed to an inline accessible delete control (❌) for admins, `deleteComment` now calls the full comments API URL with `credentials:'include'`, and the feed received a `keydown` handler so delete controls are keyboard-operable. 
- Removed the train-detail comments block from the train detail panel and adjusted related bindings (`bindCommentForms`) to handle the new markup/keyboard flow. 
- Minor JS polishing: rename/relocate globals (`window.__LB_LAST_30D_PCT`, `window.__LB_LAST_30D_KEY`), improve refresh scheduling in the premium harmonisation script, and several textual/format tweaks. 

### Testing
- No automated test suite was added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11e7148c0832da5d0d974ce1c196a)