### PR TITLE
Improve live UI, presence handling, GTFS cache behavior and signal voting UX

### DIFF
--- a/index34.html
+++ b/index34.html
@@ -1163,6 +1163,8 @@ body {
   font-weight:800;
   color:#dff8ff;
   opacity:.92;
+  animation:none !important;
+  transition:none !important;
 }
 .lb-live-user-alert{
   margin-top:1px;
@@ -1245,7 +1247,9 @@ body {
   height: 18px;
   width: auto;
   display:block;
-  filter: drop-shadow(0 0 3px rgba(0,240,255,.35));
+  filter:none;
+  animation:none !important;
+  transition:none !important;
 }
 .lb-live-presence{
   margin-top:4px;
@@ -1479,22 +1483,35 @@ body {
 .lb-signal-vote{
   display:inline-flex;
   align-items:center;
-  gap:3px;
-  font-size:.64rem;
+  gap:2px;
+  font-size:.68rem;
 }
 .lb-signal-vote-btn{
-  border:none;
-  background:transparent;
+  all:unset;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
   color:#cfe8f5;
   cursor:pointer;
-  font-size:.72rem;
+  font-size:.84rem;
   line-height:1;
-  padding:0 2px;
 }
 .lb-signal-vote-btn.is-up{ color:#22c55e; }
 .lb-signal-vote-btn.is-down{ color:#ff4d6d; }
 .lb-signal-vote-btn.is-active{
   text-shadow:0 0 8px currentColor;
+}
+.lb-signal-vote-btn:focus-visible{
+  outline:1px solid rgba(110,231,255,.7);
+  outline-offset:2px;
+  border-radius:4px;
+}
+.lb-signal-vote-count{
+  font-size:.68rem;
+  color:#cfe8f5;
+  opacity:.92;
+  min-width:1.4ch;
+  text-align:center;
 }
 .home-card[aria-label="Mur de commentaires"] .live-wall-card--home,
 .home-card[aria-label="Mur de commentaires"],
@@ -9540,16 +9557,16 @@ body{
       <h2 id="homePunctCardTitle">Ponctualité</h2>
       <div id="homePunctualityChartHost" class="home-punct-chart-host"></div>
     </article>
-  </div>
 
-  <article class="home-card" aria-label="Mes Bétaillères favorites">
-    <h2>Mes Bétaillères favorites</h2>
-<div class="home-fav-preview" id="homeFavSlot"></div>
-<div class="home-fav-wrap" id="homeFavLoginCta" style="display:none;">
-      <p>⭐ Connecte-toi pour afficher tes bétaillères favorites (matin/soir), avec voies et retards live.</p>
-      <button class="home-action" id="homeAccountBtn" type="button">Se connecter</button>
-    </div>
-  </article>
+    <article class="home-card" aria-label="Mes Bétaillères favorites">
+      <h2>Mes Bétaillères favorites</h2>
+      <div class="home-fav-preview" id="homeFavSlot"></div>
+      <div class="home-fav-wrap" id="homeFavLoginCta" style="display:none;">
+        <p>⭐ Connecte-toi pour afficher tes bétaillères favorites (matin/soir), avec voies et retards live.</p>
+        <button class="home-action" id="homeAccountBtn" type="button">Se connecter</button>
+      </div>
+    </article>
+  </div>
 
 </section>
 
@@ -17794,6 +17811,7 @@ const GTFS_RT_DATASETS = [
 
 const GTFS_RT_CACHE_KEY = 'gtfsRtMerged';
 const GTFS_RT_CACHE_MAX_AGE = 90 * 1000;
+const GTFS_RT_USE_CACHED_FIRST = false;
 
 function hydrateGtfsRetardsFromCache(){
   const cached = lbCacheRead(GTFS_RT_CACHE_KEY, GTFS_RT_CACHE_MAX_AGE);
@@ -18108,7 +18126,7 @@ for (const base of sources) {
 }
 
 async function loadGtfsRetards({ forceFresh = false, useCachedFirst = false } = {}) {
-  if (useCachedFirst && !forceFresh) hydrateGtfsRetardsFromCache();
+  if (GTFS_RT_USE_CACHED_FIRST && useCachedFirst && !forceFresh) hydrateGtfsRetardsFromCache();
   const datasetResults = [];
   const rawByDataset = {};
   let lastErr = null;
@@ -18174,7 +18192,7 @@ async function refreshLiveDataInBackground({ forceFresh = false } = {}){
       loadCompoData({ forceFresh, background: true }),
       loadVoiesByTrain({ forceFresh, onlyIfChanged: true }),
       (typeof loadCflVoiesByTrain === 'function' ? loadCflVoiesByTrain({ forceFresh, onlyIfChanged: true }) : Promise.resolve()),
-      loadGtfsRetards({ forceFresh, useCachedFirst: !forceFresh })
+      loadGtfsRetards({ forceFresh, useCachedFirst: false })
     ]);
   } finally {
     LB_BG_REFRESH_STATE.inFlight = false;
@@ -18203,7 +18221,7 @@ window.addEventListener('load', () => {
 
   setTimeout(() => {
     lbRunInBackground(() => {
-      loadGtfsRetards({ forceFresh: false, useCachedFirst: true })
+      loadGtfsRetards({ forceFresh: true, useCachedFirst: false })
         .catch(err => console.warn("GTFS-RT temporairement indisponible:", err));
     });
   }, 420);
@@ -21024,6 +21042,19 @@ function scheduleWeatherAfterTableSettled(){
     if (switchBtn) switchBtn.textContent = "Créer un compte";
   };
   
+  function updateHomeWelcomeLine(){
+    try{
+      const line = document.getElementById('homeWelcomeLine');
+      if (!line) return;
+      const pseudoFromPrefs = String(window.lbPrefsCache?.pseudo || '').trim();
+      const pseudoFromUser = String(window.currentUser?.pseudo || window.currentUser?.username || '').trim();
+      const pseudo = pseudoFromPrefs || pseudoFromUser;
+      line.textContent = pseudo
+        ? `Bienvenue ${pseudo} dans la bétaillère`
+        : 'Bienvenue dans la bétaillère';
+    }catch(_){}
+  }
+
   const applyPreferences = (prefs, options = {}) => {
     if (!prefs) return;
     applyCustomRapidPresets(prefs);
@@ -21037,15 +21068,7 @@ function scheduleWeatherAfterTableSettled(){
     if (pseudoInput) pseudoInput.value = (prefs.pseudo || "").trim();
     if (favAM) favAM.value = prefs.favoriteMorningTrain || "";
     if (favPM) favPM.value = prefs.favoriteEveningTrain || "";
-    try{
-      const line = document.getElementById('homeWelcomeLine');
-      if (line){
-        const pseudo = String(prefs.pseudo || '').trim();
-        line.textContent = pseudo
-          ? `Bienvenue ${pseudo} dans la bétaillère`
-          : 'Bienvenue dans la bétaillère';
-      }
-    }catch(e){}
+    updateHomeWelcomeLine();
     // Gare favorite (départ/arrivée) -> utilisée comme valeur par défaut dans l'onglet Affluence
     const favFrom = $("lbFavFromStation");
     const favTo   = $("lbFavToStation");
@@ -22314,10 +22337,7 @@ if (statsEl){
       }
       lbPrefsCache = null;
       window.lbPrefsCache = null;
-	  try {
-        const line = document.getElementById('homeWelcomeLine');
-        if (line) line.textContent = 'Bienvenue dans votre bétaillère Nancy–Metz–Lux';
-      } catch(e) {}
+      try { updateHomeWelcomeLine(); } catch(e) {}
       try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
       lbPrefsAppliedOnce = false;
       customRapidPresets.AM = null;
@@ -23194,7 +23214,7 @@ if (statsEl){
       if (!canLiveRetards()) return;
       if (typeof loadGtfsRetards === 'function') {
         // Force un fetch live à intervalle court, sans attendre un refresh manuel.
-        await loadGtfsRetards({ forceFresh: false, useCachedFirst: true });
+        await loadGtfsRetards({ forceFresh: true, useCachedFirst: false });
       }
 
       // Sécurité: met à jour explicitement le trafic Home même si l'event custom est raté.
@@ -23567,12 +23587,6 @@ async function updateHomeTrafficStatus(){
 
   try{
     if (window.retardsGTFS_RAW){
-      __lbUpdateHomeTrafficUI({
-        rawByDataset: window.retardsGTFS_RAW?.['sncf-nml'] ? window.retardsGTFS_RAW : null,
-        raw: window.retardsGTFS_RAW
-      });
-      hadImmediateData = true;
-    } else if (typeof hydrateGtfsRetardsFromCache === 'function' && hydrateGtfsRetardsFromCache()) {
       __lbUpdateHomeTrafficUI({
         rawByDataset: window.retardsGTFS_RAW?.['sncf-nml'] ? window.retardsGTFS_RAW : null,
         raw: window.retardsGTFS_RAW
@@ -27341,6 +27355,40 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   }
 }
 </style>
+<style id="home-desktop-symmetry-v2">
+@media (min-width: 1025px){
+  #home.home-section > .home-dashboard{
+    display:grid !important;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) !important;
+    grid-template-areas:
+      "welcome welcome"
+      "favorites traffic"
+      "comments weather"
+      "comments punct" !important;
+    align-items: stretch !important;
+    gap: 14px !important;
+  }
+  #homeWelcomeLine{
+    grid-area: welcome !important;
+    justify-self: center !important;
+    width: fit-content !important;
+    max-width: min(760px, 92vw) !important;
+    margin: 0 auto 2px !important;
+    text-align: center !important;
+  }
+  .home-card[aria-label="Mes Bétaillères favorites"]{ grid-area: favorites !important; min-height: 210px !important; }
+  .home-card[aria-label="Info trafic"]{ grid-area: traffic !important; min-height: 210px !important; }
+  .home-card[aria-label="Mur de commentaires"]{ grid-area: comments !important; min-height: 250px !important; }
+  .home-card[aria-label="Météo sur votre ligne"]{ grid-area: weather !important; min-height: 170px !important; }
+  .home-punct-card{ grid-area: punct !important; min-height: 130px !important; }
+  .home-card[aria-label="Mes Bétaillères favorites"] .home-fav-meta{
+    white-space: normal !important;
+    overflow: visible !important;
+    text-overflow: clip !important;
+    line-height: 1.2 !important;
+  }
+}
+</style>
 <script id="home-premium-harmonisation-final-script">
 (() => {
   const motionOk = !window.matchMedia || !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -27940,7 +27988,6 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
             <button type="button" class="lb-signal-type" data-signal-type="information">ℹ️ Information</button>
             <button type="button" class="lb-signal-type" data-signal-type="a-lheure">✅ À l'heure</button>
           </div>
-          <textarea id="lbSignalDetail" maxlength="180" placeholder="Ajouter un détail facultatif : forte affluence, composition simple, climatisation HS, train non parti..."></textarea>
           <div class="lb-signal-help" id="lbSignalFeedback">Connectez-vous pour publier un signalement. Les données officielles SNCF restent visibles en priorité.</div>
           <button type="button" id="lbSignalSubmit" class="lb-signal-submit">Publier le signalement</button>
         </div>
@@ -28119,7 +28166,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   const compoVisualHtml = (code)=>{
     const count = code === 'UM3' ? 3 : code === 'UM' ? 2 : code === 'US' ? 1 : 0;
     if (!count) return safeEscape(compoVisual(code));
-    const img = '<img class="lb-compo-icon" src="' + COMPO_ICON_SRC + '" alt="Rame TER" loading="lazy" decoding="async" onerror="this.onerror=null;this.replaceWith(document.createTextNode(\'🚆\'));">';
+    const img = '<img class="lb-compo-icon" src="' + COMPO_ICON_SRC + '" alt="Rame TER" loading="eager" decoding="async" onerror="this.onerror=null;this.replaceWith(document.createTextNode(\'🚆\'));">';
     return '<span class="lb-compo-inline" aria-label="' + count + ' rame(s)">' + img.repeat(count) + '</span>';
   };
   const buildLiveRouteLineHtml = (train, info)=>{
@@ -28154,6 +28201,18 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   };
   const localSignalStorageKey = ()=> `lb_local_signals_${toIsoDay()}`;
   const localPresenceStorageKey = ()=> `lb_local_presence_${toIsoDay()}`;
+  const localPresenceOptInKey = ()=> `lb_presence_optin_${toIsoDay()}`;
+
+  function isPresenceOptedInToday(){
+    try { return window.sessionStorage.getItem(localPresenceOptInKey()) === '1'; } catch(_) { return false; }
+  }
+
+  function setPresenceOptInToday(enabled){
+    try {
+      if (enabled) window.sessionStorage.setItem(localPresenceOptInKey(), '1');
+      else window.sessionStorage.removeItem(localPresenceOptInKey());
+    } catch(_){ }
+  }
   const localDeviceAccountKey = 'lb_local_account_id';
   const signalVotesStorageKey = 'lb_signal_votes_v1';
 
@@ -28328,6 +28387,10 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       const data = await res.json();
       const list = Array.isArray(data) ? data : (Array.isArray(data?.comments) ? data.comments : []);
       COMMUNITY.presences = list.map(normalizePresenceItem).filter(Boolean).sort((a,b)=> Number(b.ts||0) - Number(a.ts||0)).slice(0, 500);
+      if (!isPresenceOptedInToday()){
+        const mine = getMyPresenceToday();
+        if (mine) await clearMyPresence();
+      }
     }catch(err){
       console.warn('Impossible de charger les présences voyageurs', err);
       COMMUNITY.presences = Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences : [];
@@ -28522,8 +28585,8 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       if (normalizeKey(it.trainNumber) !== key) return;
       const day = toIsoDay(new Date(it.ts || Date.now()));
       if (day !== today) return;
-      const identity = String(it.accountId || it.pseudo || '').trim().toLowerCase();
-      const uniqKey = `${identity}|${day}|${key}`;
+      const identity = String(it.accountId || it.pseudo || it.id || '').trim().toLowerCase();
+      const uniqKey = `${identity || `presence:${String(it.id || '').trim()}`}|${day}|${key}`;
       if (!map.has(uniqKey)) map.set(uniqKey, it);
     });
     return { count: map.size, today };
@@ -28554,9 +28617,19 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     const today = toIsoDay();
     return (Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences : []).find((it)=>{
       const day = toIsoDay(new Date(it.ts || Date.now()));
-      const identity = normalizeIdentity(it.accountId || it.pseudo);
+      const identity = normalizeIdentity(it.accountId || it.pseudo || it.id);
       return day === today && identity === ident;
     }) || null;
+  }
+
+  function getMyPresencesToday(){
+    const ident = normalizeIdentity(getCurrentPresenceIdentity());
+    const today = toIsoDay();
+    return (Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences : []).filter((it)=>{
+      const day = toIsoDay(new Date(it.ts || Date.now()));
+      const identity = normalizeIdentity(it.accountId || it.pseudo || it.id);
+      return day === today && identity === ident;
+    });
   }
 
   function hasCurrentUserPresence(trainNumber){
@@ -28706,9 +28779,16 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   }
 
   function buildSignalVoteMarkup(signal){
-    if (!signal || String(signal.signalType || '').toLowerCase() !== 'information') return '';
+    const rawType = String(signal?.signalType || '').toLowerCase().trim();
+    const type = rawType
+      .normalize('NFD')
+      .replace(/[̀-ͯ]/g, '')
+      .replace(/[^a-z-]/g, '')
+      .replace(/a-lheure|alheure|a-l-heure/g, 'a-lheure');
+    if (!signal || !new Set(['information','retard','suppression','a-lheure']).has(type)) return '';
     const votes = getSignalVoteSummary(signal);
-    return `<span class="lb-signal-vote"><button type="button" class="lb-signal-vote-btn is-up${votes.mine > 0 ? ' is-active' : ''}" data-lb-vote-signal="${safeEscape(String(signal.id || ''))}" data-lb-vote-value="1" aria-label="Confirmer l'information">👍</button><span>${votes.up}</span><button type="button" class="lb-signal-vote-btn is-down${votes.mine < 0 ? ' is-active' : ''}" data-lb-vote-signal="${safeEscape(String(signal.id || ''))}" data-lb-vote-value="-1" aria-label="Signaler une information douteuse">👎</button><span>${votes.down}</span></span>`;
+    const score = Number(votes.up || 0) - Number(votes.down || 0);
+    return `<span class="lb-signal-vote"><button type="button" class="lb-signal-vote-btn is-up${votes.mine > 0 ? ' is-active' : ''}" data-lb-vote-signal="${safeEscape(String(signal.id || ''))}" data-lb-vote-value="1" aria-label="Vote positif">👍</button><span class="lb-signal-vote-count">${score}</span><button type="button" class="lb-signal-vote-btn is-down${votes.mine < 0 ? ' is-active' : ''}" data-lb-vote-signal="${safeEscape(String(signal.id || ''))}" data-lb-vote-value="-1" aria-label="Vote négatif">👎</button></span>`;
   }
 
   async function submitSignalVote(signalId, value){
@@ -28832,7 +28912,11 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       const firstStationSignal = groupedSignals.find((s)=> s.station);
       if (firstStationSignal?.station) chips.push(`<span class="lb-live-chip">📍 ${safeEscape(firstStationSignal.station)}</span>`);
       const latestNonInfoSignal = groupedSignals.find((s)=> String(s?.signalType || '').toLowerCase() !== 'information');
-      if (latestNonInfoSignal) chips.push(`<span class="lb-live-chip">${safeEscape(signalDisplayLabel(latestNonInfoSignal))}</span>`);
+      if (latestNonInfoSignal){
+        const nonInfoChip = `<span class="lb-live-chip">${safeEscape(signalDisplayLabel(latestNonInfoSignal))}</span>`;
+        const nonInfoVote = buildSignalVoteMarkup(latestNonInfoSignal);
+        chips.push(nonInfoVote ? `<span class="lb-stop-chip-wrap">${nonInfoChip}${nonInfoVote}</span>` : nonInfoChip);
+      }
       const infoSignals = groupedSignals
         .filter((s)=> String(s?.signalType || '').toLowerCase() === 'information')
         .slice(0, 4);
@@ -29003,8 +29087,8 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
           const t = String(s.signalType || '').toLowerCase().replace(/[^a-z-]/g,'');
           const attrs = mine ? ` role="button" tabindex="0" title="Supprimer mon signalement" data-lb-delete-signal="${safeEscape(String(s.id || ''))}"` : '';
           const chip = `<span class="lb-stop-chip lb-stop-chip--${safeEscape(t)}${mine ? ' is-own' : ''}"${attrs}>${safeEscape(signalDisplayLabel(s))}</span>`;
-          if (String(s.signalType || '').toLowerCase() !== 'information') return chip;
-          return `<span class="lb-stop-chip-wrap">${chip}${buildSignalVoteMarkup(s)}</span>`;
+          const voteMarkup = buildSignalVoteMarkup(s);
+          return voteMarkup ? `<span class="lb-stop-chip-wrap">${chip}${voteMarkup}</span>` : chip;
         }));
       }
       const chips = chipsList.length ? chipsList.join('') : '<span class="lb-stop-chip">Aucun signalement</span>';
@@ -29076,17 +29160,14 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   async function publishSignal(){
     const trainSelect = $id('lbSignalTrainSelect');
     const stationSelect = $id('lbSignalStationSelect');
-    const delaySelect = $id('lbSignalDelaySelect');
-    const detailEl = $id('lbSignalDetail');
     const feedback = $id('lbSignalFeedback');
     const submit = $id('lbSignalSubmit');
     const trainKey = normalizeKey(trainSelect?.value || '');
     const signalType = COMMUNITY.selectedSignalType;
     const station = String(stationSelect?.value || '').trim();
-    const delayMin = Number(delaySelect?.value || 0);
+    const delayMin = Number($id('lbSignalDelaySelect')?.value || 0);
     const infoTag = COMMUNITY.selectedInfoTag;
     const accountId = getCurrentPresenceIdentity();
-    const detail = String(detailEl?.value || '').trim().slice(0, 180);
     const needsStation = signalType !== 'information' || infoTag === 'forces-ordre';
     if (!trainKey){ if (feedback) feedback.textContent = 'Choisissez un train live.'; return; }
     if (!signalType){ if (feedback) feedback.textContent = 'Choisissez un type de signalement.'; return; }
@@ -29096,13 +29177,37 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     const train = COMMUNITY.liveTrains.find((it)=> normalizeKey(it.trainNumber) === trainKey);
     const label = train?.label || `TER ${trainKey}`;
     const baseDetail = signalType === 'retard'
-      ? `Retard +${delayMin} min${detail ? ` — ${detail}` : ''}`
+      ? `Retard +${delayMin} min`
       : signalType === 'suppression'
-        ? `Train supprimé à l'arrêt${detail ? ` — ${detail}` : ''}`
+        ? `Train supprimé à l'arrêt`
         : signalType === 'a-lheure'
-          ? `Train à l'heure${detail ? ` — ${detail}` : ''}`
-          : `${INFO_TAG_LABELS[infoTag] || 'Information'}${detail ? ` — ${detail}` : ''}`;
+          ? `Train à l'heure`
+          : `${INFO_TAG_LABELS[infoTag] || 'Information'}`;
     const message = `[${signalType.toUpperCase().replace(/-/g,' ')}] ${label}${(needsStation && station) ? ` [${station}]` : ''} — ${baseDetail}`;
+
+    const publishAutoWallAlertIfNeeded = async ()=>{
+      const isSuppression = signalType === 'suppression';
+      const isMajorDelay = signalType === 'retard' && delayMin >= 15;
+      if (!isSuppression && !isMajorDelay) return;
+      const statusTxt = isSuppression ? 'signalé supprimé' : `signalé en retard +${delayMin} min`;
+      const stationTxt = station ? ` à ${station}` : '';
+      const wallMessage = `#TER${trainKey} ${statusTxt}${stationTxt} par le #betail`;
+      try{
+        await window.fetchCommentsApi('', {
+          method:'POST',
+          headers:{ 'Content-Type':'application/json' },
+          body: JSON.stringify({
+            message: wallMessage,
+            scope:'wall',
+            train_number: trainKey,
+            account_id: accountId
+          })
+        });
+        try { window.lbComments?.refresh?.(); } catch(_){}
+      }catch(err){
+        console.warn('WALL_AUTO_SIGNAL_POST_ERROR', err);
+      }
+    };
     try{
       if (submit) submit.disabled = true;
       if (feedback) feedback.textContent = 'Publication du signalement…';
@@ -29114,12 +29219,13 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       let data = null;
       try { data = await res.json(); } catch(_){ }
       if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
-      if (detailEl) detailEl.value = '';
-      if (delaySelect) delaySelect.value = '';
+      const delaySelectEl = $id('lbSignalDelaySelect');
+      if (delaySelectEl) delaySelectEl.value = '';
       COMMUNITY.selectedSignalType = '';
       COMMUNITY.selectedInfoTag = '';
       document.querySelectorAll('.lb-signal-type.is-selected').forEach((btn)=> btn.classList.remove('is-selected'));
       if (feedback) feedback.textContent = 'Signalement publié ✅';
+      await publishAutoWallAlertIfNeeded();
       await loadSignals();
       closeCommunityModal('lbSignalModal');
       openCommunityModal('lbLiveModal');
@@ -29142,8 +29248,8 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       if (localItem){
         saveLocalSignal(localItem);
         await loadSignals();
-        if (detailEl) detailEl.value = '';
-        if (delaySelect) delaySelect.value = '';
+        const delaySelectEl = $id('lbSignalDelaySelect');
+        if (delaySelectEl) delaySelectEl.value = '';
         COMMUNITY.selectedSignalType = '';
         COMMUNITY.selectedInfoTag = '';
         updateSignalTypeUI();
@@ -29161,14 +29267,14 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   async function publishPresence(trainNumber){
     const key = normalizeKey(trainNumber);
     if (!key) return;
-    const existing = getMyPresenceToday();
-    if (existing && normalizeKey(existing.trainNumber) === key){
+    setPresenceOptInToday(true);
+    const existingPresences = getMyPresencesToday();
+    const alreadyInTargetTrain = existingPresences.some((it)=> normalizeKey(it.trainNumber) === key);
+    if (alreadyInTargetTrain){
       await clearMyPresence();
       return;
     }
-    if (existing && normalizeKey(existing.trainNumber) !== key){
-      await clearMyPresence();
-    }
+    await clearMyPresence({ keepOptIn: true });
     const accountId = getCurrentPresenceIdentity();
     const payload = { message: `[PRESENCE] TER ${key} — ${toIsoDay()}`, scope:'presence', train_number:key, account_id: accountId };
     try{
@@ -29201,16 +29307,20 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     }
   }
 
-  async function clearMyPresence(){
-    const mine = getMyPresenceToday();
-    if (!mine) return;
+  async function clearMyPresence(options = {}){
+    const keepOptIn = !!options.keepOptIn;
+    if (!keepOptIn) setPresenceOptInToday(false);
+    const mineList = getMyPresencesToday();
+    if (!mineList.length) return;
     try{
-      if (mine.id){
+      for (const mine of mineList){
+        if (!mine.id) continue;
         const deleteRes = await fetchCommentsApi(`/${encodeURIComponent(String(mine.id))}`, { method:'DELETE' });
         if (!deleteRes.ok) throw new Error(`HTTP ${deleteRes.status}`);
       }
     }catch(_){ return; }
-    COMMUNITY.presences = (Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences : []).filter((it)=> String(it.id) !== String(mine.id));
+    const mineIds = new Set(mineList.map((it)=> String(it.id)));
+    COMMUNITY.presences = (Array.isArray(COMMUNITY.presences) ? COMMUNITY.presences : []).filter((it)=> !mineIds.has(String(it.id)));
     refreshCommunityViews();
     refreshLiveModal();
   }


### PR DESCRIPTION
### Motivation
- Reduce unexpected UI animations/shadows and improve desktop home layout symmetry for clearer presentation.  
- Make GTFS-RT refresh behavior more deterministic and avoid using stale cached feeds by default.  
- Harden traveler presence handling (opt-in, de-duplication) and improve community signal voting and publishing flows.  

### Description
- CSS/UI: disabled animations/filters for some icons and passenger badge, adjusted vote button sizing/gap, added focus-visible outline and `.lb-signal-vote-count`, and introduced a desktop grid (`#home-desktop-symmetry-v2`) to rebalance home dashboard columns.  
- GTFS/refresh: added `GTFS_RT_USE_CACHED_FIRST = false` and changed calls to `loadGtfsRetards` to avoid using cached-first loads in background/periodic refreshes and the initial warmup.  
- Welcome/prefs: extracted `updateHomeWelcomeLine()` and wired it into `applyPreferences()` and logout handling to consistently update the home welcome text.  
- Composition icon: switched compo image to `loading="eager"` and removed drop-shadow.  
- Presence: introduced session opt-in keys and helpers (`isPresenceOptedInToday`, `setPresenceOptInToday`) so presences are considered only after opt-in, changed presence identity/uniqueness logic, added `getMyPresencesToday()`, and updated `publishPresence()` / `clearMyPresence()` to handle multiple presence records and preserve opt-in when requested.  
- Signals & votes: normalized signal types, tightened allowed types for vote UI, improved vote markup to show aggregated score and accessible labels, show vote controls on non-information signals where relevant, and ensure vote buttons use `all:unset` with proper layout and focus styles.  
- Publishing flow: removed free-text `detail` handling, use structured fields instead, and auto-post a wall message for suppressions or major delays (>= 15 min).  
- Misc: minor HTML whitespace/folding fixes and ensured the page ends with a newline.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca71966da4832db81413409158a3df)