### PR TITLE
UI: improve schedule delay display, alert icons and favorites rendering

### DIFF
--- a/index42.html
+++ b/index42.html
@@ -2819,12 +2819,26 @@ table[data-snapshotting="true"] tbody tr:nth-child(even) {
   animation: blinkRedStrike 1.2s infinite;
 }
 
+  .delay-stack {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  line-height: 1;
+}
   .delay-strike {
   text-decoration: line-through;
+  display: block;
+  margin: 0;
+  line-height: 1;
 }
   .delayed {
     color: #ff8a00;
-    font-weight: 600;
+    font-weight: 700;
+    display: block;
+    margin: 0;
+    line-height: 1;
   }
   .supprimé {
       color: #ff4c4c;
@@ -3453,7 +3467,15 @@ body.page-carte .train-detail-panel{
 #trainInfo table thead th:not(:first-child){ z-index: 7; }
 #trainInfo table thead th.status-head{ padding-top: 4px !important; padding-bottom: 4px !important; }
 #trainInfo table thead th .train-num{ display:block; line-height:1.05; }
-#trainInfo table thead th .train-state{ display:block; margin-top:2px; line-height:1; font-size:.86em; }
+#trainInfo table thead th .train-state{ display:inline-block; margin-top:2px; line-height:1; font-size:.86em; }
+#trainInfo table thead th .train-alert-icon{
+  display:inline-block;
+  margin-left:4px;
+  font-size:.82em;
+  line-height:1;
+  color:#ffd15a;
+  text-shadow:0 0 6px rgba(255,209,90,.7);
+}
 
 
 .table-toolbar{
@@ -3599,13 +3621,14 @@ body.page-carte .train-detail-panel{
 
 /* Variante orange pour alerte moyenne */
 .disruption-box.orange {
-  border-color: #ffb74d;
-  color: #ffb74d;
-  box-shadow: inset 0 0 4px #ffb74d33;
+  border-color: #ff922b;
+  color: #ff922b;
+  background: rgba(255,146,43,.08);
+  box-shadow: inset 0 0 4px rgba(255,146,43,.35);
 }
 
 .disruption-box.orange:hover {
-  box-shadow: 0 0 14px #ffb74d, inset 0 0 8px #ffb74d55;
+  box-shadow: 0 0 14px rgba(255,146,43,.72), inset 0 0 8px rgba(255,146,43,.38);
 }
 .disruption-box.info {
   border-color: #00f0ff;
@@ -3701,14 +3724,18 @@ body.page-carte .train-detail-panel{
 #alertDetailModal .alert-detail-desc{ margin-top:6px; line-height:1.35; opacity:.92; color:#d7ecff; }
 
 .gtfs-retard {
-  display: inline-block;
-  margin-top: 2px;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0;
   padding: 0;
   background: none;
   color: inherit;
   text-align: center;
-  font-size: 0.9em;
-  line-height: 1.2;
+  font-size: 0.86em;
+  line-height: 1.05;
+  gap: 1px;
 }
   .gtfs-retard-base,
   .gtfs-retard-new {
@@ -3721,8 +3748,8 @@ body.page-carte .train-detail-panel{
 
   .gtfs-retard-new {
     color: #ff8a00;
-    font-weight: 600;
-    margin-top: 2px;
+    font-weight: 700;
+    margin-top: 0;
   }
 
 @media (max-width: 600px) {
@@ -9109,6 +9136,20 @@ body.page-carte #affluence{ display:none !important; }
   padding:7px 8px !important;
   border-radius:13px !important;
 }
+.lb-live-card--ok{
+  border-color: rgba(0,240,255,.30) !important;
+  background: linear-gradient(180deg, rgba(11,33,52,.80), rgba(8,25,41,.95)) !important;
+}
+.lb-live-card--delay{
+  border-color: rgba(255,146,43,.82) !important;
+  background: linear-gradient(180deg, rgba(33,24,12,.78), rgba(20,14,8,.92)) !important;
+  box-shadow: 0 8px 22px rgba(0,0,0,.2), 0 0 14px rgba(255,146,43,.22) !important;
+}
+.lb-live-card--cancel{
+  border-color: rgba(255,77,109,.85) !important;
+  background: linear-gradient(180deg, rgba(34,14,20,.76), rgba(20,10,14,.92)) !important;
+  box-shadow: 0 8px 22px rgba(0,0,0,.22), 0 0 14px rgba(255,77,109,.24) !important;
+}
 .lb-live-card-top{
   gap:8px !important;
   align-items:flex-start !important;
@@ -9120,6 +9161,14 @@ body.page-carte #affluence{ display:none !important; }
 .lb-live-train{
   font-size:.88rem !important;
   line-height:1.02 !important;
+}
+.lb-live-card--delay .lb-live-train{
+  color:#ff922b !important;
+  text-shadow:0 0 8px rgba(255,146,43,.35) !important;
+}
+.lb-live-card--cancel .lb-live-train{
+  color:#ff4d6d !important;
+  text-shadow:0 0 8px rgba(255,77,109,.35) !important;
 }
 .lb-live-route,
 .lb-live-schedule{
@@ -18064,9 +18113,9 @@ const stopHasSchedule = (result, stopName) => {
           const diffMinutes = (hasAmended && hasBase) ? dl(base, amended) : null;
           const mainTimeRaw = hasAmended && (!hasBase || diffMinutes !== 0) ? ft(amended) : (baseWithVoie || baseClock);
           const baseStrike = (hasAmended && hasBase && diffMinutes > 0)
-            ? `<span class="delay-strike">${baseWithVoie || baseClock}</span><br>`
+            ? `<span class="delay-stack"><span class="delay-strike">${baseWithVoie || baseClock}</span><span class="new-start">${mainTimeRaw}</span></span>`
             : '';
-          content = `${baseStrike}<span class="new-start">${mainTimeRaw}</span>`;   
+          content = baseStrike || `<span class="new-start">${mainTimeRaw}</span>`;   
         } else if (
           isStopDeleted ||
           (newStartIndex >= 0 && index >= 0 && index < newStartIndex) ||
@@ -18074,13 +18123,13 @@ const stopHasSchedule = (result, stopName) => {
         ) {
           content = `<span class="deleted">${content}</span>`;
         } else if (amended && dl(base, amended) > 0) {
-          content = `<span class="delay-strike">${baseWithVoie || baseClock}</span><br><span class="delayed">${ft(amended)}</span>`;
+          content = `<span class="delay-stack"><span class="delay-strike">${baseWithVoie || baseClock}</span><span class="delayed">${ft(amended)}</span></span>`;
           } else if (hasDelayFromImpact) {
           const roundedDelay = Math.round(delayFromImpactRaw);
           const fallbackClock = base ? computeRetardedTime(base, delayFromImpactRaw) : null;
           const delayLabel = fallbackClock ? fallbackClock : `+${roundedDelay} min`;
-          const baseStrike = base ? `<span class="delay-strike">${baseWithVoie || baseClock}</span><br>` : '';
-          content = `${baseStrike}<span class="delayed">${delayLabel}</span>`;
+          const baseStrike = base ? `<span class="delay-strike">${baseWithVoie || baseClock}</span>` : '';
+          content = `<span class="delay-stack">${baseStrike}<span class="delayed">${delayLabel}</span></span>`;
         } else if (isFirstStop || isLastStop) {
           content = `<strong>${content}</strong>`;
         }
@@ -19293,11 +19342,26 @@ function keywordStrictCorridor(text, desc){
 }
 
 function updateDisruptionsSummaryVisibility(){
-  const hasContent = $.trim($('#disruptionsContent').text());
-  if (hasContent) {
-    $('#disruptionsSummary').css('display', 'flex');
+  const panel = document.getElementById('disruptionsSummary');
+  const content = document.getElementById('disruptionsContent');
+  if (!panel || !content) return;
+
+  const hasContent = String(content.textContent || '').trim().length > 0;
+  panel.dataset.hasContent = hasContent ? '1' : '0';
+
+  if (!hasContent) {
+    panel.style.display = 'none';
+    return;
+  }
+
+  const activeTab = document.querySelector('#tableauViewNav [data-tableau-view].is-active');
+  const activeView = activeTab ? activeTab.getAttribute('data-tableau-view') : '';
+  const hasTable = !!document.querySelector('#trainInfo table');
+
+  if (!hasTable || activeView === 'perturbations') {
+    panel.style.display = 'flex';
   } else {
-    $('#disruptionsSummary').hide();
+    panel.style.display = 'none';
   }
 }
 	  
@@ -19354,6 +19418,12 @@ async function chargerEtAfficherAlertes() {
 
       // ⚙️ sets construits à partir des trains AFFICHÉS
       const sets = buildDisplayedFilters(ymd);
+
+      document.querySelectorAll('th[data-train-number]').forEach((header) => {
+        header.classList.remove('reduced-seats');
+        header.removeAttribute('data-alert-key-main');
+        header.querySelectorAll('.reduced-seat-icon, .train-alert-icon').forEach((node) => node.remove());
+      });
 
       // 1) Filtrage strict : actif + touche nos trips/routes/stops affichés
       let alertesFiltres = alertes.filter(a => {
@@ -19446,29 +19516,28 @@ async function chargerEtAfficherAlertes() {
           return Array.from(document.querySelectorAll('th[data-train-number]'))
             .find(th => extractTrainNumber(th.dataset.trainNumber || '') === normalized) || null;
         };
-        if (isReducedSeats && targetsDisplayed.length){
-          targetsDisplayed.forEach(numeroTrain => {
-            const header = findHeaderByNumber(numeroTrain);
-            if (header) {
-              header.classList.add('reduced-seats');
-              if (!header.dataset.alertKeyMain) header.dataset.alertKeyMain = detailEntry.key;
-        try{ if(window.lbReducedSeats) window.lbReducedSeats.add(String(trainNum)); }catch(e){}
-              header.title = "Service réduit : réduction du nombre de places (UM ➜ US)";
-              const headRow = header.parentElement;
-              const index = headRow ? Array.from(headRow.children).indexOf(header) : -1;
-              const iconRow = header.closest('thead')?.querySelector('tr:nth-child(2)');
-              const iconCell = iconRow && index >= 0 ? iconRow.children[index] : null;
-              if (iconCell && !iconCell.querySelector('.reduced-seat-icon')) {
-                const iconSpan = document.createElement('span');
-                iconSpan.className = 'icon reduced-seat-icon';
-                iconSpan.textContent = styleMeta.icone || '⚠️';
-                iconSpan.title = "Service réduit : réduction du nombre de places";
-                iconSpan.dataset.alertKey = detailEntry.key;
-                iconCell.appendChild(iconSpan);
-              }
-            }
-          });
-        }
+        targetsDisplayed.forEach((numeroTrain) => {
+          const header = findHeaderByNumber(numeroTrain);
+          if (!header) return;
+
+          if (!header.dataset.alertKeyMain) header.dataset.alertKeyMain = detailEntry.key;
+
+          const iconHost = header.querySelector('.train-state') || header;
+          if (!iconHost.querySelector('.train-alert-icon')) {
+            const iconSpan = document.createElement('span');
+            iconSpan.className = 'icon train-alert-icon';
+            iconSpan.textContent = styleMeta.icone || '⚠️';
+            iconSpan.title = titre || styleMeta.label || 'Information';
+            iconSpan.dataset.alertKey = detailEntry.key;
+            iconHost.appendChild(iconSpan);
+          }
+
+          if (isReducedSeats) {
+            header.classList.add('reduced-seats');
+            try { if (window.lbReducedSeats) window.lbReducedSeats.add(String(numeroTrain)); } catch(e) {}
+            header.title = "Service réduit : réduction du nombre de places (UM ➜ US)";
+          }
+        });
 
         let classeCouleur = 'disruption-box info';
         if (styleMeta.prio === 1) classeCouleur = 'disruption-box red';
@@ -25091,18 +25160,68 @@ function lbRenderHomeFavPreview(){
     return `<span class="fav-state-badge fav-state-${key}">${escapeHtml(label)}</span>`;
   };
 
+  const compactStationLabel = (name) => {
+    const base = String(name || '').trim();
+    if (!base) return '';
+    const map = {
+      'Luxembourg': 'Lux',
+      'Thionville': 'Thionv.',
+      'Hettange-Grande': 'Hettange',
+      'Pont-à-Mousson': 'PAM',
+      'Maizières-lès-Metz': 'Maizières',
+      'Pagny-sur-Moselle': 'Pagny'
+    };
+    return map[base] || base;
+  };
+
+  const parseFavMeta = (metaTxt) => {
+    const raw = String(metaTxt || '').replace(/\s+/g, ' ').trim();
+    if (!raw) return { route: '—', timeRange: '—' };
+
+    const timeMatches = Array.from(raw.matchAll(/\b([01]?\d|2[0-3])[:h]([0-5]\d)\b/g))
+      .map((m) => `${m[1].padStart(2,'0')}:${m[2]}`);
+    const timeRange = timeMatches.length >= 2 ? `${timeMatches[0]} — ${timeMatches[1]}` : (timeMatches[0] || '—');
+
+    const stationCandidates = Array.isArray(garesParLigne)
+      ? garesParLigne.map((g) => g && g.nom).filter(Boolean)
+      : [];
+    const found = stationCandidates
+      .map((nom) => ({ nom, idx: raw.toLowerCase().indexOf(String(nom).toLowerCase()) }))
+      .filter((x) => x.idx >= 0)
+      .sort((a, b) => a.idx - b.idx);
+
+    let route = '—';
+    if (found.length >= 2) {
+      const start = compactStationLabel(found[0].nom);
+      const end = compactStationLabel(found[1].nom);
+      route = `${start} → ${end}`;
+    } else {
+      const fallback = raw
+        .replace(/\b([01]?\d|2[0-3])[:h]([0-5]\d)\b/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      route = fallback || '—';
+    }
+
+    return { route, timeRange };
+  };
+
   const buildRow = (k, data, label) => {
     const trainTxt = data.train && data.train !== '—' ? data.train : '—';
     const metaTxt  = data.meta && data.meta !== '—' ? data.meta : '';
-    const safeMeta = metaTxt ? escapeHtml(metaTxt) : '<span style="opacity:.55">—</span>';
+    const parsed = parseFavMeta(metaTxt);
 
     return `
       <div class="home-fav-row" data-fav-k="${k}" role="button" tabindex="0" aria-label="Ouvrir favoris ${label}">
-        <div class="home-fav-left">
-          <div class="home-fav-train">${escapeHtml(trainTxt)} <span style="opacity:.6;font-weight:800;letter-spacing:.06em;">${label}</span></div>
-          <div class="home-fav-meta">${safeMeta}</div>
+        <div class="home-fav-head">
+          <div class="home-fav-trainline">
+            <span class="home-fav-train">${escapeHtml(trainTxt)}</span>
+            <span class="home-fav-moment">${escapeHtml(label)}</span>
+          </div>
+          <div class="fav-train-badge home-fav-badge">${renderBadge(data.state)}</div>
         </div>
-        <div class="fav-train-badge home-fav-badge">${renderBadge(data.state)}</div>
+        <div class="home-fav-route">${escapeHtml(parsed.route)}</div>
+        <div class="home-fav-time">${escapeHtml(parsed.timeRange)}</div>
       </div>
     `;
   };
@@ -26512,16 +26631,25 @@ async function loadAffluenceDate(dateStr){
     });
   }
 
+  let lastHasTable = hasGeneratedTable();
   const mo = new MutationObserver(() => {
-	if (hasGeneratedTable()){
-      currentView = 'global';
-      if (onTableTab()){
+    const hasTableNow = hasGeneratedTable();
+
+    if (hasTableNow !== lastHasTable) {
+      lastHasTable = hasTableNow;
+      if (hasTableNow) {
+        currentView = 'global';
+        if (onTableTab()) {
+          refreshNav();
+          applyView('global', { scroll: false });
+        }
+      } else {
         refreshNav();
-        applyView('global');
       }
-    } else {
-      refreshNav();
+      return;
     }
+
+    if (!hasTableNow) refreshNav();
   });
   mo.observe(trainInfo, { childList: true, subtree: true });
 
@@ -28890,23 +29018,75 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     margin-top: 4px !important;
 	grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
   }
-  .home-fav-row{
-    padding: 5px 7px !important;
+  #homeFavSlot.home-fav-preview{
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
     gap: 6px !important;
+  }
+  #homeFavSlot .home-fav-row{
+    padding: 7px 8px !important;
     border-radius: 12px !important;
+    gap: 4px !important;
+    display: flex !important;
+    flex-direction: column !important;
+    min-width: 0 !important;
   }
-  .home-fav-train{
-    font-size: .7rem !important;
+  #homeFavSlot .home-fav-head{
+    display:flex !important;
+    align-items:flex-start !important;
+    justify-content:space-between !important;
+    gap:6px !important;
+    min-width:0 !important;
   }
-  .home-fav-meta{
-    font-size: .62rem !important;
-    line-height: 1.12 !important;
+  #homeFavSlot .home-fav-trainline{
+    display:flex !important;
+    align-items:center !important;
+    gap:5px !important;
+    min-width:0 !important;
   }
-  .home-fav-badge,
-  .home-fav-row .fav-state-badge,
-  .home-fav-pill{
-    font-size: .54rem !important;
-    padding: 3px 6px !important;
+  #homeFavSlot .home-fav-train{
+    font-size: .76rem !important;
+    font-weight: 900 !important;
+    letter-spacing: .03em !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+  }
+  #homeFavSlot .home-fav-moment{
+    font-size:.56rem !important;
+    font-weight:800 !important;
+    padding:2px 6px !important;
+    border-radius:999px !important;
+    border:1px solid rgba(0,240,255,.32) !important;
+    background:rgba(0,240,255,.10) !important;
+    color:#9ef8ff !important;
+    text-transform:uppercase !important;
+    white-space:nowrap !important;
+    flex:0 0 auto !important;
+  }
+  #homeFavSlot .home-fav-route{
+    font-size:.64rem !important;
+    color:#d6efff !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    line-height:1.12 !important;
+  }
+  #homeFavSlot .home-fav-time{
+    font-size:.68rem !important;
+    font-weight:800 !important;
+    color:#8ef8ff !important;
+    letter-spacing:.02em !important;
+    line-height:1.1 !important;
+    font-variant-numeric: tabular-nums !important;
+    white-space: nowrap !important;
+  }
+  #homeFavSlot .home-fav-badge,
+  #homeFavSlot .home-fav-row .fav-state-badge,
+  #homeFavSlot .home-fav-pill{
+    font-size: .52rem !important;
+    padding: 2px 6px !important;
+    white-space: nowrap !important;
+    flex: 0 0 auto !important;
   }
   .home-card[forwarding="ber"]{
     display: none !important;


### PR DESCRIPTION
### Motivation
- Improve clarity and compactness of train time/delay display and make alert indicators visible in header cells.
- Modernize DOM handling and layout for disruptions summary, favorites widget and mobile views to reduce jQuery usage and improve responsiveness.
- Add visual variants for live cards to better reflect OK/delay/cancellation states.

### Description
- Add stacked delay markup and CSS (`.delay-stack`, `.delay-strike`, `.delayed`, `.gtfs-retard` tweaks) to render base time + updated time compactly and with consistent line-height and weight.  Update header train state display to `inline-block` and add `.train-alert-icon` for per-train alert icons.
- Replace jQuery check logic in `updateDisruptionsSummaryVisibility` with vanilla DOM, set `data-has-content` on the panel, and refine visibility rules based on whether a generated timetable table exists and the active view tab.
- Update `chargerEtAfficherAlertes` to clear previous header decorations, append a `.train-alert-icon` into header state, manage `reduced-seats` styling and `data-alert-key-main`, and ensure reduced-seats bookkeeping calls remain guarded.
- Add `lb-live-card--ok|--delay|--cancel` CSS variants and color/text-shadow rules for `.lb-live-card` to visually distinguish live card states.
- Rework favorites preview rendering by adding `parseFavMeta` and `compactStationLabel` helpers to extract a cleaner `route` and `timeRange` from raw meta text, and update `buildRow` HTML/CSS structure for a compact, responsive favorite card layout with `renderBadge` integration.
- Minor DOM/observer improvements: mutation observer now tracks table presence changes via `lastHasTable` and adjusts `applyView`/`refreshNav` calls to avoid redundant updates, and preserved `data-base-time` attribute on table cells when `base` is present.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc914aec44832da315f6bf9e9cefd4)