### PR TITLE
UI: add home quick-presets, compact favorites redesign and dual punctuality donuts

### DIFF
--- a/index31.html
+++ b/index31.html
@@ -4838,6 +4838,19 @@ body.modal-open{ overflow:hidden; }
 .lb-auth-switch button{
   width: min(240px, 100%);
 }
+#lbAuthModal .lb-auth-actions{
+  align-items:center !important;
+}
+#lbAuthModal .lb-auth-actions .auth-button{
+  margin-inline:auto !important;
+  text-align:center !important;
+}
+#lbAuthModal .lb-auth-actions #lbBtnSubmit,
+#lbAuthModal .lb-auth-actions #lbBtnPrefs{
+  width:min(220px,100%) !important;
+  text-align:center !important;
+  justify-content:center !important;
+}
 	  
 .lb-auth-actions #lbBtnLogout{
   margin-inline: auto;
@@ -8674,9 +8687,9 @@ body{
       <span class="bottom-nav__icon" aria-hidden="true"><img class="bottom-nav__icon-img" src="/ber_icons_pack/carte.svg" alt="" loading="lazy"></span>
       <span class="bottom-nav__label">Carte</span>
     </a>
-    <a class="bottom-nav__item" href="#search">
+    <a class="bottom-nav__item bottom-nav__item--search" href="#search">
       <span class="bottom-nav__icon" aria-hidden="true"><img class="bottom-nav__icon-img" src="/ber_icons_pack/tableau.svg" alt="" loading="lazy"></span>
-      <span class="bottom-nav__label">Tableau</span>
+      <span class="bottom-nav__label">Recherche</span>
     </a>
     <a class="bottom-nav__item" href="#favoris">
       <span class="bottom-nav__icon" aria-hidden="true"><img class="bottom-nav__icon-img" src="/ber_icons_pack/favoris.svg" alt="" loading="lazy"></span>
@@ -8815,6 +8828,11 @@ body{
           <span class="traffic-split-line" id="homeTrafficLineSouth">Nancy - Metz</span>
           <span class="traffic-pill traffic-pill--loading" id="homeTrafficBadgeSouth">Chargement…</span>
         </div>
+      </div>
+      <div class="home-quick-presets" aria-label="Listes prédéfinies">
+        <div class="home-quick-presets__label">Tableaux rapides</div>
+        <button type="button" class="home-quick-presets__btn" data-home-preset-kind="AM">Matin</button>
+        <button type="button" class="home-quick-presets__btn" data-home-preset-kind="PM">Soir</button>
       </div>
     </article>
 
@@ -9065,9 +9083,7 @@ body{
 
 <!-- Widget Favoris Matin / Soir (visible si connecté) -->
 <section id="favTrainsWidget" class="fav-widget app-page" data-page="favoris" style="display:none; position:relative; z-index:2;">
-  <div class="fav-head">
-    <div class="fav-title">⭐ Mes bétaillères favorites</div>
-  </div>
+  <div class="fav-title">⭐ Mes bétaillères favorites</div>
 
   <div class="fav-grid">
     <article class="fav-card" id="favCardAM">
@@ -16002,6 +16018,21 @@ $('#btnProposer').off('click').on('click', proposerTrainsOD);
     if (!kind) return;
     applyRapidPreset(kind, { trigger: this, openModal: true });
   });
+  $(document).off('click.homePreset', '.home-quick-presets__btn[data-home-preset-kind]').on('click.homePreset', '.home-quick-presets__btn[data-home-preset-kind]', function(){
+    const kind = this.dataset.homePresetKind;
+    if (!kind) return;
+    try{
+      const modeSelect = document.getElementById('tableauModeSelect');
+      if (modeSelect){
+        modeSelect.value = 'quick';
+        modeSelect.dispatchEvent(new Event('change', { bubbles:true }));
+      }
+      location.hash = '#search';
+      applyRapidPreset(kind, { trigger: this, openModal: true });
+    }catch(e){
+      console.warn('Preset accueil impossible à ouvrir', e);
+    }
+  });
 
   (function($){
   const initFrom = $('#timeFrom').val() || '06:00';
@@ -20388,18 +20419,20 @@ function scheduleWeatherAfterTableSettled(){
     try{
       const wraps = document.querySelectorAll('.fav-aff-schema');
       wraps.forEach(w=>{
-        const train = w.querySelector('.affls-train');
+        const train = w.querySelector('.affls-rame, .affls-train');
         if(!train) return;
+        const baseScale = 0.80; // réduction visuelle globale demandée sur Favoris
         // reset
-        train.style.transform = 'scale(1)';
+        train.style.transform = `scale(${baseScale})`;
         w.classList.add('is-fit');
         // mesurer
         const cw = w.clientWidth || 0;
         const tw = train.scrollWidth || train.getBoundingClientRect().width || 0;
+        let s = baseScale;
         if(cw>0 && tw>0 && tw>cw){
-          const s = Math.max(0.60, Math.min(1, cw / tw));
-          train.style.transform = `scale(${s.toFixed(3)})`;
+          s = Math.max(0.48, Math.min(baseScale, (cw / tw) * baseScale));
         }
+        train.style.transform = `scale(${s.toFixed(3)})`;
       });
     }catch(e){}
   }
@@ -25545,18 +25578,19 @@ async function loadAffluenceDate(dateStr){
   display:flex !important;
   align-items:center !important;
   justify-content:center !important;
+  gap: 8px !important;
   min-height: 96px !important;
   margin-top: 0 !important;
 }
 .home-punct-chart-wrap{
-  width: 104px;
-  height: 104px;
+  width: 56px;
+  height: 56px;
   margin: 0 auto;
 }
 @media (max-width: 768px){
   .home-punct-chart-wrap{
-    width: 92px;
-    height: 92px;
+    width: 52px;
+    height: 52px;
   }
 }
 @media (max-width: 700px){
@@ -25572,16 +25606,18 @@ async function loadAffluenceDate(dateStr){
   }
   #homePunctualityChartHost.home-punct-chart-host{
     min-height: 68px !important;
+    gap: 6px !important;
   }
   .home-punct-chart-wrap{
-    width: 72px;
-    height: 72px;
+    width: 48px;
+    height: 48px;
   }
 }
 </style>
 <script id="home-punctuality-visual-fix-script">
 (function(){
-  var homePunctChart = null;
+  var homePunctChart7d = null;
+  var homePunctChartYesterday = null;
   var HOME_RING_REST_COLOR = 'rgba(125,217,255,0.18)';
 
   function homeFmtPctShort(x){
@@ -25601,43 +25637,46 @@ async function loadAffluenceDate(dateStr){
     return '#f97316';
   }
 
+  function makeDonutChart(canvas){
+    if (!canvas || typeof Chart !== 'function') return null;
+    return new Chart(canvas, {
+      type: 'doughnut',
+      data: {
+        labels: ['Ponctualité', 'Reste'],
+        datasets: [{
+          data: [0, 100],
+          backgroundColor: ['#22c55e', HOME_RING_REST_COLOR],
+          borderWidth: 0,
+          cutout: '74%'
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: false },
+          centerText: { lineGap: 12, lines: [] }
+        }
+      }
+    });
+  }
+
   function ensureHomePunctualityChart(){
     var host = document.getElementById('homePunctualityChartHost');
     if (!host) return null;
     host.classList.add('home-punct-chart-host');
-    if (!document.getElementById('homeWxPunctualityChart')){
-      host.innerHTML = '<div class="home-punct-chart-wrap"><canvas id="homeWxPunctualityChart"></canvas></div>';
+    if (!document.getElementById('homeWxPunctualityChart7d') || !document.getElementById('homeWxPunctualityChartYesterday')){
+      host.innerHTML =
+        '<div class="home-punct-chart-wrap"><canvas id="homeWxPunctualityChart7d"></canvas></div>' +
+        '<div class="home-punct-chart-wrap"><canvas id="homeWxPunctualityChartYesterday"></canvas></div>';
     }
-    var canvas = document.getElementById('homeWxPunctualityChart');
-    if (!canvas || typeof Chart !== 'function') return null;
-    if (!homePunctChart){
-      homePunctChart = new Chart(canvas, {
-        type: 'doughnut',
-        data: {
-          labels: ['Ponctualité', 'Reste'],
-          datasets: [{
-            data: [0, 100],
-            backgroundColor: ['#22c55e', HOME_RING_REST_COLOR],
-            borderWidth: 0,
-            cutout: '74%'
-          }]
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: {
-            legend: { display: false },
-            tooltip: { enabled: false },
-            centerText: { lineGap: 12, lines: [] }
-          }
-        }
-      });
-    }
-    return homePunctChart;
+    if (!homePunctChart7d) homePunctChart7d = makeDonutChart(document.getElementById('homeWxPunctualityChart7d'));
+    if (!homePunctChartYesterday) homePunctChartYesterday = makeDonutChart(document.getElementById('homeWxPunctualityChartYesterday'));
+    return { seven: homePunctChart7d, yesterday: homePunctChartYesterday };
   }
 
-  function renderHomePunctualityChart(pct){
-    var chart = ensureHomePunctualityChart();
+  function setDonutValue(chart, pct){
     if (!chart) return;
     var value = Number(pct);
     if (!Number.isFinite(value)) value = 0;
@@ -25649,6 +25688,13 @@ async function loadAffluenceDate(dateStr){
       { text: homeFmtPctShort(value), font: '900 16px Orbitron, system-ui', color: '#e8fbff' }
     ];
     chart.update();
+  }
+
+  function renderHomePunctualityCharts(p7, py){
+    var charts = ensureHomePunctualityChart();
+    if (!charts) return;
+    setDonutValue(charts.seven, p7);
+    setDonutValue(charts.yesterday, py);
   }
 
   async function loadHomePunctualityChart(){
@@ -25670,9 +25716,10 @@ async function loadAffluenceDate(dateStr){
       var values = series.map(function(x){ return 100 - Number(x && x.pct_not_on_time || 0); }).filter(function(v){ return Number.isFinite(v); });
       if (!values.length) throw new Error('Aucune ponctualité 7 jours');
       var avg = values.reduce(function(a, b){ return a + b; }, 0) / values.length;
-      renderHomePunctualityChart(avg);
+      var last = values[values.length - 1];
+      renderHomePunctualityCharts(avg, Number.isFinite(last) ? last : avg);
     }catch(e){
-      renderHomePunctualityChart(0);
+      renderHomePunctualityCharts(0, 0);
     }
   }
 
@@ -25688,7 +25735,7 @@ async function loadAffluenceDate(dateStr){
   if (typeof _orig === 'function' && !_orig.__lbHomePunctWrapped){
     window.updateHomePunctuality = function(pct, label){
       var out = _orig.apply(this, arguments);
-      renderHomePunctualityChart(pct);
+      renderHomePunctualityCharts(pct, pct);
       return out;
     };
     window.updateHomePunctuality.__lbHomePunctWrapped = true;
@@ -25872,39 +25919,44 @@ async function loadAffluenceDate(dateStr){
 }
 
 #favTrainsWidget{
-  background:
-    linear-gradient(180deg, rgba(126,247,255,.12), rgba(126,247,255,0) 16%),
-    linear-gradient(145deg, rgba(13,24,43,.98), rgba(8,15,28,.96)) !important;
-  border-color: rgba(126,247,255,.32) !important;
-  box-shadow:
-    inset 0 1px 0 rgba(240,255,255,.10),
-    inset 0 0 30px rgba(0,240,255,.08),
-    0 20px 46px rgba(0,0,0,.34) !important;
-  padding: 16px !important;
-}
-#favTrainsWidget .fav-head{
-  margin-bottom: 5px !important;
-  padding-bottom: 2px !important;
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  margin: 8px auto 10px auto !important;
 }
 #favTrainsWidget .fav-title{
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  margin: 0 0 6px 2px !important;
+  padding: 6px 11px !important;
+  border-radius: 999px !important;
+  border: 1px solid rgba(126,247,255,.35) !important;
+  background:
+    linear-gradient(180deg, rgba(126,247,255,.14), rgba(126,247,255,.02) 74%),
+    linear-gradient(135deg, rgba(9,22,38,.96), rgba(7,15,28,.92)) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(240,255,255,.10),
+    0 8px 16px rgba(0,0,0,.22) !important;
   font-size: .98rem !important;
   letter-spacing: .015em !important;
 }
 #favTrainsWidget .fav-grid{
-  gap: 6px !important;
+  gap: 5px !important;
 }
 #favTrainsWidget .fav-card{
   position: relative;
   overflow: hidden;
-  padding: 10px 11px !important;
+  padding: 8px 9px !important;
   border-radius: 15px !important;
-  border-color: rgba(126,247,255,.24) !important;
+  border: 1px solid rgba(126,247,255,.26) !important;
   background:
-    linear-gradient(180deg, rgba(126,247,255,.08), rgba(126,247,255,0) 38%),
+    linear-gradient(180deg, rgba(126,247,255,.09), rgba(126,247,255,0) 38%),
     linear-gradient(135deg, rgba(8,20,36,.96), rgba(5,12,24,.94)) !important;
   box-shadow:
-    inset 0 1px 0 rgba(240,255,255,.08),
-    inset 0 0 18px rgba(0,240,255,.05),
+    inset 0 1px 0 rgba(240,255,255,.09),
+    inset 0 0 18px rgba(0,240,255,.055),
     0 12px 24px rgba(0,0,0,.22) !important;
 }
 #favTrainsWidget .fav-card::before{
@@ -25914,110 +25966,148 @@ async function loadAffluenceDate(dateStr){
   pointer-events:none;
   background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0) 44%);
 }
-#favTrainsWidget .fav-card-head{ gap: 8px !important; }
+#favTrainsWidget .fav-card-head{ gap: 6px !important; }
 #favTrainsWidget .fav-tag{
-  font-size: .66rem !important;
-  padding: 3px 7px !important;
+  font-size: .62rem !important;
+  padding: 2px 6px !important;
 }
 #favTrainsWidget .fav-train{
-  font-size: .9rem !important;
+  font-size: .84rem !important;
   line-height: 1.05 !important;
 }
 #favTrainsWidget .fav-meta{
-  margin-top: 4px !important;
-  font-size: .79rem !important;
-  line-height: 1.12 !important;
+  margin-top: 2px !important;
+  font-size: .72rem !important;
+  line-height: 1.04 !important;
 }
 #favTrainsWidget .fav-line{
-  margin-top: 4px !important;
-  font-size: .79rem !important;
-  line-height: 1.12 !important;
+  margin-top: 2px !important;
+  font-size: .72rem !important;
+  line-height: 1.04 !important;
 }
 #favTrainsWidget .fav-times{
-  margin-top: 3px !important;
-  gap: 3px !important;
-  font-size: clamp(.8rem, .22vw + .78rem, .94rem) !important;
+  margin-top: 2px !important;
+  gap: 2px !important;
+  font-size: clamp(.74rem, .18vw + .72rem, .86rem) !important;
   line-height: 1 !important;
 }
 #favTrainsWidget .fav-cause,
 #favTrainsWidget .fav-cause-inline{
-  margin: 4px 0 5px 0 !important;
-  padding: 4px 6px !important;
-  font-size: .69rem !important;
+  margin: 2px 0 3px 0 !important;
+  padding: 3px 5px !important;
+  font-size: .64rem !important;
 }
 #favTrainsWidget .fav-details{
-  margin-top: 5px !important;
-  border-radius: 10px !important;
+  margin-top: 3px !important;
+  border-radius: 8px !important;
 }
 #favTrainsWidget .fav-details-summary{
-  padding: 5px 8px !important;
-  font-size: .71rem !important;
+  padding: 3px 6px !important;
+  font-size: .65rem !important;
 }
 #favTrainsWidget .fav-box-head,
 #favTrainsWidget .fav-box-body{
-  padding: 6px 7px !important;
+  padding: 4px 5px !important;
 }
 #favTrainsWidget .fav-box-body{
-  font-size: .8rem !important;
-  line-height: 1.14 !important;
-}
-#favTrainsWidget .fav-aff-summary{
-  gap: 4px !important;
-}
-#favTrainsWidget .fav-aff-top{
-  gap: 6px !important;
-}
-#favTrainsWidget .fav-aff-title{
-  font-size: .76rem !important;
-}
-#favTrainsWidget .fav-aff-meta{
   font-size: .74rem !important;
-  gap: 6px !important;
   line-height: 1.08 !important;
 }
-#favTrainsWidget .fav-aff-max{
+#favTrainsWidget .fav-aff-summary{
+  gap: 3px !important;
+}
+#favTrainsWidget .fav-aff-top{
+  gap: 4px !important;
+}
+#favTrainsWidget .fav-aff-title{
   font-size: .68rem !important;
 }
+#favTrainsWidget .fav-aff-meta{
+  font-size: .66rem !important;
+  gap: 4px !important;
+  line-height: 1.02 !important;
+}
+#favTrainsWidget .fav-aff-max{
+  font-size: .6rem !important;
+}
 #favTrainsWidget .fav-aff-schema{
-  gap: 6px !important;
-  min-height: 20px !important;
+  gap: 4px !important;
+  min-height: 16px !important;
 }
 #favTrainsWidget .fav-aff-toggleline{
   font-size: .72rem !important;
   min-height: 0 !important;
 }
 #favTrainsWidget .fav-aff-body{
-  gap: 6px !important;
-}
-#favTrainsWidget .fav-aff-stops{
-  gap: 5px !important;
-}
-#favTrainsWidget .fav-aff-stop{
-  padding: 7px 8px !important;
-  border-radius: 10px !important;
-}
-#favTrainsWidget .fav-aff-stop-head{
-  gap: 8px !important;
-}
-#favTrainsWidget .fav-aff-stop-title{
   gap: 4px !important;
 }
-#favTrainsWidget .fav-aff-stop-name{
-  font-size: .74rem !important;
+#favTrainsWidget .fav-aff-stops{
+  gap: 3px !important;
 }
-#favTrainsWidget .fav-aff-stop-time{
+#favTrainsWidget .fav-aff-stop{
+  padding: 4px 5px !important;
+  border-radius: 10px !important;
+  gap: 1px !important;
+}
+#favTrainsWidget .fav-aff-stop-head{
+  gap: 4px !important;
+}
+#favTrainsWidget .fav-aff-stop-title{
+  gap: 1px !important;
+}
+#favTrainsWidget .fav-aff-stop-name{
   font-size: .68rem !important;
 }
+#favTrainsWidget .fav-aff-stop-time{
+  font-size: .62rem !important;
+}
 #favTrainsWidget .fav-aff-stop-pct{
-  min-width: 34px !important;
-  font-size: .78rem !important;
+  min-width: 28px !important;
+  font-size: .7rem !important;
 }
 #favTrainsWidget .fav-aff-stop-schema{
-  margin-top: 4px !important;
+  margin-top: 0 !important;
+}
+#favTrainsWidget .fav-aff-stop-schema .affls-rame{
+  display:flex !important;
+  justify-content:flex-end !important;
+  width:100% !important;
+  max-width:100% !important;
+  margin-left:0 !important;
+  padding-top:9px !important;
+  gap:3px !important;
+  overflow:hidden !important;
+}
+#favTrainsWidget .fav-aff-stop-schema .affls-unit{
+  width:88px !important;
+  height:14px !important;
+  border-width:2px !important;
+}
+#favTrainsWidget .fav-aff-stop-schema .affls-unit > span{
+  border-right-width:2px !important;
+}
+#favTrainsWidget .fav-aff-stop-schema .affls-dot{
+  width:6px !important;
+  height:6px !important;
+  border-width:2px !important;
+}
+#favTrainsWidget .fav-aff-stop-schema .affls-pct{
+  top:-11px !important;
+  font-size:6px !important;
+  padding:0 3px !important;
+}
+#favTrainsWidget .fav-aff-stop-schema .aff-arrow{
+  font-size:8px !important;
+}
+#favTrainsWidget .fav-aff-schema .affls-rame,
+#favTrainsWidget .fav-aff-schema .affls-train,
+#favTrainsWidget .fav-aff-stop-schema .affls-rame,
+#favTrainsWidget .fav-aff-stop-schema .affls-train{
+  transform-origin: right center !important;
 }
 #favTrainsWidget .fav-aff-empty{
-  padding: 8px 9px !important;
-  font-size: .74rem !important;
+  padding: 6px 7px !important;
+  font-size: .66rem !important;
 }
 
 #homeWelcomeLine,
@@ -26122,6 +26212,85 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 .live-wall-feed,
 .home-stats-panel,
 .ber-lines{ gap: 10px !important; }
+.home-quick-presets{
+  margin-top: 2px !important;
+  padding: 1px 2px !important;
+  border-radius: 10px !important;
+  border: 1px solid transparent !important;
+  background: rgba(4,20,34,.62) !important;
+  display: grid !important;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  gap: 3px !important;
+  width: 100% !important;
+  box-sizing: border-box !important;
+  align-items: center !important;
+  box-shadow: none !important;
+}
+.home-quick-presets__label{
+  grid-column: 1 / -1;
+  font-size: .48rem !important;
+  letter-spacing: .08em !important;
+  text-transform: uppercase;
+  color: rgba(174,245,255,.9) !important;
+  margin: 0 !important;
+  line-height: 1 !important;
+  text-align: center !important;
+}
+.home-quick-presets__btn{
+  min-height: 22px !important;
+  width: 100% !important;
+  min-width: 0 !important;
+  max-width: 100% !important;
+  display: block !important;
+  border-radius: 999px !important;
+  border: 1px solid rgba(0,240,255,.46) !important;
+  background: linear-gradient(135deg, rgba(0,173,255,.36), rgba(0,240,255,.18)) !important;
+  color: #dffbff !important;
+  font-family: 'Orbitron', sans-serif !important;
+  font-size: .67rem !important;
+  font-weight: 800 !important;
+  line-height: 1 !important;
+  padding: 1px 1px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  text-align: center !important;
+  margin: 0 !important;
+  box-sizing: border-box !important;
+  box-shadow: none !important;
+  transform: none !important;
+  letter-spacing: 0 !important;
+}
+.home-quick-presets__btn:hover,
+.home-quick-presets__btn:focus-visible,
+.home-quick-presets__btn:active{
+  box-shadow: none !important;
+  transform: none !important;
+  filter: brightness(1.02);
+}
+.home-card[aria-label="Info trafic"]{
+  padding: 10px 10px 8px !important;
+}
+.home-card[aria-label="Info trafic"] h2{
+  margin-bottom: 6px !important;
+}
+.home-card[aria-label="Info trafic"] .traffic-split{
+  gap: 6px !important;
+}
+.home-card[aria-label="Info trafic"] .traffic-split-row{
+  padding: 5px 7px !important;
+  border-radius: 10px !important;
+  gap: 6px !important;
+}
+.home-card[aria-label="Info trafic"] .traffic-split-line{
+  font-size: .84rem !important;
+  line-height: 1.02 !important;
+}
+.home-card[aria-label="Info trafic"] .traffic-pill{
+  min-width: 0 !important;
+  font-size: .6rem !important;
+  padding: 2px 7px !important;
+}
 .traffic-split-row,
 .wx-station,
 .home-fav-row,
@@ -26229,7 +26398,14 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   line-height:1.08 !important;
   text-align:center !important;
   text-wrap:balance;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   transform:translateX(0) !important;
+}
+.bottom-nav__item--search .bottom-nav__label{
+  font-size: .58rem !important;
+  letter-spacing: 0 !important;
 }
 .bottom-nav__item:hover,
 .bottom-nav__item:focus-visible{
@@ -26293,29 +26469,84 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   .top-bar__logo-icon{ height:43.7px !important; }
   .top-bar__logo-text{ height:27.6px !important; max-width:48vw !important; }
   .top-bar__social-link svg{ width: 17px !important; height: 17px !important; }
-  #favTrainsWidget{ padding: 11px !important; border-radius: 16px !important; }
-  #favTrainsWidget .fav-head{ margin-bottom: 4px !important; }
-  #favTrainsWidget .fav-title{ font-size: .88rem !important; }
-  #favTrainsWidget .fav-grid{ gap: 6px !important; }
-  #favTrainsWidget .fav-card{ padding: 9px 9px !important; border-radius: 13px !important; }
-  #favTrainsWidget .fav-tag{ font-size: .62rem !important; padding: 3px 6px !important; }
-  #favTrainsWidget .fav-train{ font-size: .82rem !important; }
+  .home-quick-presets{
+    margin-top: 3px !important;
+    padding: 1px 1px !important;
+    gap: 2px !important;
+    border-radius: 9px !important;
+  }
+  .home-quick-presets__label{
+    font-size: .44rem !important;
+    letter-spacing: .07em !important;
+  }
+  .home-quick-presets__btn{
+    min-height: 20px !important;
+    font-size: .60rem !important;
+    padding: 1px 1px !important;
+  }
+  .home-card[aria-label="Info trafic"]{
+    padding: 8px 8px 6px !important;
+    align-self: stretch !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: space-between !important;
+  }
+  .home-card[aria-label="Info trafic"] h2{
+    margin-bottom: 5px !important;
+  }
+  .home-card[aria-label="Info trafic"] .traffic-split{
+    gap: 4px !important;
+  }
+  .home-card[aria-label="Info trafic"] .traffic-split-row{
+    padding: 4px 6px !important;
+    gap: 5px !important;
+  }
+  .home-card[aria-label="Info trafic"] .traffic-split-line{
+    font-size: .78rem !important;
+  }
+  .home-card[aria-label="Info trafic"] .traffic-pill{
+    font-size: .56rem !important;
+    padding: 2px 6px !important;
+  }
+  .bottom-nav__item--search .bottom-nav__label{
+    font-size: .52rem !important;
+  }
+  #favTrainsWidget{ padding: 0 !important; margin: 6px auto 8px auto !important; }
+  #favTrainsWidget .fav-title{
+    font-size: .82rem !important;
+    margin: 0 0 5px 1px !important;
+    padding: 4px 9px !important;
+  }
+  #favTrainsWidget .fav-grid{ gap: 3px !important; }
+  #favTrainsWidget .fav-card{ padding: 7px 8px !important; border-radius: 12px !important; }
+  #favTrainsWidget .fav-tag{ font-size: .58rem !important; padding: 2px 5px !important; }
+  #favTrainsWidget .fav-train{ font-size: .78rem !important; }
   #favTrainsWidget .fav-meta,
-  #favTrainsWidget .fav-line{ font-size: .72rem !important; line-height: 1.08 !important; }
-  #favTrainsWidget .fav-times{ font-size: .8rem !important; gap: 2px !important; }
-  #favTrainsWidget .fav-details-summary{ padding: 4px 7px !important; font-size: .68rem !important; }
+  #favTrainsWidget .fav-line{ font-size: .68rem !important; line-height: 1.02 !important; }
+  #favTrainsWidget .fav-times{ font-size: .74rem !important; gap: 1px !important; }
+  #favTrainsWidget .fav-details-summary{ padding: 3px 6px !important; font-size: .62rem !important; }
   #favTrainsWidget .fav-box-head,
-  #favTrainsWidget .fav-box-body{ padding: 5px 6px !important; }
-  #favTrainsWidget .fav-aff-title{ font-size: .72rem !important; }
-  #favTrainsWidget .fav-aff-meta{ font-size: .7rem !important; gap: 4px !important; }
-  #favTrainsWidget .fav-aff-max{ font-size: .64rem !important; }
-  #favTrainsWidget .fav-aff-body{ gap: 5px !important; }
-  #favTrainsWidget .fav-aff-stops{ gap: 4px !important; }
-  #favTrainsWidget .fav-aff-stop{ padding: 6px 7px !important; }
-  #favTrainsWidget .fav-aff-stop-name{ font-size: .7rem !important; }
-  #favTrainsWidget .fav-aff-stop-time{ font-size: .64rem !important; }
-  #favTrainsWidget .fav-aff-stop-pct{ min-width: 30px !important; font-size: .74rem !important; }
-  #favTrainsWidget .fav-aff-empty{ padding: 7px 8px !important; font-size: .7rem !important; }
+  #favTrainsWidget .fav-box-body{ padding: 4px 5px !important; }
+  #favTrainsWidget .fav-aff-title{ font-size: .64rem !important; }
+  #favTrainsWidget .fav-aff-meta{ font-size: .62rem !important; gap: 3px !important; }
+  #favTrainsWidget .fav-aff-max{ font-size: .58rem !important; }
+  #favTrainsWidget .fav-aff-body{ gap: 3px !important; }
+  #favTrainsWidget .fav-aff-stops{ gap: 2px !important; }
+  #favTrainsWidget .fav-aff-stop{ padding: 3px 4px !important; gap: 1px !important; }
+  #favTrainsWidget .fav-aff-stop-name{ font-size: .64rem !important; }
+  #favTrainsWidget .fav-aff-stop-time{ font-size: .58rem !important; }
+  #favTrainsWidget .fav-aff-stop-pct{ min-width: 24px !important; font-size: .64rem !important; }
+  #favTrainsWidget .fav-aff-stop-schema .affls-rame{ padding-top: 8px !important; gap: 2px !important; }
+  #favTrainsWidget .fav-aff-stop-schema .affls-unit{ width: 80px !important; height: 12px !important; }
+  #favTrainsWidget .fav-aff-stop-schema .affls-dot{ width: 5px !important; height: 5px !important; }
+  #favTrainsWidget .fav-aff-stop-schema .affls-pct{ top: -10px !important; font-size: 6px !important; }
+  #favTrainsWidget .fav-aff-empty{ padding: 5px 6px !important; font-size: .62rem !important; }
+  body.page-favoris #favTrainsWidget{ margin: 4px auto 6px auto !important; }
+  body.page-favoris #favTrainsWidget .fav-title{
+    margin-bottom: 3px !important;
+    padding: 3px 8px !important;
+    font-size: .76rem !important;
+  }
   body{ padding-bottom: calc(var(--bottom-bar-height, 54px) + 8px) !important; }
   .bottom-nav{ padding:2px calc(env(safe-area-inset-right, 0px) + 8px) 0 calc(env(safe-area-inset-left, 0px) + 8px) !important; }
   .bottom-nav__items{ gap:2px !important; }


### PR DESCRIPTION
### Motivation
- Improve the mobile/home UX by adding quick access presets for common search time windows and make the favorites widget more compact and consistent on small screens.
- Surface both 7-day average and yesterday punctuality on the home card for better at-a-glance information.
- Fix alignment issues in the auth modal and ensure the tableau/search entry behaves better in constrained layouts.

### Description
- Adds a new home quick-presets UI block (`.home-quick-presets`) with two buttons (`data-home-preset-kind="AM|PM"`) and a JS handler that sets `#tableauModeSelect` to `quick`, navigates to `#search` and calls `applyRapidPreset` when pressed.
- Renames the bottom navigation item label from "Tableau" to "Recherche" and adds the class `bottom-nav__item--search` to allow targeted styling.
- Revamps the favorites widget markup and large CSS refactor: removes the old `.fav-head` wrapper, tightens paddings/typography, adds many responsive size tweaks and visual refinements under `#favTrainsWidget` and related selectors to improve compactness and alignment on mobile.
- Improves punctuality visualization on the home card by creating two doughnut charts (7-day average and yesterday) via `makeDonutChart`, `setDonutValue` and `renderHomePunctualityCharts`, and updates `updateHomePunctuality` wrapping to write to both charts.
- Adjusts `lbFitFavSchemas` to query `.affls-rame` or `.affls-train`, introduces a `baseScale` and tighter scaling logic for the favorites schematic rendering.
- Adds several small CSS fixes for the auth modal (`#lbAuthModal .lb-auth-actions`) to center action buttons and to constrain widths for `#lbBtnSubmit` and `#lbBtnPrefs`.

### Testing
- No automated tests were added or run for these UI/CSS/HTML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c38e74fe2c832da505f4971a0d1e94)