### PR TITLE
Add gamification grade cards and progress UI to profile and preferences

### DIFF
--- a/index43.html
+++ b/index43.html
@@ -5987,6 +5987,102 @@ body.modal-open{ overflow:hidden; }
 }
 .lb-profile-chip b{ display:block; font-size:.7rem; color:#8da8bc; font-weight:600; }
 .lb-profile-chip span{ display:block; margin-top:2px; font-size:.82rem; color:#e2f7ff; font-weight:700; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.lb-grade-card{
+  margin: 0 0 12px;
+  border: 1px solid rgba(0,240,255,.25);
+  border-radius: 14px;
+  background: radial-gradient(circle at 50% -20%, rgba(0,255,255,.15), transparent 60%), rgba(5,16,28,.6);
+  box-shadow: inset 0 0 14px rgba(0,220,255,.08);
+  padding: 12px 10px;
+  text-align: center;
+}
+.lb-grade-card .lb-grade-label{
+  font-size: .68rem;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color:#8fdaf2;
+  margin-bottom: 8px;
+}
+.lb-grade-card img{
+  width: 86px;
+  height: 86px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid rgba(0,240,255,.35);
+  box-shadow: 0 0 18px rgba(0,255,255,.2);
+  background: rgba(8,18,32,.75);
+}
+.lb-grade-name{
+  margin-top: 8px;
+  font-size: .9rem;
+  font-weight: 700;
+  color: #e6fbff;
+}
+.lb-grade-points{
+  margin-top: 3px;
+  font-size: .75rem;
+  color:#9fc1d7;
+}
+.lb-grade-progress{
+  margin: 10px auto 0;
+  width: min(280px, 100%);
+}
+.lb-grade-progress-track{
+  width: 100%;
+  height: 9px;
+  border-radius: 999px;
+  border: 1px solid rgba(0,240,255,.28);
+  background: rgba(8,18,32,.75);
+  overflow: hidden;
+}
+.lb-grade-progress-fill{
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #20d6ff, #79f9ff);
+  box-shadow: 0 0 12px rgba(70,240,255,.45);
+  transition: width .25s ease;
+}
+.lb-grade-next{
+  margin-top: 5px;
+  font-size: .7rem;
+  color:#8da8bc;
+}
+.lb-grade-inline{
+  border: 1px solid rgba(0,240,255,.2);
+  border-radius: 10px;
+  background: rgba(7,18,30,.65);
+  padding: 8px;
+  display: grid;
+  grid-template-columns: 54px 1fr;
+  gap: 8px;
+  align-items: center;
+}
+.lb-grade-inline img{
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid rgba(0,240,255,.32);
+}
+.lb-grade-inline .lb-grade-name{
+  margin-top: 0;
+  font-size: .8rem;
+}
+.lb-grade-inline .lb-grade-points{
+  margin-top: 2px;
+  font-size: .68rem;
+}
+.lb-grade-inline .lb-grade-progress{
+  margin-top: 6px;
+  width: 100%;
+}
+.lb-grade-inline .lb-grade-progress-track{
+  height: 7px;
+}
+.lb-grade-inline .lb-grade-next{
+  margin-top: 4px;
+  font-size: .62rem;
+}
 .lb-ranking-head{
   display:flex;
   align-items:center;
@@ -10515,6 +10611,19 @@ body{
           <div class="lb-profile-chip"><b>Points</b><span id="lbProfilePoints">0 meuh</span></div>
           <div class="lb-profile-chip"><b>Rang</b><span id="lbProfileRank">—</span></div>
         </div>
+        <div id="lbProfileGradeCard" class="lb-grade-inline" style="display:none;">
+          <img id="lbProfileGradeImage" src="./Mouton%20%C3%A9gar%C3%A9.png" alt="Grade du profil">
+          <div>
+            <div id="lbProfileGradeName" class="lb-grade-name">Mouton égaré</div>
+            <div id="lbProfileGradePoints" class="lb-grade-points">0 meuh</div>
+            <div class="lb-grade-progress">
+              <div class="lb-grade-progress-track">
+                <div id="lbProfileGradeProgressFill" class="lb-grade-progress-fill"></div>
+              </div>
+              <div id="lbProfileGradeNext" class="lb-grade-next">Prochain niveau : —</div>
+            </div>
+          </div>
+        </div>
       </div>
       <div id="lbLoginFields" class="lb-auth-fields">
         <label for="lbEmail">Email</label>
@@ -10617,6 +10726,18 @@ body{
     <div class="lb-auth-card" role="dialog" aria-modal="true" aria-labelledby="lbPrefsTitle">
       <button id="lbBtnClosePrefs" class="lb-auth-close tron-close-button" type="button" aria-label="Fermer"></button>
       <h3 id="lbPrefsTitle">Mes préférences</h3>
+      <div id="lbPrefsGradeCard" class="lb-grade-card" style="display:none;">
+        <div class="lb-grade-label">Niveau du troupeau</div>
+        <img id="lbGradeImage" src="./Mouton%20%C3%A9gar%C3%A9.png" alt="Grade du profil">
+        <div id="lbGradeName" class="lb-grade-name">Mouton égaré</div>
+        <div id="lbGradePoints" class="lb-grade-points">0 meuh</div>
+        <div class="lb-grade-progress">
+          <div class="lb-grade-progress-track">
+            <div id="lbGradeProgressFill" class="lb-grade-progress-fill"></div>
+          </div>
+          <div id="lbGradeNext" class="lb-grade-next">Prochain niveau : —</div>
+        </div>
+      </div>
       <p class="lb-prefs-note">Personnalise tes listes rapides (10 trains max).</p>
       <div class="lb-prefs-grid">
         <div class="lb-prefs-section" data-preset="AM">
@@ -21761,6 +21882,16 @@ function scheduleWeatherAfterTableSettled(){
   let currentUser = null;
   window.currentUser = null;
   const lbGamificationState = { profile: null, ranking: [], myRank: null, me: null, lastFetchAt: 0, inflight: null };
+  const LB_GRADE_LEVELS = [
+    { name: 'Mouton égaré', min: 0, image: 'Mouton égaré.png' },
+    { name: 'Poulet du Quai', min: 120, image: 'Poulet du Quai.png' },
+    { name: 'Porc en déroute', min: 280, image: 'Porc en déroute.png' },
+    { name: 'Porc entassé du couloir', min: 500, image: 'Porc entassé du couloir.png' },
+    { name: 'Bélier du sas', min: 800, image: 'Bélier du sas.png' },
+    { name: 'Architecte Chèvre de la galère', min: 1150, image: 'Architecte Chèvre de la galère.png' },
+    { name: 'Golden Vache', min: 1550, image: 'Golden Vache.png' },
+    { name: 'Ministre dindon du chaos ferroviaire', min: 2000, image: 'Ministre dindon du chaos ferroviaire.png' }
+  ];
   let lbProfileCache = null;
   let lbRankingCache = null;
   let lbCurrentMe = null;
@@ -21772,6 +21903,60 @@ function scheduleWeatherAfterTableSettled(){
 
   const safePseudo = () => String(lbPrefsCache?.pseudo || '').trim().slice(0,24);
   const isCommentingAllowed = () => window.lbIsAuthed === true;
+  const normalizeGradeKey = (v) => String(v || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+  function resolveGradeMeta(gradeLabel, points){
+    const key = normalizeGradeKey(gradeLabel);
+    let idx = LB_GRADE_LEVELS.findIndex((it)=> normalizeGradeKey(it.name) === key);
+    if (idx < 0) idx = LB_GRADE_LEVELS.reduce((best, it, i)=> (points >= it.min ? i : best), 0);
+    const current = LB_GRADE_LEVELS[Math.max(0, idx)] || LB_GRADE_LEVELS[0];
+    const next = LB_GRADE_LEVELS[idx + 1] || null;
+    return { current, next };
+  }
+  function renderPrefsGradeCard(grade, points){
+    const safePoints = Number(points || 0) || 0;
+    const { current, next } = resolveGradeMeta(grade, safePoints);
+    const span = next ? Math.max(1, (next.min - current.min)) : 1;
+    const progress = next ? Math.min(100, Math.max(0, ((safePoints - current.min) / span) * 100)) : 100;
+    const nextText = next
+      ? `Prochain niveau : ${next.name} · ${Math.max(0, next.min - safePoints)} meuh restants`
+      : 'Niveau max atteint 🏆';
+    const imagePath = `./${encodeURIComponent(current?.image || 'Mouton égaré.png')}`;
+    const cards = [
+      {
+        card: $("lbPrefsGradeCard"),
+        nameEl: $("lbGradeName"),
+        pointsEl: $("lbGradePoints"),
+        imageEl: $("lbGradeImage"),
+        fillEl: $("lbGradeProgressFill"),
+        nextEl: $("lbGradeNext")
+      },
+      {
+        card: $("lbProfileGradeCard"),
+        nameEl: $("lbProfileGradeName"),
+        pointsEl: $("lbProfileGradePoints"),
+        imageEl: $("lbProfileGradeImage"),
+        fillEl: $("lbProfileGradeProgressFill"),
+        nextEl: $("lbProfileGradeNext")
+      }
+    ];
+    cards.forEach((ctx)=>{
+      if (!ctx.card) return;
+      if (ctx.nameEl) ctx.nameEl.textContent = current?.name || String(grade || 'Mouton égaré');
+      if (ctx.pointsEl) ctx.pointsEl.textContent = `${safePoints} meuh`;
+      if (ctx.imageEl){
+        ctx.imageEl.src = imagePath;
+        ctx.imageEl.alt = `Grade ${current?.name || 'Mouton égaré'}`;
+      }
+      if (ctx.fillEl) ctx.fillEl.style.width = `${progress.toFixed(1)}%`;
+      if (ctx.nextEl) ctx.nextEl.textContent = nextText;
+      ctx.card.style.display = window.lbIsAuthed ? "grid" : "none";
+    });
+  }
 
   const renderPseudoValue = (it) => String(it?.displayPseudo || it?.pseudo || 'Voyageur').trim().slice(0, 24) || 'Voyageur';
   const renderGradeValue = (it) => String(it?.authorGrade || it?.grade || 'Mouton égaré').trim() || 'Mouton égaré';
@@ -22395,6 +22580,7 @@ function scheduleWeatherAfterTableSettled(){
     if ($("lbProfileGrade")) $("lbProfileGrade").textContent = grade || "—";
     if ($("lbProfilePoints")) $("lbProfilePoints").textContent = `${points} meuh`;
     if ($("lbProfileRank")) $("lbProfileRank").textContent = myRank ? `#${myRank}` : "—";
+    renderPrefsGradeCard(grade, points);
 
     const top3 = ranking.slice(0, 3);
     podium.innerHTML = [2,1,3].map((rankNum)=>{
@@ -22440,6 +22626,7 @@ function scheduleWeatherAfterTableSettled(){
     if ($("lbProfileGrade")) $("lbProfileGrade").textContent = "—";
     if ($("lbProfilePoints")) $("lbProfilePoints").textContent = "0 meuh";
     if ($("lbProfileRank")) $("lbProfileRank").textContent = "—";
+    renderPrefsGradeCard('Mouton égaré', 0);
     if ($("lbRankingPodium")) $("lbRankingPodium").innerHTML = '';
     if ($("lbRankingList")) $("lbRankingList").innerHTML = '<div class="live-wall-empty">Classement indisponible.</div>';
   }


### PR DESCRIPTION
### Motivation
- Surface the user's gamification "grade" and progress in the account and preferences modals so users can see their current level and next milestone at a glance.
- Provide a consistent visual component for both the compact profile area and the full preferences modal including image, name, points and progress.

### Description
- Added CSS rules for `.lb-grade-card`, `.lb-grade-inline` and related elements to style grade cards and progress bars in `index43.html`.
- Inserted grade card markup into the profile modal (`#lbProfileGradeCard`) and the preferences modal (`#lbPrefsGradeCard`) in `index43.html` and wired image, name, points and progress fill elements.
- Introduced `LB_GRADE_LEVELS` grade table and new JS helpers `normalizeGradeKey`, `resolveGradeMeta` and `renderPrefsGradeCard` to pick the current/next grade, compute progress and update the UI elements and image paths.
- Integrated grade rendering into existing flows by calling `renderPrefsGradeCard` from `renderGamificationUI` and `resetGamificationUI` so the cards update when profile/ranking state changes.

### Testing
- No automated tests were added for this UI-only change; existing automated test suite (if present in the project) was executed and reported as passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de65739838832d8cb99e2d8b998c2e)