### PR TITLE
Polish ranking podium and modal UIs; style prefs & preset builder; update podium render HTML

### DIFF
--- a/index56.html
+++ b/index56.html
@@ -6154,23 +6154,97 @@ body.modal-open{ overflow:hidden; }
   padding:5px 7px;
 }
 .lb-ranking-podium{
+  position: relative;
   display:grid;
   grid-template-columns:repeat(3,minmax(0,1fr));
-  gap:6px;
+  gap:8px;
   align-items:end;
+  margin: 4px 0 2px;
+  padding: 4px 2px 14px;
+}
+.lb-ranking-podium::after{
+  content:"";
+  position:absolute;
+  left:4%;
+  right:4%;
+  bottom:2px;
+  height:18px;
+  border-radius:999px;
+  background: radial-gradient(60% 140% at 50% 0%, rgba(0,240,255,.34), rgba(0,120,180,.18) 62%, rgba(0,40,80,.1));
+  box-shadow: 0 0 16px rgba(0,220,255,.22), inset 0 0 10px rgba(120,240,255,.2);
+  border:1px solid rgba(120,220,255,.3);
+  pointer-events:none;
 }
 .lb-ranking-podium-item{
-  border:1px solid rgba(0,240,255,.25);
-  border-radius:10px;
-  padding:6px 5px;
-  background:rgba(8,18,32,.7);
+  position: relative;
+  z-index: 1;
+  display:grid;
+  gap:6px;
   text-align:center;
-  min-height:56px;
+  min-width: 0;
 }
-.lb-ranking-podium-item.pos-1{ min-height:68px; box-shadow:0 0 12px rgba(0,240,255,.18); }
-.lb-ranking-podium-item .rank{ font-size:.68rem; color:#8fdaf2; }
-.lb-ranking-podium-item .pseudo{ font-size:.78rem; font-weight:700; color:#e6f9ff; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.lb-ranking-podium-item .meta{ font-size:.64rem; color:#a7c4d8; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.lb-ranking-podium-item .podium-caption{
+  display:grid;
+  gap:1px;
+  align-items:center;
+  justify-items:center;
+  min-height: 30px;
+}
+.lb-ranking-podium-item .pseudo{
+  max-width: 100%;
+  font-size:.74rem;
+  font-weight:800;
+  color:#eafcff;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+.lb-ranking-podium-item .meta{
+  font-size:.63rem;
+  color:#b9d9e9;
+  white-space:nowrap;
+}
+.lb-ranking-podium-item .podium-step{
+  height: 46px;
+  border-radius: 12px 12px 10px 10px;
+  border:1px solid rgba(120,220,255,.4);
+  background: linear-gradient(180deg, rgba(12,44,66,.82), rgba(8,20,34,.9));
+  box-shadow: inset 0 1px 0 rgba(220,250,255,.18), inset 0 -8px 12px rgba(0,0,0,.25), 0 4px 10px rgba(0,0,0,.26);
+  display:grid;
+  place-items:center;
+}
+.lb-ranking-podium-item .rank{
+  font-size:1.8rem;
+  line-height:1;
+  font-weight:900;
+  letter-spacing:.02em;
+  color:#dff8ff;
+  text-shadow: 0 0 10px rgba(0,240,255,.35);
+}
+.lb-ranking-podium-item.pos-1 .podium-step{
+  height: 62px;
+  border-color: rgba(255,216,108,.72);
+  background: linear-gradient(180deg, rgba(120,88,6,.9), rgba(255,198,45,.26) 42%, rgba(80,52,5,.94));
+  box-shadow: inset 0 1px 0 rgba(255,245,180,.25), inset 0 -10px 14px rgba(80,45,0,.3), 0 0 18px rgba(255,210,70,.28);
+}
+.lb-ranking-podium-item.pos-1 .rank{
+  color:#fff2a4;
+  text-shadow: 0 0 12px rgba(255,220,88,.45);
+}
+.lb-ranking-podium-item.pos-2 .podium-step{
+  height: 50px;
+  background: linear-gradient(180deg, rgba(90,130,155,.9), rgba(20,45,62,.92));
+  border-color: rgba(188,230,248,.6);
+}
+.lb-ranking-podium-item.pos-3 .podium-step{
+  height: 42px;
+  background: linear-gradient(180deg, rgba(150,90,30,.9), rgba(62,30,8,.94));
+  border-color: rgba(255,190,110,.58);
+}
+.lb-ranking-podium-item.pos-3 .rank{
+  color:#ffd2a2;
+  text-shadow: 0 0 10px rgba(255,170,80,.35);
+}
 .lb-ranking-list{
   display:grid;
   gap:4px;
@@ -6328,7 +6402,7 @@ body.modal-open{ overflow:hidden; }
 }
 
 #lbAuthModal{
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
   padding:
     calc(var(--top-bar-height, 72px) + env(safe-area-inset-top, 0px) + 10px)
@@ -6427,6 +6501,11 @@ body.modal-open{ overflow:hidden; }
   justify-content:center;
   text-align:center;
   white-space:normal;
+}
+#lbAuthModal .lb-auth-actions #lbBtnLogout{
+  grid-column: 1 / -1;
+  width: min(240px, 100%);
+  justify-self: center;
 }
 #lbAuthModal .lb-auth-actions #lbBtnContact{
   grid-column: 1 / -1;
@@ -6656,7 +6735,7 @@ body.modal-open{ overflow:hidden; }
 
 /* === PATCH index50: prefs modal fully visible between fixed bars === */
 #lbPrefsModal{
-  align-items:flex-start !important;
+  align-items:center !important;
   justify-content:center !important;
   padding-top: calc(var(--top-bar-height, 72px) + 14px) !important;
   padding-bottom: calc(var(--bottom-bar-height, 84px) + 14px) !important;
@@ -6695,6 +6774,20 @@ body.modal-open{ overflow:hidden; }
 #lbPrefsModal .lb-prefs-section input,
 #lbPrefsModal .lb-prefs-section select{
   padding: 8px 10px;
+  border: 1px solid rgba(120,220,255,.38);
+  background: linear-gradient(180deg, rgba(7,20,34,.9), rgba(5,16,28,.88));
+  color: #e6f7ff;
+  box-shadow: inset 0 0 12px rgba(0,220,255,.14);
+}
+#lbPrefsModal .lb-prefs-grid input::placeholder,
+#lbPrefsModal .lb-prefs-section input::placeholder{
+  color: rgba(168, 208, 224, .72);
+}
+#lbPrefsModal .lb-prefs-grid input:-webkit-autofill,
+#lbPrefsModal .lb-prefs-section input:-webkit-autofill{
+  -webkit-text-fill-color: #e6f7ff;
+  -webkit-box-shadow: 0 0 0 1000px rgba(7,20,34,.95) inset;
+  transition: background-color 9999s ease-out 0s;
 }
 #lbPrefsModal .lb-prefs-utility{
   margin-top: 8px !important;
@@ -6776,6 +6869,26 @@ body.modal-open{ overflow:hidden; }
 }
 .lb-prefs-build:hover{
   box-shadow: 0 0 16px rgba(0,220,255,.35);
+}
+#presetBuilderModal .lb-auth-card{
+  width: min(420px, 94vw);
+}
+#presetBuilderModal .lb-prefs-note{
+  margin-bottom: 8px;
+  font-size: .76rem;
+  line-height: 1.2;
+}
+#presetBuilderModal .lb-auth-fields{
+  gap: 7px;
+}
+#presetBuilderModal .lb-auth-fields input{
+  background: linear-gradient(180deg, rgba(7,20,34,.9), rgba(5,16,28,.88));
+  border: 1px solid rgba(120,220,255,.38);
+  color: #e6f7ff;
+  box-shadow: inset 0 0 12px rgba(0,220,255,.14);
+}
+#presetBuilderModal .lb-auth-actions{
+  margin-top: 8px;
 }    
 .preset-btn--add{
   border-style: dashed;
@@ -11170,7 +11283,6 @@ body{
           <input id="lbPresetLabelAM" type="text" placeholder="Matin">
           <label class="visually-hidden" for="lbPresetTrainsAM">Trains de la liste 1</label>
           <input id="lbPresetTrainsAM" type="text" placeholder="88704, 88706, 88708">
-          <small>Format : 10 numéros max, séparés par des virgules.</small>
           <button class="lb-prefs-build" type="button" data-preset-build="AM">Rechercher</button>
         </div>
         <div class="lb-prefs-section" data-preset="PM">
@@ -11179,7 +11291,6 @@ body{
           <input id="lbPresetLabelPM" type="text" placeholder="Soir">
           <label class="visually-hidden" for="lbPresetTrainsPM">Trains de la liste 2</label>
           <input id="lbPresetTrainsPM" type="text" placeholder="88741, 88743, 88745">
-          <small>Format : 10 numéros max, séparés par des virgules.</small>
           <button class="lb-prefs-build" type="button" data-preset-build="PM">Rechercher</button>
         </div>
         <div class="lb-prefs-section lb-prefs-section--optional" data-preset="L3">
@@ -11188,7 +11299,6 @@ body{
           <input id="lbPresetLabelL3" type="text" placeholder="Liste 3">
           <label class="visually-hidden" for="lbPresetTrainsL3">Trains de la liste 3</label>
           <input id="lbPresetTrainsL3" type="text" placeholder="88752, 88754, 88756">
-          <small>Format : 10 numéros max, séparés par des virgules.</small>
           <button class="lb-prefs-build" type="button" data-preset-build="L3">Rechercher</button>
           <button class="lb-prefs-remove" type="button" data-remove-preset="L3">Supprimer la liste 3</button>
         </div>
@@ -11198,7 +11308,6 @@ body{
           <input id="lbPresetLabelL4" type="text" placeholder="Liste 4">
           <label class="visually-hidden" for="lbPresetTrainsL4">Trains de la liste 4</label>
           <input id="lbPresetTrainsL4" type="text" placeholder="88760, 88762, 88764">
-          <small>Format : 10 numéros max, séparés par des virgules.</small>
           <button class="lb-prefs-build" type="button" data-preset-build="L4">Rechercher</button>
           <button class="lb-prefs-remove" type="button" data-remove-preset="L4">Supprimer la liste 4</button>
         </div>
@@ -13254,7 +13363,7 @@ html, body{
   <div class="lb-auth-card" role="dialog" aria-modal="true" aria-labelledby="presetBuilderTitle">
     <button id="presetBuilderClose" class="lb-auth-close tron-close-button" type="button" aria-label="Fermer"></button>
     <h3 id="presetBuilderTitle">Sélection liste</h3>
-    <p class="lb-prefs-note">Choisis les critères pour générer des trains, puis sélectionne les chips à ajouter (10 max).</p>
+    <p class="lb-prefs-note">Choisis les critères puis ajoute jusqu’à 10 trains.</p>
     <div class="lb-auth-fields">
       <label for="presetStartSearch">Gare de départ</label>
       <input id="presetStartSearch" type="search" list="stationNamesList" placeholder="Tape Nancy, Champigneulles..." autocomplete="off">
@@ -23028,8 +23137,22 @@ function scheduleWeatherAfterTableSettled(){
     const top3 = ranking.slice(0, 3);
     const podiumHtml = [2,1,3].map((rankNum)=>{
       const item = top3.find((it)=> it.rank === rankNum);
-      if (!item) return `<div class="lb-ranking-podium-item pos-${rankNum}"><div class="rank">#${rankNum}</div><div class="pseudo">—</div></div>`;
-      return `<div class="lb-ranking-podium-item pos-${rankNum}"><div class="rank">#${item.rank}</div><div class="pseudo">${escapeHtml(item.pseudo)}</div><div class="meta">${escapeHtml(item.grade)} · ${escapeHtml(String(item.points))}</div></div>`;
+      if (!item){
+        return `<div class="lb-ranking-podium-item pos-${rankNum}">
+          <div class="podium-caption">
+            <div class="pseudo">—</div>
+            <div class="meta">0 meuh</div>
+          </div>
+          <div class="podium-step"><div class="rank">${rankNum}</div></div>
+        </div>`;
+      }
+      return `<div class="lb-ranking-podium-item pos-${rankNum}">
+        <div class="podium-caption">
+          <div class="pseudo">${escapeHtml(item.pseudo)}</div>
+          <div class="meta">${escapeHtml(String(item.points))} meuh</div>
+        </div>
+        <div class="podium-step"><div class="rank">${item.rank}</div></div>
+      </div>`;
     }).join('');
     if (podium) podium.innerHTML = podiumHtml;
     if (podiumInline) podiumInline.innerHTML = podiumHtml;


### PR DESCRIPTION
### Motivation
- Improve the visual presentation of the leaderboard podium and its responsiveness to better highlight top ranks.
- Make authentication and preferences modals center within the viewport between fixed top/bottom bars and improve layout/controls for mobile.
- Provide improved input styling (including autofill handling) and a compact preset builder UI text for a clearer user experience.

### Description
- Add extensive CSS for ` .lb-ranking-podium`, `.lb-ranking-podium-item`, `.podium-step`, `.podium-caption`, and per-position variants (`.pos-1`, `.pos-2`, `.pos-3`) including a background glow/shadow via `::after`, adjusted gaps, paddings and z-indexing. 
- Change podium render markup generated by JavaScript to a richer structure (caption + step) and update empty-slot fallbacks to use the new HTML (`.podium-caption` + `.podium-step` with `.rank` and `.pseudo`/`.meta`).
- Align `#lbAuthModal` and `#lbPrefsModal` to center (`align-items: center`), tweak `#lbAuthModal .lb-auth-actions #lbBtnLogout` to span columns and center, and adjust sizing/padding/scrolling constraints for modal content (`.lb-auth-card`).
- Add input styling and autofill fixes for `#lbPrefsModal` and `#presetBuilderModal` fields, adjust a few spacing rules and remove redundant helper `small` lines in presets, and shorten the preset builder instruction copy.
- Add minor layout tweaks elsewhere (small gap adjustments, added final newline in `index56.html`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3b09832c832d85e03c6b0ce29c75)