### PR TITLE
Add community live features: presence, local signals, train detail, UI polish and GTFS dataset

### DIFF
--- a/index33.html
+++ b/index33.html
@@ -980,15 +980,16 @@ body {
 }
 .lb-community-close{
   position:absolute;
-  top:10px;
-  right:10px;
-  width:28px;
-  height:28px;
-  border-radius:999px;
-  border:1px solid rgba(255,255,255,.12);
-  background:rgba(255,255,255,.04);
-  color:#fff;
-  cursor:pointer;
+  top:8px;
+  right:8px;
+  z-index:2;
+  left:auto !important;
+}
+.lb-community-close.tron-close-button{
+  position:absolute !important;
+  top:8px !important;
+  right:8px !important;
+  left:auto !important;
 }
 .lb-community-grid{
   display:grid;
@@ -1029,13 +1030,42 @@ body {
   border-radius:14px;
   background:linear-gradient(180deg, rgba(11,33,52,.8), rgba(8,25,41,.95));
   box-shadow:0 8px 22px rgba(0,0,0,.18);
-  padding:10px;
+  padding:8px;
+  transition: transform .16s ease, box-shadow .16s ease, border-color .16s ease;
+}
+.lb-live-card--delay{
+  border-color: rgba(255,138,26,.55);
+  box-shadow:0 8px 22px rgba(0,0,0,.18), 0 0 16px rgba(255,138,26,.2);
+}
+.lb-live-card--cancel{
+  border-color: rgba(255,77,109,.6);
+  box-shadow:0 8px 22px rgba(0,0,0,.2), 0 0 16px rgba(255,77,109,.24);
+}
+.lb-live-card:hover,
+.lb-live-card:focus-within{
+  border-color: rgba(0,240,255,.42);
+  box-shadow:0 10px 24px rgba(0,0,0,.25), 0 0 18px rgba(0,240,255,.15);
+}
+.lb-live-card:active{
+  transform: scale(.988);
+  box-shadow:0 6px 16px rgba(0,0,0,.22), 0 0 12px rgba(0,240,255,.12);
 }
 .lb-live-card-top{
   display:flex;
   justify-content:space-between;
   gap:10px;
   align-items:flex-start;
+}
+.lb-live-right{
+  display:flex;
+  flex-direction:column;
+  align-items:flex-end;
+  gap:2px;
+}
+.lb-live-status-row{
+  display:flex;
+  align-items:center;
+  gap:5px;
 }
 .lb-live-train{
   color:#9ef5ff;
@@ -1055,9 +1085,31 @@ body {
   border:1px solid transparent;
   text-align:center;
 }
-.lb-live-status--delay{ color:#ffd464; background:rgba(255,186,36,.1); border-color:rgba(255,199,72,.3); }
-.lb-live-status--ok{ color:#53ecad; background:rgba(41,202,139,.08); border-color:rgba(83,236,173,.26); }
-.lb-live-status--cancel{ color:#ff6988; background:rgba(255,73,110,.08); border-color:rgba(255,105,136,.24); }
+.lb-live-status--delay{ color:#ff8a1a; background:rgba(255,138,26,.12); border-color:rgba(255,138,26,.42); }
+.lb-live-status--ok{ color:#22c55e; background:rgba(34,197,94,.12); border-color:rgba(34,197,94,.42); }
+.lb-live-status--cancel{ color:#ff4d6d; background:rgba(255,77,109,.12); border-color:rgba(255,77,109,.42); }
+.lb-live-passenger{
+  font-size:.64rem;
+  font-weight:800;
+  color:#dff8ff;
+  opacity:.92;
+}
+.lb-live-user-alert{
+  margin-top:1px;
+  font-size:.6rem;
+  font-weight:800;
+  color:#ff8a1a;
+  padding:1px 6px;
+  border-radius:999px;
+  border:1px solid rgba(255,138,26,.45);
+  background:rgba(110,58,12,.26);
+  white-space:nowrap;
+}
+.lb-live-user-alert--cancel{
+  color:#ff4d6d;
+  border-color: rgba(255,77,109,.5);
+  background: rgba(110,20,42,.3);
+}
 .lb-live-meta{ display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; }
 .lb-live-chip{
   font-size:.68rem;
@@ -1068,18 +1120,71 @@ body {
   background:rgba(255,255,255,.05);
   color:#eafcff;
 }
-.lb-live-card-actions{ display:flex; gap:6px; margin-top:8px; }
+.lb-live-chip.is-own{
+  border-color:rgba(255,160,160,.45);
+  cursor:pointer;
+}
+.lb-live-sncf-cause{
+  margin-top:6px;
+  border-radius:10px;
+  border:1px solid rgba(255,168,76,.45);
+  background:rgba(112,62,18,.38);
+  color:#ffbd72;
+  font-size:.66rem;
+  font-weight:800;
+  padding:5px 8px;
+  line-height:1.2;
+}
+.lb-live-card-actions{ display:flex; gap:6px; margin-top:6px; }
 .lb-live-card-actions button{
   flex:1;
-  min-height:30px;
+  min-height:24px;
   border-radius:999px;
   border:1px solid rgba(0,240,255,.22);
   background:rgba(13,54,82,.9);
   color:#fff;
   font-family:'Orbitron', sans-serif;
-  font-size:.72rem;
+  font-size:.66rem;
   font-weight:800;
   cursor:pointer;
+  padding:0 8px;
+}
+.lb-live-schedule{
+  margin-top:3px;
+  padding:0;
+  border:none;
+  background:transparent;
+  font-size:.74rem;
+  line-height:1.25;
+  color:#bfe6f5;
+}
+.lb-live-presence{
+  margin-top:4px;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:6px;
+}
+.lb-live-presence-count{
+  font-size:.76rem;
+  min-width:44px;
+  opacity:.92;
+  font-weight:800;
+}
+.lb-live-presence-btn{
+  border:1px solid rgba(77,245,174,.45);
+  background:linear-gradient(180deg, rgba(8,88,72,.65), rgba(6,56,46,.92));
+  color:#dcffef;
+  border-radius:999px;
+  padding:4px 8px;
+  font-weight:700;
+  font-size:.62rem;
+  cursor:pointer;
+  min-height:24px;
+}
+.lb-live-presence-btn:disabled{
+  opacity:.65;
+  cursor:not-allowed;
 }
 .lb-live-feed{ display:grid; gap:8px; max-height:55vh; overflow:auto; }
 .lb-live-feed-item{
@@ -1097,16 +1202,43 @@ body {
 .lb-live-feed-item .text{ font-size:.76rem; color:#a9c4d6; line-height:1.3; }
 .lb-live-empty{ opacity:.76; font-size:.78rem; color:#c7dceb; text-align:center; padding:8px 0; }
 .lb-signal-form-grid{ display:grid; gap:10px; }
+.lb-signal-delay-wrap{ display:none; }
+.lb-signal-delay-wrap.is-visible{ display:block; }
+.lb-signal-station-wrap.is-hidden{ display:none; }
 .lb-signal-form select,
 .lb-signal-form textarea{
   width:100%;
   border-radius:14px;
   border:1px solid rgba(255,255,255,.08);
   background:rgba(255,255,255,.05);
-  color:white;
+  color:#eaf8ff;
   padding:12px 12px;
   font-size:.86rem;
   font-family:inherit;
+}
+.lb-signal-form select{
+  appearance:none;
+  -webkit-appearance:none;
+  -moz-appearance:none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #9ad8ee 50%),
+    linear-gradient(135deg, #9ad8ee 50%, transparent 50%);
+  background-position:
+    calc(100% - 18px) calc(50% - 2px),
+    calc(100% - 12px) calc(50% - 2px);
+  background-size:6px 6px, 6px 6px;
+  background-repeat:no-repeat;
+  padding-right:34px;
+}
+.lb-signal-form select option,
+.lb-signal-form select optgroup{
+  background:#10273b;
+  color:#eaf8ff;
+}
+.lb-signal-form select:focus{
+  outline:none;
+  border-color:rgba(0,240,255,.5);
+  box-shadow:0 0 0 2px rgba(0,240,255,.16);
 }
 .lb-signal-types{ display:grid; grid-template-columns:1fr 1fr; gap:8px; }
 .lb-signal-type{
@@ -1142,6 +1274,139 @@ body {
   cursor:pointer;
 }
 .lb-signal-help{ font-size:.72rem; color:#b1cad9; line-height:1.35; }
+.lb-info-quick-grid{
+  display:grid;
+  grid-template-columns:repeat(2, minmax(0,1fr));
+  gap:10px;
+}
+.lb-info-quick-btn{
+  min-height:58px;
+  border-radius:14px;
+  border:1px solid rgba(94,228,255,.28);
+  background:rgba(11,54,79,.68);
+  color:#e8fbff;
+  font-family:'Orbitron', sans-serif;
+  font-size:.72rem;
+  font-weight:800;
+  cursor:pointer;
+  text-align:center;
+  padding:8px;
+}
+.lb-info-quick-btn.is-selected{
+  border-color:rgba(139,255,205,.66);
+  box-shadow:0 0 0 1px rgba(139,255,205,.34) inset, 0 0 16px rgba(139,255,205,.22);
+}
+.lb-train-detail-route{ font-size:.82rem; color:#cbe8f7; margin-top:2px; }
+.lb-train-detail-cause{
+  margin-top:6px;
+  font-size:.67rem;
+  color:#ffbd72;
+  border:1px solid rgba(255,168,76,.4);
+  background:rgba(112,62,18,.28);
+  border-radius:8px;
+  padding:4px 7px;
+}
+.lb-train-detail-stops{
+  margin-top:10px;
+  border:1px solid rgba(0,240,255,.18);
+  border-radius:12px;
+  background:rgba(0,16,30,.4);
+  padding:8px;
+  max-height:46vh;
+  overflow:auto;
+  display:grid;
+  gap:6px;
+}
+.lb-train-stop-item{
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:10px;
+  padding:7px 8px;
+  background:rgba(255,255,255,.03);
+}
+.lb-train-stop-head{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:8px;
+}
+.lb-train-stop-name{ font-weight:800; font-size:.78rem; color:#dcf9ff; }
+.lb-train-stop-time{
+  font-size:.76rem;
+  font-weight:800;
+  color:#e8f8ff;
+  white-space:nowrap;
+}
+.lb-train-stop-time .planned{
+  text-decoration:line-through;
+  opacity:.82;
+  margin-right:4px;
+}
+.lb-train-stop-time .actual{ color:#ffffff; }
+.lb-train-stop-time.is-delay .planned{
+  color:#ffffff;
+}
+.lb-train-stop-time.is-delay .actual{
+  color:#ff8a1a;
+  font-weight:900;
+}
+.lb-train-stop-time.is-cancel .actual{
+  text-decoration:line-through;
+  color:#ff4d6d;
+  opacity:.9;
+}
+.lb-train-stop-signals{ margin-top:5px; display:flex; flex-wrap:wrap; gap:5px; }
+.lb-stop-chip{
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,.15);
+  background:rgba(255,255,255,.07);
+  font-size:.66rem;
+  padding:3px 7px;
+  font-weight:800;
+}
+.lb-stop-chip--retard{
+  color:#ff8a1a;
+  border-color:rgba(255,138,26,.62);
+  background:rgba(120,62,8,.24);
+}
+.lb-stop-chip--suppression{
+  color:#ff4d6d;
+  border-color:rgba(255,77,109,.62);
+  background:rgba(115,28,45,.25);
+}
+.lb-stop-chip--a-lheure{
+  color:#22c55e;
+  border-color:rgba(34,197,94,.45);
+  background:rgba(20,84,43,.22);
+}
+.lb-stop-chip.is-own{
+  border-color:rgba(255,160,160,.48);
+  cursor:pointer;
+}
+.lb-stop-chip-wrap{
+  display:inline-flex;
+  align-items:center;
+  gap:4px;
+}
+.lb-signal-vote{
+  display:inline-flex;
+  align-items:center;
+  gap:3px;
+  font-size:.64rem;
+}
+.lb-signal-vote-btn{
+  border:none;
+  background:transparent;
+  color:#cfe8f5;
+  cursor:pointer;
+  font-size:.72rem;
+  line-height:1;
+  padding:0 2px;
+}
+.lb-signal-vote-btn.is-up{ color:#22c55e; }
+.lb-signal-vote-btn.is-down{ color:#ff4d6d; }
+.lb-signal-vote-btn.is-active{
+  text-shadow:0 0 8px currentColor;
+}
 .home-card[aria-label="Mur de commentaires"] .live-wall-card--home,
 .home-card[aria-label="Mur de commentaires"],
 .home-card.live-wall-card--home{ min-height:0; }
@@ -17376,6 +17641,16 @@ const GTFS_RT_DATASETS = [
     ]
   },
   {
+    id: 'sncf-carte',
+    label: 'GTFS-RT SNCF Carte',
+    filename: 'retards_carte.json',
+    sources: [
+      'https://vps.labetaillere.fr/gtfs/retards_carte.json',
+      'https://raw.githubusercontent.com/TekMaTe-lux/Assistant-train/main/Assistant-train/retards_carte.json',
+      'https://cdn.jsdelivr.net/gh/TekMaTe-lux/Assistant-train@main/Assistant-train/retards_carte.json'
+    ]
+  },
+  {
     id: 'cfl-hafas',
     label: 'GTFS-RT CFL / HAFAS',
     filename: 'retards_cfl.json',
@@ -27446,7 +27721,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 
   <div id="lbLiveModal" class="lb-community-modal" aria-hidden="true">
     <div class="lb-community-panel" role="dialog" aria-modal="true" aria-labelledby="lbLiveModalTitle">
-      <button type="button" class="lb-community-close" data-lb-community-close="lbLiveModal" aria-label="Fermer">✕</button>
+      <button type="button" class="lb-community-close tron-close-button" data-lb-community-close="lbLiveModal" aria-label="Fermer"></button>
       <div class="lb-community-head">
         <div>
           <h3 id="lbLiveModalTitle">📡 LIVE voyageurs</h3>
@@ -27478,7 +27753,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 
   <div id="lbSignalModal" class="lb-community-modal" aria-hidden="true">
     <div class="lb-community-panel" role="dialog" aria-modal="true" aria-labelledby="lbSignalModalTitle">
-      <button type="button" class="lb-community-close" data-lb-community-close="lbSignalModal" aria-label="Fermer">✕</button>
+      <button type="button" class="lb-community-close tron-close-button" data-lb-community-close="lbSignalModal" aria-label="Fermer"></button>
       <div class="lb-community-head">
         <div>
           <h3 id="lbSignalModalTitle">⚠️ Signaler un train live</h3>
@@ -27490,9 +27765,23 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
           <select id="lbSignalTrainSelect">
             <option value="">Choisir un train live</option>
           </select>
-          <select id="lbSignalStationSelect">
-            <option value="">Choisir la gare concernée</option>
-          </select>
+          <div class="lb-signal-station-wrap" id="lbSignalStationWrap">
+            <select id="lbSignalStationSelect">
+              <option value="">Choisir la gare concernée</option>
+            </select>
+          </div>
+          <div class="lb-signal-delay-wrap" id="lbSignalDelayWrap">
+            <select id="lbSignalDelaySelect">
+              <option value="">Choisir le retard</option>
+              <option value="5">+5 min</option>
+              <option value="10">+10 min</option>
+              <option value="15">+15 min</option>
+              <option value="20">+20 min</option>
+              <option value="30">+30 min</option>
+              <option value="45">+45 min</option>
+              <option value="60">+60 min</option>
+            </select>
+          </div>
           <div class="lb-signal-types" id="lbSignalTypes">
             <button type="button" class="lb-signal-type" data-signal-type="retard">⏱ Retard</button>
             <button type="button" class="lb-signal-type" data-signal-type="suppression">❌ Suppression</button>
@@ -27504,6 +27793,46 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
           <button type="button" id="lbSignalSubmit" class="lb-signal-submit">Publier le signalement</button>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div id="lbInfoQuickModal" class="lb-community-modal" aria-hidden="true">
+    <div class="lb-community-panel" role="dialog" aria-modal="true" aria-labelledby="lbInfoQuickModalTitle">
+      <button type="button" class="lb-community-close tron-close-button" data-lb-community-close="lbInfoQuickModal" aria-label="Fermer"></button>
+      <div class="lb-community-head">
+        <div>
+          <h3 id="lbInfoQuickModalTitle">ℹ️ Partager une information</h3>
+          <div class="lb-community-panel-sub">Choisissez une information prédéfinie à ajouter dans la fiche train.</div>
+        </div>
+      </div>
+      <div class="lb-info-quick-grid" id="lbInfoQuickGrid">
+        <button type="button" class="lb-info-quick-btn" data-info-tag="composition-simple">🚆 Composition simple</button>
+        <button type="button" class="lb-info-quick-btn" data-info-tag="composition-double">🚆🚆 Composition double</button>
+        <button type="button" class="lb-info-quick-btn" data-info-tag="composition-triple">🚆🚆🚆 Composition triple</button>
+        <button type="button" class="lb-info-quick-btn" data-info-tag="climatisation-hs">❄️ Climatisation HS</button>
+        <button type="button" class="lb-info-quick-btn" data-info-tag="chauffage-hs">🌡️ Chauffage HS</button>
+        <button type="button" class="lb-info-quick-btn" data-info-tag="forte-affluence">👥 Forte affluence</button>
+        <button type="button" class="lb-info-quick-btn" data-info-tag="wc-condamne">🚻 WC condamné</button>
+        <button type="button" class="lb-info-quick-btn" data-info-tag="prise-hs">🔌 Prise de courant HS</button>
+        <button type="button" class="lb-info-quick-btn" data-info-tag="porte-hs">🚪 Porte HS</button>
+        <button type="button" class="lb-info-quick-btn" data-info-tag="forces-ordre">👮 Intervention forces de l'ordre</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="lbTrainDetailModal" class="lb-community-modal" aria-hidden="true">
+    <div class="lb-community-panel" role="dialog" aria-modal="true" aria-labelledby="lbTrainDetailTitle">
+      <button type="button" class="lb-community-close tron-close-button" data-lb-community-close="lbTrainDetailModal" aria-label="Fermer"></button>
+      <div class="lb-community-head">
+        <div>
+          <h3 id="lbTrainDetailTitle">Fiche train</h3>
+          <div class="lb-train-detail-route" id="lbTrainDetailRoute">—</div>
+          <div class="lb-train-detail-cause" id="lbTrainDetailCause" hidden></div>
+        </div>
+      </div>
+      <section class="lb-train-detail-stops" id="lbTrainDetailStops">
+        <div class="lb-live-empty">Chargement des arrêts…</div>
+      </section>
     </div>
   </div>
 
@@ -27523,9 +27852,178 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   const COMMUNITY = {
     selectedTrain: '',
     selectedSignalType: '',
+    selectedInfoTag: '',
     liveTrains: [],
-    signals: []
+    signals: [],
+    presences: [],
+    staticInfoCache: new Map(),
+    localSignals: []
   };
+
+  const toYmd = (date = new Date())=>{
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}${m}${d}`;
+  };
+  const toIsoDay = (date = new Date())=> `${toYmd(date).slice(0,4)}-${toYmd(date).slice(4,6)}-${toYmd(date).slice(6,8)}`;
+  const formatGtfsHHMM = (raw)=>{
+    const digits = String(raw || '').replace(/\D/g, '');
+    if (!digits) return '—';
+    const hh = digits.slice(0, 2);
+    const mm = digits.slice(2, 4) || '00';
+    if (!hh) return '—';
+    return `${hh}:${mm}`;
+  };
+  const addMinutesToHHMM = (hhmm, delta)=>{
+    const m = String(hhmm || '').match(/^(\d{2}):(\d{2})$/);
+    if (!m) return hhmm || '—';
+    const base = Number(m[1]) * 60 + Number(m[2]);
+    const total = base + Number(delta || 0);
+    const day = 24 * 60;
+    const normalized = ((total % day) + day) % day;
+    const h = String(Math.floor(normalized / 60)).padStart(2, '0');
+    const mn = String(normalized % 60).padStart(2, '0');
+    return `${h}:${mn}`;
+  };
+  const hhmmToMinutes = (hhmm)=>{
+    const m = String(hhmm || '').match(/^(\d{2}):(\d{2})$/);
+    if (!m) return null;
+    return Number(m[1]) * 60 + Number(m[2]);
+  };
+  const getCompoForTrain = (trainNumber)=>{
+    const raw = window.compoData?.[String(trainNumber || '').trim()] || '';
+    const normalized = String(raw || '').trim().toUpperCase();
+    if (!normalized) return '';
+    if (normalized === 'US') return 'US';
+    if (normalized.startsWith('UM3')) return 'UM3';
+    if (normalized.startsWith('UM')) return 'UM';
+    return '';
+  };
+  const compoVisual = (code)=>{
+    if (code === 'US') return '🚆';
+    if (code === 'UM') return '🚆🚆';
+    if (code === 'UM3') return '🚆🚆🚆';
+    return '🚆?';
+  };
+  const compoCodeFromInfoTag = (tag)=>{
+    switch(String(tag || '').toLowerCase()){
+      case 'composition-simple': return 'US';
+      case 'composition-double': return 'UM';
+      case 'composition-triple': return 'UM3';
+      default: return '';
+    }
+  };
+  const INFO_TAG_LABELS = {
+    'composition-simple': '🚆 Composition simple',
+    'composition-double': '🚆🚆 Composition double',
+    'composition-triple': '🚆🚆🚆 Composition triple',
+    'climatisation-hs': '❄️ Climatisation HS',
+    'chauffage-hs': '🌡️ Chauffage HS',
+    'forte-affluence': '👥 Forte affluence',
+    'wc-condamne': '🚻 WC condamné',
+    'prise-hs': '🔌 Prise de courant HS',
+    'porte-hs': '🚪 Porte HS',
+    'forces-ordre': '👮 Intervention forces de l\'ordre'
+  };
+  const localSignalStorageKey = ()=> `lb_local_signals_${toIsoDay()}`;
+  const localPresenceStorageKey = ()=> `lb_local_presence_${toIsoDay()}`;
+  const localDeviceAccountKey = 'lb_local_account_id';
+  const signalVotesStorageKey = 'lb_signal_votes_v1';
+
+  function getLocalAccountId(){
+    try{
+      const existing = localStorage.getItem(localDeviceAccountKey);
+      if (existing) return existing;
+      const created = `device_${Math.random().toString(36).slice(2, 10)}`;
+      localStorage.setItem(localDeviceAccountKey, created);
+      return created;
+    }catch(_){
+      return `device_fallback`;
+    }
+  }
+
+  function loadLocalSignals(){
+    try{
+      const raw = JSON.parse(localStorage.getItem(localSignalStorageKey()) || '[]');
+      COMMUNITY.localSignals = Array.isArray(raw) ? raw.map(normalizeSignalItem).filter(Boolean) : [];
+    }catch(_){
+      COMMUNITY.localSignals = [];
+    }
+  }
+
+  function saveLocalSignal(item){
+    loadLocalSignals();
+    COMMUNITY.localSignals.unshift(item);
+    COMMUNITY.localSignals = COMMUNITY.localSignals.slice(0, 300);
+    try { localStorage.setItem(localSignalStorageKey(), JSON.stringify(COMMUNITY.localSignals)); } catch(_){}
+  }
+
+  function removeLocalSignalById(signalId){
+    loadLocalSignals();
+    COMMUNITY.localSignals = COMMUNITY.localSignals.filter((it)=> String(it.id) !== String(signalId));
+    try { localStorage.setItem(localSignalStorageKey(), JSON.stringify(COMMUNITY.localSignals)); } catch(_){}
+  }
+
+  function loadLocalPresences(){
+    try{
+      const raw = JSON.parse(localStorage.getItem(localPresenceStorageKey()) || '[]');
+      const list = Array.isArray(raw) ? raw : [];
+      return list.map(normalizePresenceItem).filter(Boolean);
+    }catch(_){
+      return [];
+    }
+  }
+
+  function saveLocalPresence(item){
+    const current = loadLocalPresences();
+    current.unshift(item);
+    try { localStorage.setItem(localPresenceStorageKey(), JSON.stringify(current.slice(0, 500))); } catch(_){}
+  }
+
+  function removeLocalPresenceById(presenceId){
+    const current = loadLocalPresences().filter((it)=> String(it.id) !== String(presenceId));
+    try { localStorage.setItem(localPresenceStorageKey(), JSON.stringify(current)); } catch(_){}
+  }
+
+  function loadSignalVotes(){
+    try{
+      const raw = JSON.parse(localStorage.getItem(signalVotesStorageKey) || '{}');
+      return (raw && typeof raw === 'object') ? raw : {};
+    }catch(_){
+      return {};
+    }
+  }
+
+  function saveSignalVotes(store){
+    try { localStorage.setItem(signalVotesStorageKey, JSON.stringify(store || {})); } catch(_){}
+  }
+
+  function getSignalVoteSummary(signalId){
+    const id = String(signalId || '');
+    if (!id) return { up:0, down:0, mine:0 };
+    const store = loadSignalVotes();
+    const votes = store[id] && typeof store[id] === 'object' ? store[id] : {};
+    let up = 0, down = 0;
+    Object.values(votes).forEach((v)=>{
+      if (Number(v) > 0) up += 1;
+      else if (Number(v) < 0) down += 1;
+    });
+    const mine = Number(votes[getCurrentPresenceIdentity()] || 0);
+    return { up, down, mine };
+  }
+
+  function setSignalVote(signalId, value){
+    const id = String(signalId || '');
+    if (!id) return;
+    const val = Number(value) > 0 ? 1 : -1;
+    const user = getCurrentPresenceIdentity();
+    const store = loadSignalVotes();
+    if (!store[id] || typeof store[id] !== 'object') store[id] = {};
+    store[id][user] = (store[id][user] === val) ? 0 : val;
+    if (store[id][user] === 0) delete store[id][user];
+    saveSignalVotes(store);
+  }
 
   function detectCommentTrainNumber(item){
     if (!item) return '';
@@ -27546,12 +28044,18 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     const station = String(raw.station || (parsed && parsed[4]) || '').trim();
     const signalType = String(raw.signal_type || (parsed && parsed[1]) || '').trim().toLowerCase().replace(/\s+/g,'-');
     const detail = parsed ? String(parsed[5] || '').trim() : message;
+    const delayMin = Number(raw.delay_min || raw.delayMin || 0);
+    const infoTag = String(raw.info_tag || raw.infoTag || '').trim();
+    const accountId = String(raw.account_id || raw.accountId || raw.user_id || '').trim();
     return {
       id: raw.id || `${ts}_${Math.random().toString(36).slice(2,8)}`,
       pseudo: String(raw.pseudo || raw.username || raw.user_pseudo || 'Voyageur').trim().slice(0,24),
       text: message,
       detail: detail || message,
       signalType,
+      delayMin: Number.isFinite(delayMin) ? delayMin : 0,
+      infoTag,
+      accountId,
       trainNumber,
       station,
       ts
@@ -27559,8 +28063,13 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   }
 
   async function loadSignals(){
+    loadLocalSignals();
+    if (typeof fetchCommentsApi !== 'function'){
+      COMMUNITY.signals = Array.isArray(COMMUNITY.localSignals) ? COMMUNITY.localSignals.slice(0, 200) : [];
+      refreshCommunityViews();
+      return COMMUNITY.signals;
+    }
     try{
-      if (typeof fetchCommentsApi !== 'function') return [];
       const res = await fetchCommentsApi('?scope=signals');
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
@@ -27570,12 +28079,57 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       console.warn('Impossible de charger les signalements', err);
       COMMUNITY.signals = Array.isArray(COMMUNITY.signals) ? COMMUNITY.signals : [];
     }
+    if (Array.isArray(COMMUNITY.localSignals) && COMMUNITY.localSignals.length){
+      COMMUNITY.signals = [...COMMUNITY.localSignals, ...COMMUNITY.signals]
+        .sort((a,b)=> Number(b.ts||0) - Number(a.ts||0))
+        .slice(0, 200);
+    }
     refreshCommunityViews();
     return COMMUNITY.signals;
   }
 
+  function normalizePresenceItem(raw){
+    if (!raw || typeof raw !== 'object') return null;
+    const createdAt = raw.created_at || raw.createdAt || raw.ts || raw.timestamp || Date.now();
+    const ts = Number.isFinite(Number(createdAt)) ? Number(createdAt) : (Date.parse(createdAt) || Date.now());
+    const trainNumber = normalizeKey(raw.train_number || raw.trainNumber || detectCommentTrainNumber(raw));
+    if (!trainNumber) return null;
+    return {
+      id: raw.id || `${ts}_${Math.random().toString(36).slice(2,8)}`,
+      pseudo: String(raw.pseudo || raw.username || raw.user_pseudo || '').trim().slice(0,24),
+      accountId: String(raw.account_id || raw.accountId || raw.user_id || '').trim(),
+      trainNumber,
+      ts
+    };
+  }
+
+  async function loadPresences(){
+    const localPres = loadLocalPresences();
+    if (typeof fetchCommentsApi !== 'function'){
+      COMMUNITY.presences = localPres.slice(0, 500);
+      refreshCommunityViews();
+      return COMMUNITY.presences;
+    }
+    try{
+      const res = await fetchCommentsApi('?scope=presence');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const list = Array.isArray(data) ? data : (Array.isArray(data?.comments) ? data.comments : []);
+      COMMUNITY.presences = list.map(normalizePresenceItem).filter(Boolean).sort((a,b)=> Number(b.ts||0) - Number(a.ts||0)).slice(0, 500);
+    }catch(err){
+      console.warn('Impossible de charger les présences voyageurs', err);
+      COMMUNITY.presences = Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences : [];
+    }
+    COMMUNITY.presences = [...localPres, ...(Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences : [])]
+      .sort((a,b)=> Number(b.ts||0) - Number(a.ts||0))
+      .slice(0, 500);
+    refreshCommunityViews();
+    return COMMUNITY.presences;
+  }
+
   function getRawLiveTrainPayload(){
     const raw = window.retardsGTFS_RAW;
+    if (raw && raw['sncf-carte']?.trains) return raw['sncf-carte'];
     if (raw && raw['sncf-nml']) return raw['sncf-nml'];
     return raw || null;
   }
@@ -27585,6 +28139,52 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     const trainsObj = raw?.trains || raw?.normalized?.trains || null;
     const list = [];
     if (!trainsObj || typeof trainsObj !== 'object') return list;
+    const buildCauseIndex = (root)=>{
+      const out = new Map();
+      const seen = new WeakSet();
+      const walk = (node, keyHint = '', depth = 0)=>{
+        if (!node || typeof node !== 'object') return;
+        if (depth > 7) return;
+        if (seen.has(node)) return;
+        seen.add(node);
+        const trainNum = normalizeKey(node.train_number || node.train || node.number || keyHint);
+        const directCause = String(
+          node.sncf_disruption_cause
+          || node.disruption_cause
+          || node.cause
+          || node.reason
+          || node?.data?.sncf_disruption_cause
+          || ''
+        ).trim();
+        if (trainNum && directCause && !out.has(trainNum)) out.set(trainNum, directCause);
+        Object.entries(node).forEach(([k, v])=>{
+          if (v && typeof v === 'object') walk(v, k, depth + 1);
+        });
+      };
+      walk(root);
+      return out;
+    };
+    const causeIndex = buildCauseIndex(window.retardsGTFS_RAW);
+    const extractSncfCause = (payload)=>{
+      if (!payload || typeof payload !== 'object') return '';
+      const direct = [
+        payload.sncf_disruption_cause,
+        payload.disruption_cause,
+        payload.cause,
+        payload.reason,
+        payload?.data?.sncf_disruption_cause
+      ].map((v)=> String(v || '').trim()).find(Boolean);
+      if (direct) return direct;
+      const disruptions = Array.isArray(payload.disruptions) ? payload.disruptions : (Array.isArray(payload?.data?.disruptions) ? payload.data.disruptions : []);
+      const causes = [];
+      disruptions.forEach((d)=>{
+        const c = String(d?.cause || '').trim();
+        if (c) causes.push(c);
+        const msg = String(d?.messages?.[0]?.text || '').trim();
+        if (msg) causes.push(msg);
+      });
+      return Array.from(new Set(causes)).slice(0, 2).join(' • ');
+    };
     Object.entries(trainsObj).forEach(([key, payload])=>{
       if (!payload || typeof payload !== 'object') return;
       const trainNumber = normalizeKey(payload.train_number || payload.train || payload.number || key);
@@ -27619,6 +28219,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
         to: routeTo,
         statusLabel,
         statusClass,
+        sncfCause: extractSncfCause(payload) || String(causeIndex.get(trainNumber) || '').trim(),
         maxDelay,
         stops: stopNames,
         raw: payload
@@ -27648,6 +28249,145 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     return (Array.isArray(COMMUNITY.signals) ? COMMUNITY.signals : []).filter((it)=> normalizeKey(it.trainNumber) === key);
   }
 
+  function getEffectiveCompositionCode(trainNumber){
+    const fromSignals = getSignalsForTrain(trainNumber)
+      .filter((s)=> String(s.signalType || '').toLowerCase() === 'information')
+      .sort((a,b)=> Number(b.ts || 0) - Number(a.ts || 0))
+      .map((s)=> compoCodeFromInfoTag(s.infoTag))
+      .find(Boolean);
+    return fromSignals || getCompoForTrain(trainNumber) || '';
+  }
+
+  function getLatestTravelerDisruption(trainNumber){
+    const disruptions = getSignalsForTrain(trainNumber)
+      .filter((s)=> ['retard', 'suppression'].includes(String(s.signalType || '').toLowerCase()))
+      .sort((a,b)=> Number(b.ts || 0) - Number(a.ts || 0));
+    if (!disruptions.length) return null;
+    const latest = disruptions[0];
+    return {
+      type: String(latest.signalType || '').toLowerCase(),
+      delayMin: Number(latest.delayMin || 0),
+      station: latest.station || '',
+      ts: Number(latest.ts || 0)
+    };
+  }
+
+  function getPresenceStatsForTrain(trainNumber){
+    const key = normalizeKey(trainNumber);
+    const today = toIsoDay();
+    const map = new Map();
+    (Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences : []).forEach((it)=>{
+      if (normalizeKey(it.trainNumber) !== key) return;
+      const day = toIsoDay(new Date(it.ts || Date.now()));
+      if (day !== today) return;
+      const identity = String(it.accountId || it.pseudo || '').trim().toLowerCase();
+      const uniqKey = `${identity}|${day}|${key}`;
+      if (!map.has(uniqKey)) map.set(uniqKey, it);
+    });
+    return { count: map.size, today };
+  }
+
+  function getCurrentPresenceIdentity(){
+    const userId = String(window.currentUser?.id || window.currentUser?.user_id || '').trim();
+    if (userId) return `uid:${userId}`;
+    const pseudo = String(window.currentUser?.pseudo || window.currentUser?.username || window.lbPrefsCache?.pseudo || '').trim().toLowerCase();
+    if (pseudo) return `pseudo:${pseudo}`;
+    return `local:${getLocalAccountId()}`;
+  }
+
+  function normalizeIdentity(value){
+    return String(value || '').trim().toLowerCase();
+  }
+
+  function isOwnSignal(signal){
+    const current = normalizeIdentity(getCurrentPresenceIdentity());
+    const byAccount = normalizeIdentity(signal?.accountId);
+    if (byAccount) return byAccount === current;
+    const pseudo = normalizeIdentity(window.currentUser?.pseudo || window.currentUser?.username || window.lbPrefsCache?.pseudo);
+    return !!pseudo && normalizeIdentity(signal?.pseudo) === pseudo;
+  }
+
+  function getMyPresenceToday(){
+    const ident = normalizeIdentity(getCurrentPresenceIdentity());
+    const today = toIsoDay();
+    return (Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences : []).find((it)=>{
+      const day = toIsoDay(new Date(it.ts || Date.now()));
+      const identity = normalizeIdentity(it.accountId || it.pseudo);
+      return day === today && identity === ident;
+    }) || null;
+  }
+
+  function hasCurrentUserPresence(trainNumber){
+    const key = normalizeKey(trainNumber);
+    const mine = getMyPresenceToday();
+    return !!mine && normalizeKey(mine.trainNumber) === key;
+  }
+
+  function getGtfsRtDelayForStop(trainNumber, stopName){
+    const trainKey = normalizeKey(trainNumber);
+    const station = String(stopName || '').trim();
+    if (!trainKey || !station) return null;
+    const perTrain = window.retardsGTFS && typeof window.retardsGTFS === 'object'
+      ? window.retardsGTFS[trainKey]
+      : null;
+    if (!perTrain || typeof perTrain !== 'object') return null;
+    let value = perTrain[station];
+    if (value == null && typeof normalizeStationName === 'function'){
+      const targetNorm = normalizeStationName(station);
+      if (targetNorm){
+        const normalizedLookup = perTrain[GTFS_NORMALIZED_STATION_MAP_KEY];
+        if (normalizedLookup instanceof Map && normalizedLookup.has(targetNorm)){
+          value = normalizedLookup.get(targetNorm);
+        } else {
+          for (const [knownStop, knownValue] of Object.entries(perTrain)){
+            if (normalizeStationName(knownStop) === targetNorm){
+              value = knownValue;
+              if (normalizedLookup instanceof Map) normalizedLookup.set(targetNorm, knownValue);
+              break;
+            }
+          }
+        }
+      }
+    }
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+  }
+
+  async function getLiveTrainStaticInfo(trainNumber){
+    const key = normalizeKey(trainNumber);
+    const day = toYmd();
+    if (!key) return null;
+    const cacheKey = `${key}_${day}`;
+    if (COMMUNITY.staticInfoCache.has(cacheKey)) return COMMUNITY.staticInfoCache.get(cacheKey);
+    let info = null;
+    if (typeof buildGtfsFallbackResult === 'function'){
+      try{
+        const fallback = await buildGtfsFallbackResult(key, { ymd: day });
+        const stops = fallback?.train?.stop_times || [];
+        if (stops.length){
+          const stopRows = stops.map((s)=>({
+            name: String(s?.stop_point?.name || '').trim(),
+            time: formatGtfsHHMM(s?.arrival_time || s?.departure_time || ''),
+            amendedTime: formatGtfsHHMM(s?.amended_arrival_time || s?.amended_departure_time || ''),
+            delayMin: Number.isFinite(Number(s?.delay_minutes)) ? Number(s.delay_minutes) : null
+          })).filter((s)=> s.name);
+          info = {
+            departure: formatGtfsHHMM(stops[0]?.departure_time || stops[0]?.arrival_time),
+            arrival: formatGtfsHHMM(stops[stops.length - 1]?.arrival_time || stops[stops.length - 1]?.departure_time),
+            trainType: getCompoForTrain(key),
+            stops: stopRows.map((s)=> s.name),
+            stopRows
+          };
+        }
+      }catch(_){}
+    }
+    if (!info){
+      info = { departure:'—', arrival:'—', trainType:getCompoForTrain(key), stops:[], stopRows:[] };
+    }
+    COMMUNITY.staticInfoCache.set(cacheKey, info);
+    return info;
+  }
+
   function formatSignalTypeLabel(type){
     switch(String(type || '').toLowerCase()){
       case 'retard': return '⏱ Retard';
@@ -27660,6 +28400,36 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       case 'a-lheure ': return '✅ À l\'heure';
       default: return 'ℹ️ Signalement';
     }
+  }
+
+  function signalDisplayLabel(signal){
+    if (!signal) return 'Signalement';
+    const base = formatSignalTypeLabel(signal.signalType);
+    if (signal.signalType === 'retard' && Number(signal.delayMin) > 0) return `${base} +${signal.delayMin} min`;
+    if (signal.signalType === 'information' && signal.infoTag && INFO_TAG_LABELS[signal.infoTag]) return INFO_TAG_LABELS[signal.infoTag];
+    return base;
+  }
+
+  function buildPropagatedSignalsByStop(stopNames, trainSignals){
+    const normalizedStops = (Array.isArray(stopNames) ? stopNames : []).map((name)=> String(name || '').trim()).filter(Boolean);
+    const latestPerStop = new Map();
+    const propagationTypes = new Set(['retard', 'a-lheure', 'suppression']);
+    (Array.isArray(trainSignals) ? trainSignals : []).forEach((sig)=>{
+      const station = String(sig?.station || '').trim();
+      if (!station || !propagationTypes.has(String(sig?.signalType || '').toLowerCase())) return;
+      const key = station.toLowerCase();
+      const prev = latestPerStop.get(key);
+      if (!prev || Number(sig.ts || 0) > Number(prev.ts || 0)) latestPerStop.set(key, sig);
+    });
+    const out = new Map();
+    let carry = null;
+    normalizedStops.forEach((name)=>{
+      const key = name.toLowerCase();
+      const atStop = latestPerStop.get(key);
+      if (atStop) carry = atStop;
+      if (carry) out.set(key, carry);
+    });
+    return out;
   }
 
   function openCommunityModal(id){
@@ -27682,7 +28452,10 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     const statusEl = $id('lbCommunityStatus');
     if (statusEl){
       const signalCount = Array.isArray(COMMUNITY.signals) ? COMMUNITY.signals.length : 0;
-      statusEl.textContent = signalCount > 0 ? `${signalCount} signalement(s) voyageurs disponibles en live.` : 'Live voyageurs et signalements en temps réel.';
+      const presenceCount = Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences.filter((it)=> toIsoDay(new Date(it.ts || Date.now())) === toIsoDay()).length : 0;
+      statusEl.textContent = (signalCount > 0 || presenceCount > 0)
+        ? `${signalCount} signalement(s) · ${presenceCount} voyageur(s) en live aujourd'hui.`
+        : 'Live voyageurs et signalements en temps réel.';
     }
     if ($id('lbLiveModal')?.classList.contains('is-open')) refreshLiveModal();
     if ($id('lbSignalModal')?.classList.contains('is-open')) refreshSignalModal();
@@ -27701,27 +28474,77 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     cardsEl.innerHTML = COMMUNITY.liveTrains.map((train)=>{
       const signals = getSignalsForTrain(train.trainNumber);
       const wallComments = getWallCommentsForTrain(train.trainNumber);
+      const presence = getPresenceStatsForTrain(train.trainNumber);
+      const myPresence = getMyPresenceToday();
+      const isInThisTrain = !!myPresence && normalizeKey(myPresence.trainNumber) === normalizeKey(train.trainNumber);
+      const travelerDisruption = getLatestTravelerDisruption(train.trainNumber);
+      const effectiveCompo = getEffectiveCompositionCode(train.trainNumber);
+      const cardState = (()=> {
+        if (train.statusClass === 'cancel') return 'cancel';
+        if (train.statusClass === 'delay') return 'delay';
+        if (train.statusClass === 'ok' && travelerDisruption?.type === 'suppression') return 'cancel';
+        if (train.statusClass === 'ok' && travelerDisruption?.type === 'retard') return 'delay';
+        return 'ok';
+      })();
+      const gtfsInfo = COMMUNITY.staticInfoCache.get(`${normalizeKey(train.trainNumber)}_${toYmd()}`) || null;
       const chips = [];
-      if (signals.length) chips.push(`👥 ${signals.length} signalement(s)`);
-      if (wallComments.length) chips.push(`💬 ${wallComments.length} commentaire(s)`);
-      if (signals[0]?.station) chips.push(`📍 ${safeEscape(signals[0].station)}`);
-      if (signals[0]?.signalType) chips.push(safeEscape(formatSignalTypeLabel(signals[0].signalType)));
+      if (wallComments.length) chips.push(`<span class="lb-live-chip">💬 ${wallComments.length} commentaire(s)</span>`);
+      if (signals[0]?.station) chips.push(`<span class="lb-live-chip">📍 ${safeEscape(signals[0].station)}</span>`);
+      const latestNonInfoSignal = signals.find((s)=> String(s?.signalType || '').toLowerCase() !== 'information');
+      if (latestNonInfoSignal) chips.push(`<span class="lb-live-chip">${safeEscape(signalDisplayLabel(latestNonInfoSignal))}</span>`);
+      const infoSignals = signals
+        .filter((s)=> String(s?.signalType || '').toLowerCase() === 'information')
+        .slice(0, 4);
+      infoSignals.forEach((s)=>{
+        const mine = isOwnSignal(s);
+        const attrs = mine ? ` role="button" tabindex="0" title="Supprimer mon signalement" data-lb-delete-signal="${safeEscape(String(s.id || ''))}"` : '';
+        chips.push(`<span class="lb-live-chip${mine ? ' is-own' : ''}"${attrs}>${safeEscape(signalDisplayLabel(s))}</span>`);
+      });
       return `
-        <div class="lb-live-card" data-lb-live-train="${safeEscape(train.trainNumber)}">
+        <div class="lb-live-card lb-live-card--${safeEscape(cardState)}" data-lb-live-train="${safeEscape(train.trainNumber)}">
           <div class="lb-live-card-top">
             <div>
               <div class="lb-live-train">${safeEscape(train.label)}</div>
               <div class="lb-live-route">${safeEscape(train.route)}</div>
             </div>
-            <span class="lb-live-status lb-live-status--${safeEscape(train.statusClass)}">${safeEscape(train.statusLabel)}</span>
+            <div class="lb-live-right">
+              <div class="lb-live-status-row">
+                <span class="lb-live-passenger">🐮 ${presence.count}</span>
+                <span class="lb-live-status lb-live-status--${safeEscape(train.statusClass)}">${safeEscape(train.statusLabel)}</span>
+              </div>
+              ${train.statusClass === 'ok' && travelerDisruption
+                ? (travelerDisruption.type === 'suppression'
+                    ? `<span class="lb-live-user-alert lb-live-user-alert--cancel" title="Signalement usager récent (infos SNCF conservées en priorité)">❌ Supprimé (usager)</span>`
+                    : `<span class="lb-live-user-alert" title="Signalement usager récent (infos SNCF conservées en priorité)">Signalé: +${safeEscape(travelerDisruption.delayMin || '?')} min</span>`)
+                : ''}
+              ${(train.statusClass === 'delay' || train.statusClass === 'cancel') && train.sncfCause
+                ? `<div class="lb-live-sncf-cause">${safeEscape(train.statusClass === 'cancel' ? 'Suppression' : 'Retard')} : ${safeEscape(train.sncfCause)}</div>`
+                : ''}
+            </div>
           </div>
-          <div class="lb-live-meta">${chips.length ? chips.map((chip)=>`<span class="lb-live-chip">${chip}</span>`).join('') : '<span class="lb-live-chip">Aucun retour voyageur</span>'}</div>
+          <div class="lb-live-schedule" data-lb-train-schedule="${safeEscape(train.trainNumber)}">
+            ⏱ ${safeEscape(gtfsInfo ? `${gtfsInfo.departure} - ${gtfsInfo.arrival}` : 'Horaires GTFS en chargement...')} · ${safeEscape(compoVisual(effectiveCompo))}
+          </div>
+          ${chips.length ? `<div class="lb-live-meta">${chips.join('')}</div>` : ''}
           <div class="lb-live-card-actions">
-            <button type="button" data-lb-view-train="${safeEscape(train.trainNumber)}">Voir les retours</button>
             <button type="button" data-lb-signal-train="${safeEscape(train.trainNumber)}">⚠️ Signaler</button>
+            <button type="button" class="lb-live-presence-btn" data-lb-presence-train="${safeEscape(train.trainNumber)}">${isInThisTrain ? '🐮 Je quitte' : '🐮 Je suis'}</button>
           </div>
         </div>`;
     }).join('');
+    hydrateLiveTrainStaticInfos();
+  }
+
+  async function hydrateLiveTrainStaticInfos(){
+    const trains = Array.isArray(COMMUNITY.liveTrains) ? COMMUNITY.liveTrains.slice(0, 20) : [];
+    if (!trains.length) return;
+    await Promise.all(trains.map(async (train)=>{
+      const info = await getLiveTrainStaticInfo(train.trainNumber);
+      const effectiveCompo = getEffectiveCompositionCode(train.trainNumber);
+      const node = document.querySelector(`[data-lb-train-schedule="${String(train.trainNumber)}"]`);
+      if (!node || !info) return;
+      node.textContent = `⏱ ${info.departure} - ${info.arrival} · ${compoVisual(effectiveCompo)}`;
+    }));
   }
 
   function renderLiveFeed(trainNumber){
@@ -27735,11 +28558,11 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     titleEl.textContent = train ? `Retours voyageurs — ${train.label}` : 'Flux voyageurs';
     let items = [];
     if (train){
-      const signals = getSignalsForTrain(train.trainNumber).map((it)=>({ kind:'signal', ts:it.ts, pseudo:it.pseudo, text:`${formatSignalTypeLabel(it.signalType)}${it.station ? ` — ${it.station}` : ''}${it.detail ? ` — ${it.detail}` : ''}` }));
+      const signals = getSignalsForTrain(train.trainNumber).map((it)=>({ kind:'signal', ts:it.ts, pseudo:it.pseudo, text:`${signalDisplayLabel(it)}${it.station ? ` — ${it.station}` : ''}${it.detail ? ` — ${it.detail}` : ''}` }));
       const comments = getWallCommentsForTrain(train.trainNumber).map((it)=>({ kind:'comment', ts:it.ts, pseudo:it.pseudo || 'Voyageur', text: String(it.text || '') }));
       items = [...signals, ...comments].sort((a,b)=> Number(b.ts||0) - Number(a.ts||0)).slice(0, 30);
     } else {
-      items = (Array.isArray(COMMUNITY.signals) ? COMMUNITY.signals : []).slice(0, 30).map((it)=>({ kind:'signal', ts:it.ts, pseudo:it.pseudo, text:`${it.trainNumber ? `TER ${it.trainNumber} — ` : ''}${formatSignalTypeLabel(it.signalType)}${it.station ? ` — ${it.station}` : ''}${it.detail ? ` — ${it.detail}` : ''}` }));
+      items = (Array.isArray(COMMUNITY.signals) ? COMMUNITY.signals : []).slice(0, 30).map((it)=>({ kind:'signal', ts:it.ts, pseudo:it.pseudo, text:`${it.trainNumber ? `TER ${it.trainNumber} — ` : ''}${signalDisplayLabel(it)}${it.station ? ` — ${it.station}` : ''}${it.detail ? ` — ${it.detail}` : ''}` }));
     }
     countEl.textContent = String(items.length);
     if (!items.length){
@@ -27758,6 +28581,94 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     renderLiveFeed(COMMUNITY.selectedTrain || (COMMUNITY.liveTrains[0]?.trainNumber || ''));
   }
 
+  async function renderTrainDetail(trainNumber){
+    const key = normalizeKey(trainNumber || COMMUNITY.selectedTrain);
+    const title = $id('lbTrainDetailTitle');
+    const route = $id('lbTrainDetailRoute');
+    const cause = $id('lbTrainDetailCause');
+    const stopsEl = $id('lbTrainDetailStops');
+    const train = COMMUNITY.liveTrains.find((it)=> normalizeKey(it.trainNumber) === key);
+    if (!title || !route || !stopsEl || !train) return;
+    title.textContent = `Fiche ${train.label}`;
+    route.textContent = train.route;
+    if (cause){
+      const txt = String(train.sncfCause || '').trim();
+      if ((train.statusClass === 'delay' || train.statusClass === 'cancel') && txt){
+        cause.hidden = false;
+        cause.textContent = `${train.statusClass === 'cancel' ? 'Suppression' : 'Retard'} : ${txt}`;
+      } else {
+        cause.hidden = true;
+        cause.textContent = '';
+      }
+    }
+
+    let stops = Array.isArray(train.stops) ? train.stops.filter(Boolean) : [];
+    const info = await getLiveTrainStaticInfo(train.trainNumber);
+    if (info?.stops?.length) stops = info.stops;
+    const stopRows = Array.isArray(info?.stopRows) && info.stopRows.length
+      ? info.stopRows
+      : stops.map((name)=>({ name, time:'—' }));
+    if (!stops.length){
+      stopsEl.innerHTML = '<div class="lb-live-empty">Aucun arrêt disponible.</div>';
+      return;
+    }
+    const signals = getSignalsForTrain(train.trainNumber);
+    const propagatedByStop = buildPropagatedSignalsByStop(stopRows.map((s)=> s.name), signals);
+    stopsEl.innerHTML = stopRows.map((row)=>{
+      const stopName = row?.name || '';
+      const stopKey = String(stopName || '').toLowerCase();
+      const stopSignals = signals.filter((s)=> String(s.station || '').toLowerCase() === stopKey);
+      const propagated = propagatedByStop.get(stopKey) || null;
+      const baseTime = String(row?.time || '—');
+      const gtfsAmendedTime = String(row?.amendedTime || '—');
+      const gtfsDelayFromStop = getGtfsRtDelayForStop(train.trainNumber, stopName);
+      const gtfsDelayMin = Number.isFinite(gtfsDelayFromStop) ? gtfsDelayFromStop : Number(row?.delayMin);
+      const baseMinutes = hhmmToMinutes(baseTime);
+      const amendedMinutes = hhmmToMinutes(gtfsAmendedTime);
+      const hasGtfsDelay = baseTime !== '—'
+        && gtfsAmendedTime !== '—'
+        && baseMinutes != null
+        && amendedMinutes != null
+        && amendedMinutes > baseMinutes;
+      let timeClass = 'lb-train-stop-time';
+      let timeHtml = `<span class="actual">${safeEscape(baseTime)}</span>`;
+      if (hasGtfsDelay){
+        timeClass = 'lb-train-stop-time is-delay';
+        timeHtml = `<span class="planned">${safeEscape(baseTime)}</span><span class="actual">${safeEscape(gtfsAmendedTime)}</span>`;
+      } else if (baseTime !== '—' && Number.isFinite(gtfsDelayMin) && gtfsDelayMin > 0){
+        timeClass = 'lb-train-stop-time is-delay';
+        timeHtml = `<span class="planned">${safeEscape(baseTime)}</span><span class="actual">${safeEscape(addMinutesToHHMM(baseTime, gtfsDelayMin))}</span>`;
+      } else if (baseTime !== '—' && String(propagated?.signalType || '').toLowerCase() === 'retard' && Number(propagated.delayMin || 0) > 0){
+        timeClass = 'lb-train-stop-time is-delay';
+        timeHtml = `<span class="planned">${safeEscape(baseTime)}</span><span class="actual">${safeEscape(addMinutesToHHMM(baseTime, Number(propagated.delayMin || 0)))}</span>`;
+      } else if (baseTime !== '—' && String(propagated?.signalType || '').toLowerCase() === 'suppression'){
+        timeClass = 'lb-train-stop-time is-cancel';
+        timeHtml = `<span class="actual">${safeEscape(baseTime)}</span>`;
+      }
+      const chipsList = [];
+      if (propagated){
+        const alreadyExact = stopSignals.some((s)=> String(s.id) === String(propagated.id));
+        if (!alreadyExact){
+          const t = String(propagated.signalType || '').toLowerCase().replace(/[^a-z-]/g,'');
+          chipsList.push(`<span class="lb-stop-chip lb-stop-chip--${safeEscape(t)}">${safeEscape(`${signalDisplayLabel(propagated)} · depuis ${propagated.station}`)}</span>`);
+        }
+      }
+      if (stopSignals.length){
+        chipsList.push(...stopSignals.slice(0, 6).map((s)=>{
+          const mine = isOwnSignal(s);
+          const t = String(s.signalType || '').toLowerCase().replace(/[^a-z-]/g,'');
+          const attrs = mine ? ` role="button" tabindex="0" title="Supprimer mon signalement" data-lb-delete-signal="${safeEscape(String(s.id || ''))}"` : '';
+          const chip = `<span class="lb-stop-chip lb-stop-chip--${safeEscape(t)}${mine ? ' is-own' : ''}"${attrs}>${safeEscape(signalDisplayLabel(s))}</span>`;
+          if (String(s.signalType || '').toLowerCase() !== 'information') return chip;
+          const votes = getSignalVoteSummary(s.id);
+          return `<span class="lb-stop-chip-wrap">${chip}<span class="lb-signal-vote"><button type="button" class="lb-signal-vote-btn is-up${votes.mine > 0 ? ' is-active' : ''}" data-lb-vote-signal="${safeEscape(String(s.id || ''))}" data-lb-vote-value="1">👍</button><span>${votes.up}</span><button type="button" class="lb-signal-vote-btn is-down${votes.mine < 0 ? ' is-active' : ''}" data-lb-vote-signal="${safeEscape(String(s.id || ''))}" data-lb-vote-value="-1">👎</button><span>${votes.down}</span></span></span>`;
+        }));
+      }
+      const chips = chipsList.length ? chipsList.join('') : '<span class="lb-stop-chip">Aucun signalement</span>';
+      return `<article class="lb-train-stop-item"><div class="lb-train-stop-head"><div class="lb-train-stop-name">${safeEscape(stopName)}</div><div class="${timeClass}">${timeHtml}</div></div><div class="lb-train-stop-signals">${chips}</div></article>`;
+    }).join('');
+  }
+
   function refreshSignalModal(){
     COMMUNITY.liveTrains = extractLiveTrains();
     const trainSelect = $id('lbSignalTrainSelect');
@@ -27766,15 +28677,46 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     const can = typeof isCommentingAllowed === 'function' ? isCommentingAllowed() : false;
     if (trainSelect){
       const current = normalizeKey(trainSelect.value || COMMUNITY.selectedTrain);
-      trainSelect.innerHTML = '<option value="">Choisir un train live</option>' + COMMUNITY.liveTrains.map((train)=>`<option value="${safeEscape(train.trainNumber)}">${safeEscape(train.label)} — ${safeEscape(train.route)} (${safeEscape(train.statusLabel)})</option>`).join('');
+      trainSelect.innerHTML = '<option value="">Choisir un train live</option>' + COMMUNITY.liveTrains.map((train)=>{
+        const info = COMMUNITY.staticInfoCache.get(`${normalizeKey(train.trainNumber)}_${toYmd()}`) || null;
+        const times = info ? `${info.departure} - ${info.arrival}` : '--:-- - --:--';
+        return `<option value="${safeEscape(train.trainNumber)}">${safeEscape(train.label)} — ${safeEscape(train.route)} (${safeEscape(times)})</option>`;
+      }).join('');
       if (current) trainSelect.value = current;
     }
+    hydrateSignalTrainOptions();
     updateSignalStationOptions();
     if (feedback){
-      feedback.textContent = can ? 'Le signalement sera publié dans le live voyageurs et restera distinct des données officielles SNCF.' : 'Connectez-vous pour publier un signalement. Les données officielles SNCF restent visibles en priorité.';
+      feedback.textContent = can
+        ? 'Le signalement sera publié dans le live voyageurs et restera distinct des données officielles SNCF.'
+        : 'Mode local activé : le signalement est testé en local et sera branché API ensuite.';
     }
     const submit = $id('lbSignalSubmit');
-    if (submit) submit.disabled = !can;
+    if (submit) submit.disabled = false;
+    updateSignalTypeUI();
+  }
+
+  async function hydrateSignalTrainOptions(){
+    const trainSelect = $id('lbSignalTrainSelect');
+    if (!trainSelect || !COMMUNITY.liveTrains.length) return;
+    await Promise.all(COMMUNITY.liveTrains.slice(0, 30).map(async (train)=>{
+      const info = await getLiveTrainStaticInfo(train.trainNumber);
+      const option = trainSelect.querySelector(`option[value="${String(train.trainNumber)}"]`);
+      if (!option || !info) return;
+      option.textContent = `${train.label} — ${train.route} (${info.departure} - ${info.arrival})`;
+    }));
+  }
+
+  function updateSignalTypeUI(){
+    const delayWrap = $id('lbSignalDelayWrap');
+    const stationWrap = $id('lbSignalStationWrap');
+    if (delayWrap){
+      delayWrap.classList.toggle('is-visible', COMMUNITY.selectedSignalType === 'retard');
+    }
+    const needStation = COMMUNITY.selectedSignalType !== 'information' || COMMUNITY.selectedInfoTag === 'forces-ordre';
+    if (stationWrap){
+      stationWrap.classList.toggle('is-hidden', !needStation);
+    }
   }
 
   function updateSignalStationOptions(){
@@ -27790,35 +28732,48 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   async function publishSignal(){
     const trainSelect = $id('lbSignalTrainSelect');
     const stationSelect = $id('lbSignalStationSelect');
+    const delaySelect = $id('lbSignalDelaySelect');
     const detailEl = $id('lbSignalDetail');
     const feedback = $id('lbSignalFeedback');
     const submit = $id('lbSignalSubmit');
     const trainKey = normalizeKey(trainSelect?.value || '');
     const signalType = COMMUNITY.selectedSignalType;
     const station = String(stationSelect?.value || '').trim();
+    const delayMin = Number(delaySelect?.value || 0);
+    const infoTag = COMMUNITY.selectedInfoTag;
+    const accountId = getCurrentPresenceIdentity();
     const detail = String(detailEl?.value || '').trim().slice(0, 180);
+    const needsStation = signalType !== 'information' || infoTag === 'forces-ordre';
     if (!trainKey){ if (feedback) feedback.textContent = 'Choisissez un train live.'; return; }
     if (!signalType){ if (feedback) feedback.textContent = 'Choisissez un type de signalement.'; return; }
-    if (typeof isCommentingAllowed === 'function' && !isCommentingAllowed()){
-      if (feedback) feedback.textContent = 'Connectez-vous pour publier un signalement.';
-      return;
-    }
+    if (needsStation && !station){ if (feedback) feedback.textContent = 'Choisissez la gare concernée.'; return; }
+    if (signalType === 'retard' && !(delayMin > 0)){ if (feedback) feedback.textContent = 'Choisissez un retard.'; return; }
+    if (signalType === 'information' && !infoTag){ if (feedback) feedback.textContent = 'Choisissez une information prédéfinie.'; return; }
     const train = COMMUNITY.liveTrains.find((it)=> normalizeKey(it.trainNumber) === trainKey);
     const label = train?.label || `TER ${trainKey}`;
-    const message = `[${signalType.toUpperCase().replace(/-/g,' ')}] ${label}${station ? ` [${station}]` : ''}${detail ? ` — ${detail}` : ''}`;
+    const baseDetail = signalType === 'retard'
+      ? `Retard +${delayMin} min${detail ? ` — ${detail}` : ''}`
+      : signalType === 'suppression'
+        ? `Train supprimé à l'arrêt${detail ? ` — ${detail}` : ''}`
+        : signalType === 'a-lheure'
+          ? `Train à l'heure${detail ? ` — ${detail}` : ''}`
+          : `${INFO_TAG_LABELS[infoTag] || 'Information'}${detail ? ` — ${detail}` : ''}`;
+    const message = `[${signalType.toUpperCase().replace(/-/g,' ')}] ${label}${(needsStation && station) ? ` [${station}]` : ''} — ${baseDetail}`;
     try{
       if (submit) submit.disabled = true;
       if (feedback) feedback.textContent = 'Publication du signalement…';
       const res = await fetchCommentsApi('', {
         method:'POST',
         headers:{ 'Content-Type':'application/json' },
-        body: JSON.stringify({ message, scope:'signals', train_number: trainKey, station, signal_type: signalType })
+        body: JSON.stringify({ message, scope:'signals', train_number: trainKey, station: needsStation ? station : '', signal_type: signalType, delay_min: delayMin || null, info_tag: infoTag || null, account_id: accountId })
       });
       let data = null;
       try { data = await res.json(); } catch(_){ }
       if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
       if (detailEl) detailEl.value = '';
+      if (delaySelect) delaySelect.value = '';
       COMMUNITY.selectedSignalType = '';
+      COMMUNITY.selectedInfoTag = '';
       document.querySelectorAll('.lb-signal-type.is-selected').forEach((btn)=> btn.classList.remove('is-selected'));
       if (feedback) feedback.textContent = 'Signalement publié ✅';
       await loadSignals();
@@ -27826,10 +28781,105 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       openCommunityModal('lbLiveModal');
       renderLiveFeed(trainKey);
     }catch(err){
+      const localItem = normalizeSignalItem({
+        message,
+        pseudo: window.currentUser?.pseudo || window.lbPrefsCache?.pseudo || 'Voyageur',
+        train_number: trainKey,
+        station: needsStation ? station : '',
+        signal_type: signalType,
+        delay_min: delayMin || 0,
+        info_tag: infoTag || '',
+        account_id: accountId,
+        created_at: Date.now()
+      });
+      if (localItem){
+        saveLocalSignal(localItem);
+        await loadSignals();
+        if (detailEl) detailEl.value = '';
+        if (delaySelect) delaySelect.value = '';
+        COMMUNITY.selectedSignalType = '';
+        COMMUNITY.selectedInfoTag = '';
+        updateSignalTypeUI();
+        closeCommunityModal('lbSignalModal');
+        openCommunityModal('lbLiveModal');
+        renderLiveFeed(trainKey);
+        return;
+      }
       if (feedback) feedback.textContent = err?.message || 'Impossible de publier le signalement.';
     }finally{
-      if (submit) submit.disabled = !(typeof isCommentingAllowed === 'function' ? isCommentingAllowed() : false);
+      if (submit) submit.disabled = false;
     }
+  }
+
+  async function publishPresence(trainNumber){
+    const key = normalizeKey(trainNumber);
+    if (!key) return;
+    const existing = getMyPresenceToday();
+    if (existing && normalizeKey(existing.trainNumber) === key){
+      await clearMyPresence();
+      return;
+    }
+    if (existing && normalizeKey(existing.trainNumber) !== key){
+      await clearMyPresence();
+    }
+    const accountId = getCurrentPresenceIdentity();
+    const payload = { message: `[PRESENCE] TER ${key} — ${toIsoDay()}`, scope:'presence', train_number:key, account_id: accountId };
+    try{
+      const res = await fetchCommentsApi('', {
+        method:'POST',
+        headers:{ 'Content-Type':'application/json' },
+        body: JSON.stringify(payload)
+      });
+      let data = null;
+      try { data = await res.json(); } catch(_){ }
+      if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
+      await loadPresences();
+      refreshLiveModal();
+    }catch(err){
+      const localItem = normalizePresenceItem({
+        created_at: Date.now(),
+        train_number: key,
+        pseudo: window.currentUser?.pseudo || window.lbPrefsCache?.pseudo || 'Voyageur',
+        account_id: accountId
+      });
+      if (localItem){
+        saveLocalPresence(localItem);
+        loadPresences();
+        refreshLiveModal();
+      }else{
+        console.warn('Impossible de publier la présence train', err);
+      }
+    }
+  }
+
+  async function clearMyPresence(){
+    const mine = getMyPresenceToday();
+    if (!mine) return;
+    try{
+      if (mine.id){
+        const deleteRes = await fetchCommentsApi(`/${encodeURIComponent(String(mine.id))}`, { method:'DELETE' });
+        if (!deleteRes.ok) throw new Error(`HTTP ${deleteRes.status}`);
+      }
+    }catch(_){}
+    removeLocalPresenceById(mine.id);
+    COMMUNITY.presences = (Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences : []).filter((it)=> String(it.id) !== String(mine.id));
+    refreshCommunityViews();
+    refreshLiveModal();
+  }
+
+  async function deleteOwnSignal(signalId){
+    const sig = (Array.isArray(COMMUNITY.signals) ? COMMUNITY.signals : []).find((it)=> String(it.id) === String(signalId));
+    if (!sig || !isOwnSignal(sig)) return;
+    try{
+      if (sig.id){
+        const res = await fetchCommentsApi(`/${encodeURIComponent(String(sig.id))}`, { method:'DELETE' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      }
+    }catch(_){}
+    removeLocalSignalById(sig.id);
+    COMMUNITY.signals = (Array.isArray(COMMUNITY.signals) ? COMMUNITY.signals : []).filter((it)=> String(it.id) !== String(sig.id));
+    refreshCommunityViews();
+    renderTrainDetail(COMMUNITY.selectedTrain);
   }
 
   document.addEventListener('click', (e)=>{
@@ -27840,7 +28890,13 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     const closeBtn = e.target.closest('[data-lb-community-close]');
     if (closeBtn){ e.preventDefault(); closeCommunityModal(closeBtn.getAttribute('data-lb-community-close')); return; }
     const viewTrainBtn = e.target.closest('[data-lb-view-train]');
-    if (viewTrainBtn){ COMMUNITY.selectedTrain = normalizeKey(viewTrainBtn.getAttribute('data-lb-view-train')); renderLiveFeed(COMMUNITY.selectedTrain); return; }
+    if (viewTrainBtn){
+      COMMUNITY.selectedTrain = normalizeKey(viewTrainBtn.getAttribute('data-lb-view-train'));
+      renderLiveFeed(COMMUNITY.selectedTrain);
+      renderTrainDetail(COMMUNITY.selectedTrain);
+      openCommunityModal('lbTrainDetailModal');
+      return;
+    }
     const signalTrainBtn = e.target.closest('[data-lb-signal-train]');
     if (signalTrainBtn){
       COMMUNITY.selectedTrain = normalizeKey(signalTrainBtn.getAttribute('data-lb-signal-train'));
@@ -27848,6 +28904,44 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       const trainSelect = $id('lbSignalTrainSelect');
       if (trainSelect) trainSelect.value = COMMUNITY.selectedTrain;
       updateSignalStationOptions();
+      return;
+    }
+    const presenceBtn = e.target.closest('[data-lb-presence-train]');
+    if (presenceBtn){
+      e.preventDefault();
+      publishPresence(presenceBtn.getAttribute('data-lb-presence-train'));
+      return;
+    }
+    const infoQuickBtn = e.target.closest('.lb-info-quick-btn');
+    if (infoQuickBtn){
+      e.preventDefault();
+      COMMUNITY.selectedInfoTag = infoQuickBtn.getAttribute('data-info-tag') || '';
+      document.querySelectorAll('.lb-info-quick-btn').forEach((btn)=> btn.classList.toggle('is-selected', btn === infoQuickBtn));
+      closeCommunityModal('lbInfoQuickModal');
+      const feedback = $id('lbSignalFeedback');
+      if (feedback) feedback.textContent = `Information sélectionnée : ${INFO_TAG_LABELS[COMMUNITY.selectedInfoTag] || COMMUNITY.selectedInfoTag}`;
+      updateSignalTypeUI();
+      return;
+    }
+    const liveCard = e.target.closest('.lb-live-card');
+    if (liveCard && !e.target.closest('button,[data-lb-delete-signal]')){
+      const trainNo = liveCard.getAttribute('data-lb-live-train');
+      COMMUNITY.selectedTrain = normalizeKey(trainNo);
+      renderTrainDetail(COMMUNITY.selectedTrain);
+      openCommunityModal('lbTrainDetailModal');
+      return;
+    }
+    const deleteSignalChip = e.target.closest('[data-lb-delete-signal]');
+    if (deleteSignalChip){
+      e.preventDefault();
+      deleteOwnSignal(deleteSignalChip.getAttribute('data-lb-delete-signal'));
+      return;
+    }
+    const voteBtn = e.target.closest('[data-lb-vote-signal]');
+    if (voteBtn){
+      e.preventDefault();
+      setSignalVote(voteBtn.getAttribute('data-lb-vote-signal'), Number(voteBtn.getAttribute('data-lb-vote-value') || 1));
+      renderTrainDetail(COMMUNITY.selectedTrain);
       return;
     }
     if (e.target.classList.contains('lb-community-modal')){
@@ -27864,6 +28958,13 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     if (!typeBtn) return;
     COMMUNITY.selectedSignalType = typeBtn.getAttribute('data-signal-type') || '';
     document.querySelectorAll('.lb-signal-type').forEach((btn)=> btn.classList.toggle('is-selected', btn === typeBtn));
+    if (COMMUNITY.selectedSignalType === 'information'){
+      openCommunityModal('lbInfoQuickModal');
+    }else{
+      COMMUNITY.selectedInfoTag = '';
+      document.querySelectorAll('.lb-info-quick-btn').forEach((btn)=> btn.classList.remove('is-selected'));
+    }
+    updateSignalTypeUI();
   });
 
   const signalSubmit = $id('lbSignalSubmit');
@@ -27886,9 +28987,15 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   window.addEventListener('gtfsrt:loaded', ()=>{ refreshCommunityViews(); });
   window.addEventListener('load', ()=>{
     refreshCommunityViews();
-    setTimeout(()=>{ loadSignals(); }, 1000);
+    setTimeout(()=>{
+      loadSignals();
+      loadPresences();
+    }, 1000);
   });
-  setInterval(loadSignals, 8000);
+  setInterval(()=>{
+    loadSignals();
+    loadPresences();
+  }, 8000);
 
   window.lbCommunityLive = {
     refresh: refreshCommunityViews,


### PR DESCRIPTION
### Motivation
- Enhance the "LIVE voyageurs" experience by surfacing traveler signalements, presence counts and quick info tags alongside GTFS-RT train data. 
- Allow users to post and manage local/offline signals and presences when the backend API is unavailable, and persist them in `localStorage` per day. 
- Improve the train card and modal UX with richer status, composition, GTFS static times and clearer visual states. 

### Description
- UI and styling: adjust close button position and add many new styles and classes for `.lb-live-card`, status variants, chips, presence buttons and new components like `.lb-info-quick-grid`, `.lb-train-detail-stops`, `.lb-stop-chip` and vote buttons; replace textual close glyphs with styled buttons. 
- New GTFS dataset: add `sncf-carte` to `GTFS_RT_DATASETS` and prefer its payload when available via `getRawLiveTrainPayload()`. 
- New modals and controls: add `lbInfoQuickModal` (quick info tags) and `lbTrainDetailModal` (detailed stop list), extend `lbSignalModal` with `lbSignalDelayWrap` and station handling, and wire quick-info selection. 
- Community JS features: implement local signal/presence storage (`localSignalStorageKey`, `localPresenceStorageKey`), normalization helpers, presence publish/clear (`publishPresence`, `clearMyPresence`), vote storage (`lb_signal_votes_v1`), signal CRUD (including local fallback save on POST failure), signal/presence loaders (`loadSignals`, `loadPresences`) and periodic refresh integration. 
- Rendering and data: enrich `renderLiveTrainCards`, `renderLiveFeed`, add `renderTrainDetail`, propagate traveler disruptions to stops, show GTFS static times via `getLiveTrainStaticInfo` and `hydrateLiveTrainStaticInfos`, display effective composition (from `compoData` or info tags) and integrate SNCF disruption cause extraction. 
- Event handlers: add handlers for presence toggles, info quick buttons, voting, deleting own signals, opening train detail modal and binding the signal publish button; wrap existing `renderMessages` to refresh community views. 
- Misc: add utility helpers (`toYmd`, `toIsoDay`, `formatGtfsHHMM`, `addMinutesToHHMM`, etc.), extend `COMMUNITY` state with `presences`, `localSignals`, `staticInfoCache`, and update initial load to call both `loadSignals` and `loadPresences` and an interval to refresh both. 

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c44f6b2bfc832dbb5f73638860d9a9)