### PR TITLE
Intégration profil/classement compact + tooltips pseudo discrets

### DIFF
--- a/index41.html
+++ b/index41.html
@@ -5858,6 +5858,118 @@ body.modal-open{ overflow:hidden; }
   background: rgba(5,16,28,.55)
 }
 
+.lb-profile-card{
+  margin: 4px 0 12px;
+  border: 1px solid rgba(0,240,255,.28);
+  border-radius: 12px;
+  background: rgba(5,16,28,.58);
+  box-shadow: inset 0 0 12px rgba(0,220,255,.1);
+  padding: 10px;
+  display: grid;
+  gap: 8px;
+}
+.lb-profile-title{
+  font-size: .76rem;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  color: #9defff;
+}
+.lb-profile-grid{
+  display:grid;
+  grid-template-columns: repeat(2,minmax(0,1fr));
+  gap:6px;
+}
+.lb-profile-chip{
+  border:1px solid rgba(0,240,255,.2);
+  border-radius:10px;
+  background:rgba(8,18,32,.72);
+  padding:6px 8px;
+}
+.lb-profile-chip b{ display:block; font-size:.7rem; color:#8da8bc; font-weight:600; }
+.lb-profile-chip span{ display:block; margin-top:2px; font-size:.82rem; color:#e2f7ff; font-weight:700; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.lb-ranking-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+}
+.lb-ranking-filter{
+  width:auto;
+  border-radius:9px;
+  border:1px solid rgba(120,220,255,.32);
+  background:rgba(6,16,28,.8);
+  color:#dffbff;
+  font-size:.74rem;
+  padding:5px 7px;
+}
+.lb-ranking-podium{
+  display:grid;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+  gap:6px;
+  align-items:end;
+}
+.lb-ranking-podium-item{
+  border:1px solid rgba(0,240,255,.25);
+  border-radius:10px;
+  padding:6px 5px;
+  background:rgba(8,18,32,.7);
+  text-align:center;
+  min-height:56px;
+}
+.lb-ranking-podium-item.pos-1{ min-height:68px; box-shadow:0 0 12px rgba(0,240,255,.18); }
+.lb-ranking-podium-item .rank{ font-size:.68rem; color:#8fdaf2; }
+.lb-ranking-podium-item .pseudo{ font-size:.78rem; font-weight:700; color:#e6f9ff; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.lb-ranking-podium-item .meta{ font-size:.64rem; color:#a7c4d8; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.lb-ranking-list{
+  display:grid;
+  gap:4px;
+  max-height:160px;
+  overflow:auto;
+}
+.lb-ranking-row{
+  display:grid;
+  grid-template-columns:26px 1fr auto;
+  gap:6px;
+  align-items:center;
+  border:1px solid rgba(0,240,255,.14);
+  border-radius:9px;
+  padding:5px 7px;
+  background:rgba(8,18,32,.58);
+  font-size:.73rem;
+}
+.lb-ranking-row.me{ color:#8df7ff; border-color: rgba(0,240,255,.35); }
+
+.lb-pseudo-trigger{
+  display:inline-flex;
+  align-items:center;
+  max-width:140px;
+  color:inherit;
+  text-decoration:none;
+  border-bottom:1px dotted rgba(120,220,255,.3);
+  cursor:pointer;
+}
+.lb-pseudo-tooltip{
+  position:fixed;
+  z-index:3900;
+  min-width:120px;
+  max-width:170px;
+  border:1px solid rgba(0,240,255,.45);
+  background:rgba(4,14,24,.95);
+  border-radius:10px;
+  box-shadow:0 10px 24px rgba(0,0,0,.35), inset 0 0 10px rgba(0,220,255,.1);
+  padding:7px 8px;
+  font-size:.7rem;
+  line-height:1.25;
+  pointer-events:none;
+}
+.lb-pseudo-tooltip strong{
+  display:block;
+  color:#ddfbff;
+  margin-bottom:3px;
+  font-size:.74rem;
+}
+
 .lb-auth-actions{
   display: flex;
   flex-direction: column;
@@ -10127,6 +10239,26 @@ body{
       <button id="lbBtnCloseAuth" class="lb-auth-close tron-close-button" type="button" aria-label="Fermer"></button>
       <h3 id="lbAuthTitle">Mon compte</h3>
       <div id="lbAuthMsg" class="lb-auth-msg">ℹ️ Non connecté</div>
+      <div id="lbProfileTroupeau" class="lb-profile-card" style="display:none;">
+        <div class="lb-profile-title">Mon profil troupeau</div>
+        <div class="lb-profile-grid">
+          <div class="lb-profile-chip"><b>Pseudo</b><span id="lbProfilePseudo">—</span></div>
+          <div class="lb-profile-chip"><b>Grade</b><span id="lbProfileGrade">—</span></div>
+          <div class="lb-profile-chip"><b>Points</b><span id="lbProfilePoints">0 meuh</span></div>
+          <div class="lb-profile-chip"><b>Rang</b><span id="lbProfileRank">—</span></div>
+        </div>
+        <div class="lb-ranking-head">
+          <div class="lb-profile-title" style="margin:0;">Classement</div>
+          <select id="lbRankingFilter" class="lb-ranking-filter">
+            <option value="top10" selected>Top 10</option>
+            <option value="top3">Top 3</option>
+            <option value="top50">Top 50</option>
+            <option value="around">Autour de moi</option>
+          </select>
+        </div>
+        <div id="lbRankingPodium" class="lb-ranking-podium"></div>
+        <div id="lbRankingList" class="lb-ranking-list"></div>
+      </div>
       <div id="lbLoginFields" class="lb-auth-fields">
         <label for="lbEmail">Email</label>
         <input id="lbEmail" type="email" autocomplete="username" placeholder="email@exemple.fr">
@@ -21311,9 +21443,51 @@ function scheduleWeatherAfterTableSettled(){
   let lbCommentsPoller = null;
   let currentUser = null;
   window.currentUser = null;
+  const lbGamificationState = { profile: null, ranking: [], myRank: null, lastFetchAt: 0, inflight: null };
+  let lbPseudoTooltip = null;
+  let lbPseudoTooltipAnchor = null;
 
   const safePseudo = () => String(lbPrefsCache?.pseudo || '').trim().slice(0,24);
   const isCommentingAllowed = () => window.lbIsAuthed === true;
+
+  const renderPseudoValue = (it) => String(it?.displayPseudo || it?.pseudo || 'Voyageur').trim().slice(0, 24) || 'Voyageur';
+  const renderGradeValue = (it) => String(it?.authorGrade || it?.grade || 'Mouton égaré').trim() || 'Mouton égaré';
+  const renderPointsValue = (it) => Number(it?.authorPoints ?? it?.points ?? 0) || 0;
+
+  function closePseudoTooltip(){
+    if (lbPseudoTooltip) lbPseudoTooltip.remove();
+    lbPseudoTooltip = null;
+    lbPseudoTooltipAnchor = null;
+  }
+
+  function openPseudoTooltip(anchor){
+    if (!anchor) return;
+    const pseudo = anchor.getAttribute('data-pseudo') || 'Voyageur';
+    const grade = anchor.getAttribute('data-grade') || 'Mouton égaré';
+    const points = Number(anchor.getAttribute('data-points') || 0) || 0;
+    if (lbPseudoTooltipAnchor === anchor && lbPseudoTooltip){
+      closePseudoTooltip();
+      return;
+    }
+    closePseudoTooltip();
+    const tip = document.createElement('div');
+    tip.className = 'lb-pseudo-tooltip';
+    tip.innerHTML = `<strong>${escapeHtml(pseudo)}</strong><div>${escapeHtml(grade)}</div><div>${escapeHtml(String(points))} meuh</div>`;
+    document.body.appendChild(tip);
+    const rect = anchor.getBoundingClientRect();
+    const margin = 8;
+    const maxLeft = Math.max(margin, window.innerWidth - tip.offsetWidth - margin);
+    const left = Math.min(maxLeft, Math.max(margin, rect.left));
+    const top = Math.min(window.innerHeight - tip.offsetHeight - margin, rect.bottom + 6);
+    tip.style.left = `${left}px`;
+    tip.style.top = `${Math.max(margin, top)}px`;
+    lbPseudoTooltip = tip;
+    lbPseudoTooltipAnchor = anchor;
+  }
+
+  function buildPseudoTriggerHtml(item){
+    return `<span class="lb-pseudo-trigger" data-lb-pseudo-trigger data-pseudo="${escapeHtml(renderPseudoValue(item))}" data-grade="${escapeHtml(renderGradeValue(item))}" data-points="${escapeHtml(String(renderPointsValue(item)))}">${escapeHtml(renderPseudoValue(item))}</span>`;
+  }
 
   window.lbParseTimestamp = window.lbParseTimestamp || function(value){
     const raw = value == null ? Date.now() : value;
@@ -21350,7 +21524,10 @@ function scheduleWeatherAfterTableSettled(){
     const createdTs = window.lbParseTimestamp(createdAt);
     return {
       id: raw.id || `${createdTs}_${Math.random().toString(36).slice(2,8)}`,
-      pseudo: String(raw.pseudo || raw.username || raw.user_pseudo || 'Voyageur').trim().slice(0, 24),
+      pseudo: String(raw.pseudo || raw.username || raw.user_pseudo || raw.display_pseudo || 'Voyageur').trim().slice(0, 24),
+      displayPseudo: String(raw.display_pseudo || raw.pseudo || raw.username || raw.user_pseudo || 'Voyageur').trim().slice(0, 24),
+      authorGrade: String(raw.author_grade || raw.grade || '').trim(),
+      authorPoints: Number(raw.author_points || raw.points || 0),
       text: String(raw.message || raw.text || '').trim().slice(0, 180),
       trainNumber: String(raw.train_number || raw.trainNumber || '').trim(),
 	  accountId: String(raw.account_id || raw.accountId || raw.user_id || '').trim(),
@@ -21508,7 +21685,7 @@ function scheduleWeatherAfterTableSettled(){
     } else {
       feed.innerHTML = wall.map((it) => `
         <div class="live-wall-item live-wall-item--home live-wall-item--compact">
-          <div class="live-wall-item-text"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span class="live-wall-inline-meta">${escapeHtml(fmtHour(it.ts))}</span> : ${lbRenderWallMessageHtml(it.text || '')}${currentUser?.role === 'admin' && it.id ? `<span class="fav-comments-row"><span class="fav-comment-btn" role="button" tabindex="0" data-comment-delete="${escapeHtml(String(it.id))}" aria-label="Supprimer le commentaire" title="Supprimer le commentaire">❌</span></span>` : ''}</div>
+          <div class="live-wall-item-text"><strong>${buildPseudoTriggerHtml(it)}</strong><span class="live-wall-inline-meta">${escapeHtml(fmtHour(it.ts))}</span> : ${lbRenderWallMessageHtml(it.text || '')}${currentUser?.role === 'admin' && it.id ? `<span class="fav-comments-row"><span class="fav-comment-btn" role="button" tabindex="0" data-comment-delete="${escapeHtml(String(it.id))}" aria-label="Supprimer le commentaire" title="Supprimer le commentaire">❌</span></span>` : ''}</div>
         </div>
       `).join('');
       feed.scrollTop = 0;
@@ -21545,7 +21722,7 @@ function scheduleWeatherAfterTableSettled(){
 
     countEl.textContent = String(comments.length);
     listEl.innerHTML = comments.length
-      ? comments.map((it)=>`<div class="train-comments-item"><div class="live-wall-meta"><strong>${escapeHtml(it.pseudo || 'Voyageur')}</strong><span>${fmtHour(it.ts)}</span></div><div>${lbRenderWallMessageHtml(it.text || '')}</div></div>`).join('')
+      ? comments.map((it)=>`<div class="train-comments-item"><div class="live-wall-meta"><strong>${buildPseudoTriggerHtml(it)}</strong><span>${fmtHour(it.ts)}</span></div><div>${lbRenderWallMessageHtml(it.text || '')}</div></div>`).join('')
       : '<div class="live-wall-empty">Pas encore de commentaire sur ce train.</div>';
 
     form.hidden = true;
@@ -21583,6 +21760,7 @@ function scheduleWeatherAfterTableSettled(){
     }
 
     renderCommentsUI();
+    refreshGamificationUI({ force: true }).catch(()=>{});
     return isAuthed;
   }
 
@@ -21704,6 +21882,37 @@ function scheduleWeatherAfterTableSettled(){
     }
   }
 
+  function bindPseudoTooltipEvents(){
+    if (document.body.dataset.lbPseudoBound) return;
+    document.body.dataset.lbPseudoBound = '1';
+    document.addEventListener('mouseover', (e)=>{
+      const trigger = e.target.closest('[data-lb-pseudo-trigger]');
+      if (!trigger) return;
+      if (window.matchMedia('(hover: hover)').matches) openPseudoTooltip(trigger);
+    });
+    document.addEventListener('mouseout', (e)=>{
+      if (!window.matchMedia('(hover: hover)').matches) return;
+      const leaving = e.target.closest?.('[data-lb-pseudo-trigger]');
+      if (!leaving) return;
+      const related = e.relatedTarget?.closest?.('[data-lb-pseudo-trigger]');
+      if (related === leaving) return;
+      closePseudoTooltip();
+    });
+    document.addEventListener('click', (e)=>{
+      const trigger = e.target.closest('[data-lb-pseudo-trigger]');
+      if (trigger){
+        if (window.matchMedia('(hover: none)').matches || 'ontouchstart' in window){
+          e.preventDefault();
+          openPseudoTooltip(trigger);
+        }
+        return;
+      }
+      if (lbPseudoTooltip && !e.target.closest('.lb-pseudo-tooltip')) closePseudoTooltip();
+    });
+    window.addEventListener('scroll', closePseudoTooltip, { passive: true });
+    window.addEventListener('resize', closePseudoTooltip, { passive: true });
+  }
+
   function startCommentsPolling(){
     if (lbCommentsPoller) clearInterval(lbCommentsPoller);
     lbCommentsPoller = setInterval(loadMessages, 5000);
@@ -21728,6 +21937,7 @@ function scheduleWeatherAfterTableSettled(){
   };
 
   bindCommentForms();
+  bindPseudoTooltipEvents();
   renderCommentsUI();
   checkAuth().finally(loadMessages);
   startCommentsPolling();
@@ -21830,6 +22040,101 @@ function scheduleWeatherAfterTableSettled(){
       console.warn("Impossible de charger les préférences", err);
     }
   };
+
+  function normalizeRankingList(raw){
+    const list = Array.isArray(raw) ? raw : (Array.isArray(raw?.ranking) ? raw.ranking : (Array.isArray(raw?.items) ? raw.items : []));
+    return list.map((it, idx)=>({
+      rank: Number(it?.rank || it?.position || (idx + 1)),
+      pseudo: String(it?.display_pseudo || it?.pseudo || it?.username || 'Voyageur').trim().slice(0, 24),
+      grade: String(it?.grade || it?.author_grade || 'Mouton égaré').trim(),
+      points: Number(it?.points || it?.author_points || 0) || 0,
+      me: !!(it?.me || it?.is_me || it?.self)
+    })).filter((it)=> it.rank > 0).sort((a,b)=> a.rank - b.rank);
+  }
+
+  function renderGamificationUI(){
+    const host = $("lbProfileTroupeau");
+    const filter = $("lbRankingFilter");
+    const podium = $("lbRankingPodium");
+    const listEl = $("lbRankingList");
+    if (!host || !filter || !podium || !listEl) return;
+    if (!window.lbIsAuthed){
+      host.style.display = "none";
+      return;
+    }
+    host.style.display = "grid";
+    const p = lbGamificationState.profile || {};
+    const ranking = Array.isArray(lbGamificationState.ranking) ? lbGamificationState.ranking : [];
+    const pseudo = String(p.display_pseudo || p.pseudo || safePseudo() || currentUser?.pseudo || 'Voyageur').trim();
+    const grade = String(p.grade || 'Mouton égaré').trim();
+    const points = Number(p.points || 0) || 0;
+    const myRank = Number(lbGamificationState.myRank || p.rank || 0) || null;
+    if ($("lbProfilePseudo")) $("lbProfilePseudo").textContent = pseudo || "—";
+    if ($("lbProfileGrade")) $("lbProfileGrade").textContent = grade || "—";
+    if ($("lbProfilePoints")) $("lbProfilePoints").textContent = `${points} meuh`;
+    if ($("lbProfileRank")) $("lbProfileRank").textContent = myRank ? `#${myRank}` : "—";
+
+    const top3 = ranking.slice(0, 3);
+    podium.innerHTML = [2,1,3].map((rankNum)=>{
+      const item = top3.find((it)=> it.rank === rankNum);
+      if (!item) return `<div class="lb-ranking-podium-item pos-${rankNum}"><div class="rank">#${rankNum}</div><div class="pseudo">—</div></div>`;
+      return `<div class="lb-ranking-podium-item pos-${rankNum}"><div class="rank">#${item.rank}</div><div class="pseudo">${escapeHtml(item.pseudo)}</div><div class="meta">${escapeHtml(item.grade)} · ${escapeHtml(String(item.points))}</div></div>`;
+    }).join('');
+
+    const mode = filter.value || 'top10';
+    let rows = ranking;
+    if (mode === 'top3') rows = ranking.slice(0, 3);
+    else if (mode === 'top10') rows = ranking.slice(0, 10);
+    else if (mode === 'top50') rows = ranking.slice(0, 50);
+    else if (mode === 'around'){
+      const aroundRank = myRank || ranking.find((it)=> it.me)?.rank || null;
+      if (aroundRank){
+        rows = ranking.filter((it)=> Math.abs(it.rank - aroundRank) <= 2).slice(0, 7);
+      } else {
+        rows = ranking.slice(0, 10);
+      }
+    }
+    listEl.innerHTML = rows.length
+      ? rows.map((it)=> `<div class="lb-ranking-row${(myRank && it.rank === myRank) ? ' me' : ''}"><span>#${it.rank}</span><span title="${escapeHtml(it.grade)}">${escapeHtml(it.pseudo)}</span><span>${escapeHtml(String(it.points))} 🐮</span></div>`).join('')
+      : '<div class="live-wall-empty">Classement indisponible.</div>';
+  }
+
+  async function refreshGamificationUI(options = {}){
+    const force = !!options.force;
+    if (!window.lbIsAuthed){
+      lbGamificationState.profile = null;
+      lbGamificationState.ranking = [];
+      lbGamificationState.myRank = null;
+      renderGamificationUI();
+      return;
+    }
+    const ttl = 15000;
+    const now = Date.now();
+    if (!force && lbGamificationState.inflight) return lbGamificationState.inflight;
+    if (!force && lbGamificationState.lastFetchAt && (now - lbGamificationState.lastFetchAt) < ttl){
+      renderGamificationUI();
+      return;
+    }
+    lbGamificationState.inflight = (async ()=>{
+      try{
+        const [profileData, rankingData] = await Promise.all([
+          api('/me/profile', { method:'GET' }).catch(()=> ({})),
+          api('/ranking', { method:'GET' }).catch(()=> ({}))
+        ]);
+        const profile = profileData?.profile || profileData?.me || profileData || {};
+        const ranking = normalizeRankingList(rankingData);
+        const profileRank = Number(profile?.rank || 0) || null;
+        const detectedRank = ranking.find((it)=> it.me || normalizeIdentity(it.pseudo) === normalizeIdentity(profile?.display_pseudo || profile?.pseudo || safePseudo()))?.rank || null;
+        lbGamificationState.profile = profile;
+        lbGamificationState.ranking = ranking;
+        lbGamificationState.myRank = profileRank || detectedRank || null;
+        lbGamificationState.lastFetchAt = Date.now();
+      }catch(_){}
+      renderGamificationUI();
+    })();
+    try{ await lbGamificationState.inflight; } finally { lbGamificationState.inflight = null; }
+  }
+  window.refreshGamificationUI = refreshGamificationUI;
   
 
 
@@ -23033,6 +23338,7 @@ if (statsEl){
       if (deleteLinkWrap) deleteLinkWrap.style.display = "block";
       msg(`✅ Connecté : ${me?.user?.email || "utilisateur"}`);
       await loadPreferences();
+      await refreshGamificationUI({ force: true });
       try { if (typeof window.updateFavoriteWidgetFromPrefs === "function") await window.updateFavoriteWidgetFromPrefs(); } catch(e) {}
       try{ window.lbComments?.refresh(); }catch(e){}
     } catch {
@@ -23073,6 +23379,7 @@ if (statsEl){
         window.updateStatsConsoleAuth(false);
       }
       msg("ℹ️ Non connecté");
+      refreshGamificationUI({ force: true }).catch(()=>{});
       try{ window.lbComments?.refresh(); }catch(e){}
     }
     updateQuickAddButton();
@@ -23093,6 +23400,7 @@ if (statsEl){
   const prefsSaveBtn = $("lbSavePrefs");
   const prefsAddListBtn = $("lbAddPrefsList");
   const prefsResetBtn = $("lbResetPresets");
+  const rankingFilter = $("lbRankingFilter");
   const quickAddListBtn = $("lbQuickAddList");
   const registerModal = $("lbRegisterModal");
   const registerCloseBtn = $("lbBtnCloseRegister");
@@ -23105,6 +23413,11 @@ if (statsEl){
   const switchBtn = $("lbAuthSwitchBtn");
 
   if (!openBtn || !closeBtn || !modal || !submitBtn || !logoutBtn) return;
+
+  if (rankingFilter && !rankingFilter.dataset.bound){
+    rankingFilter.dataset.bound = '1';
+    rankingFilter.addEventListener('change', renderGamificationUI);
+  }
 
   openBtn.addEventListener("click", openModal);
   closeBtn.addEventListener("click", closeModal);
@@ -23567,6 +23880,7 @@ if (statsEl){
           body: JSON.stringify({ prefs: payload })
         });
         applyPreferences(payload, { auto: false });
+        await refreshGamificationUI({ force: true });
         prefsMsg("✅ Préférences enregistrées.");
         closePrefsModal();
       } catch (err) {
@@ -29330,7 +29644,10 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     const accountId = String(raw.account_id || raw.accountId || raw.user_id || '').trim();
     return {
       id: raw.id || `${ts}_${Math.random().toString(36).slice(2,8)}`,
-      pseudo: String(raw.pseudo || raw.username || raw.user_pseudo || 'Voyageur').trim().slice(0,24),
+      pseudo: String(raw.pseudo || raw.username || raw.user_pseudo || raw.display_pseudo || 'Voyageur').trim().slice(0,24),
+      displayPseudo: String(raw.display_pseudo || raw.pseudo || raw.username || raw.user_pseudo || 'Voyageur').trim().slice(0,24),
+      authorGrade: String(raw.author_grade || raw.grade || '').trim(),
+      authorPoints: Number(raw.author_points || raw.points || 0),
       text: message,
       detail: detail || message,
       signalType,
@@ -29375,7 +29692,10 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     if (!trainNumber) return null;
     return {
       id: raw.id || `${ts}_${Math.random().toString(36).slice(2,8)}`,
-      pseudo: String(raw.pseudo || raw.username || raw.user_pseudo || '').trim().slice(0,24),
+      pseudo: String(raw.pseudo || raw.username || raw.user_pseudo || raw.display_pseudo || '').trim().slice(0,24),
+      displayPseudo: String(raw.display_pseudo || raw.pseudo || raw.username || raw.user_pseudo || '').trim().slice(0,24),
+      authorGrade: String(raw.author_grade || raw.grade || '').trim(),
+      authorPoints: Number(raw.author_points || raw.points || 0),
       accountId: String(raw.account_id || raw.accountId || raw.user_id || '').trim(),
       trainNumber,
       ts
@@ -29934,6 +30254,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       if (signalRemovedByModeration) rememberHiddenWallRuleFromSignal(signalRemovedByModeration);
       if (signalRemovedByModeration) forceHideWallCommentsInFrontForSignal(signalRemovedByModeration);
       await loadSignals();
+      if (typeof window.refreshGamificationUI === 'function') window.refreshGamificationUI({ force: true }).catch(()=>{});
 	  if (voteValue < 0) await pruneWallAlertsWithoutActiveSignals();
       if (COMMUNITY.selectedTrain) renderTrainDetail(COMMUNITY.selectedTrain);
       refreshLiveModal();
@@ -30110,13 +30431,13 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     titleEl.textContent = train ? `Retours voyageurs — ${train.label}` : 'Flux voyageurs';
     let items = [];
     if (train){
-      const signals = getSignalsForTrain(train.trainNumber).map((it)=>({ kind:'signal', ts:it.ts, pseudo:it.pseudo, text:`${signalDisplayLabel(it)}${it.station ? ` — ${it.station}` : ''}${it.detail ? ` — ${it.detail}` : ''}` }));
+      const signals = getSignalsForTrain(train.trainNumber).map((it)=>({ kind:'signal', ts:it.ts, pseudo:it.pseudo, displayPseudo: it.displayPseudo, authorGrade: it.authorGrade, authorPoints: it.authorPoints, text:`${signalDisplayLabel(it)}${it.station ? ` — ${it.station}` : ''}${it.detail ? ` — ${it.detail}` : ''}` }));
       const comments = getWallCommentsForTrain(train.trainNumber)
         .filter((it)=> !shouldHideLiveCommentByAutomoderation(it, train.trainNumber))
-        .map((it)=>({ kind:'comment', ts:it.ts, pseudo:it.pseudo || 'Voyageur', text: String(it.text || '') }));
+        .map((it)=>({ kind:'comment', ts:it.ts, pseudo:it.pseudo || 'Voyageur', displayPseudo: it.displayPseudo, authorGrade: it.authorGrade, authorPoints: it.authorPoints, text: String(it.text || '') }));
       items = [...signals, ...comments].sort((a,b)=> Number(b.ts||0) - Number(a.ts||0)).slice(0, 30);
     } else {
-      items = (Array.isArray(COMMUNITY.signals) ? COMMUNITY.signals : []).slice(0, 30).map((it)=>({ kind:'signal', ts:it.ts, pseudo:it.pseudo, text:`${it.trainNumber ? `TER ${it.trainNumber} — ` : ''}${signalDisplayLabel(it)}${it.station ? ` — ${it.station}` : ''}${it.detail ? ` — ${it.detail}` : ''}` }));
+      items = (Array.isArray(COMMUNITY.signals) ? COMMUNITY.signals : []).slice(0, 30).map((it)=>({ kind:'signal', ts:it.ts, pseudo:it.pseudo, displayPseudo: it.displayPseudo, authorGrade: it.authorGrade, authorPoints: it.authorPoints, text:`${it.trainNumber ? `TER ${it.trainNumber} — ` : ''}${signalDisplayLabel(it)}${it.station ? ` — ${it.station}` : ''}${it.detail ? ` — ${it.detail}` : ''}` }));
     }
     countEl.textContent = String(items.length);
     if (!items.length){
@@ -30125,7 +30446,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     }
     feedEl.innerHTML = items.map((it)=>`
       <div class="lb-live-feed-item">
-        <div class="meta">${safeEscape(it.pseudo || 'Voyageur')} — ${safeEscape(formatHour(it.ts))}</div>
+        <div class="meta">${buildPseudoTriggerHtml(it)} — ${safeEscape(formatHour(it.ts))}</div>
         <div class="text">${safeEscape(it.text || '')}</div>
       </div>`).join('');
   }
@@ -30418,6 +30739,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
       if (feedback) feedback.textContent = 'Signalement publié ✅';
       await publishAutoWallAlertIfNeeded();
       await loadSignals();
+      if (typeof window.refreshGamificationUI === 'function') window.refreshGamificationUI({ force: true }).catch(()=>{});
       closeCommunityModal('lbSignalModal');
       openCommunityModal('lbLiveModal');
       renderLiveFeed(trainKey);
@@ -30504,6 +30826,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     COMMUNITY.signals = (Array.isArray(COMMUNITY.signals) ? COMMUNITY.signals : []).filter((it)=> String(it.id) !== String(sig.id));
     refreshCommunityViews();
     renderTrainDetail(COMMUNITY.selectedTrain);
+    if (typeof window.refreshGamificationUI === 'function') window.refreshGamificationUI({ force: true }).catch(()=>{});
   }
 
   async function removeAssociatedWallAlertsForSignal(signal, options = {}){


### PR DESCRIPTION
### Motivation

- Intégrer le système profil / classement exposé côté backend (`GET /api/me/profile`, `GET /api/ranking`) dans la modale compte sans alourdir l’UI ni casser les vues existantes.  
- Afficher uniquement le pseudo dans les listes/commentaires/LIVE et fournir grade/points uniquement via un tooltip discret (hover desktop / tap mobile).  
- Centraliser un rafraîchissement léger du module gamification après actions clés (connexion, déconnexion, prefs, publication/suppression/vote signalement) pour éviter fetchs redondants.

### Description

- Ajout d’un bloc compact “Mon profil troupeau” dans la modale compte (`#lbProfileTroupeau`) affichant `pseudo`, `grade`, `points` et `rang` et d’un petit module classement avec `#lbRankingFilter`, `#lbRankingPodium` et `#lbRankingList` (HTML + styles dans `index41.html`).  
- Nouveau flux JS: `normalizeRankingList`, `renderGamificationUI` et `refreshGamificationUI({ force })` qui consomment `GET /api/me/profile` et `GET /api/ranking` avec TTL/inflight pour éviter doublons; rendu conditionnel et filtre (`Top 3/10/50/Autour de moi`).  
- Enrichissement des normalizers pour commentaires/signalements/présences afin d’utiliser `display_pseudo`, `author_grade`, `author_points` tout en conservant un affichage de secours si absent.  
- Remplacement discret du pseudo affiché dans les commentaires / LIVE par un trigger compact (`buildPseudoTriggerHtml`) et ajout d’un composant tooltip léger (`openPseudoTooltip` / `closePseudoTooltip`) activé au hover (desktop) ou au tap (mobile) sans augmenter la hauteur des lignes ni déplacer la mise en page.  
- Hooks: appel de `refreshGamificationUI({ force: true })` après les moments demandés (connexion, déconnexion, sauvegarde prefs, publication/suppression/vote signalement) pour maintenir les données synchronisées sans boucles.

### Testing

- Contrôles statiques et basiques sur code modifié: `git diff --check` passé (vérification des espaces/erreurs de patch).  
- Smoke checks automatisés d’intégration front: l’UI de commentaires / LIVE et la modale compte rendent sans erreur JavaScript dans cet environnement (bindings des events ajoutés et fonctions accessibles), et les points d’appel vers `refreshGamificationUI` ont été ajoutés sur les handlers demandés (connexion, prefs, publication/suppression/vote).  
- Aucune suite de tests unitaires spécifique n’a été modifiée; les changements sont localisés dans `index41.html` et conçus pour être dégradables si les nouveaux champs backend ne sont pas fournis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d650241564832d9612a9715bc06cb9)