### PR TITLE
Ranking UI: add load-more button, medal badges and podium/CSS adjustments

### DIFF
--- a/index57.html
+++ b/index57.html
@@ -6109,7 +6109,7 @@ body.modal-open{ overflow:hidden; }
   font-weight:900;
   text-shadow:0 0 8px rgba(255,230,161,.22);
 }
-.lb-grade-inline img{
+.lb-grade-inline #lbProfileGradeImage{
   width: 116px;
   height: 116px;
   border-radius: 50%;
@@ -6153,21 +6153,58 @@ body.modal-open{ overflow:hidden; }
   font-size:.74rem;
   padding:5px 7px;
 }
+.lb-ranking-actions{
+  display:flex;
+  align-items:center;
+  gap:6px;
+}
+.lb-ranking-default{
+  font-size:.74rem;
+  font-weight:700;
+  color:#dffbff;
+  padding:5px 7px;
+  border:1px solid rgba(120,220,255,.2);
+  border-radius:9px;
+  background:rgba(6,16,28,.45);
+}
+.lb-ranking-loadmore{
+  min-width:28px;
+  height:28px;
+  padding:0 8px;
+  border-radius:9px;
+  border:1px solid rgba(120,220,255,.42);
+  background:rgba(6,16,28,.9);
+  color:#dffbff;
+  font-size:.98rem;
+  font-weight:800;
+  line-height:1;
+  cursor:pointer;
+}
+.lb-ranking-loadmore[disabled]{
+  opacity:.42;
+  cursor:default;
+}
 .lb-ranking-podium{
   position: relative;
-  margin: 4px 0 6px;
+  margin: 10px auto 6px;
+  display: flex;
+  justify-content: center;
 }
 .lb-ranking-podium-visual{
   position: relative;
   width: 100%;
-  max-width: 360px;
+  max-width: 432px;
   margin: 0 auto;
-  padding-top: 38px;
+  padding-top: 16px;
 }
 .lb-ranking-podium-art{
-  width: 100%;
+  width: 104%;
   height: auto;
   display: block;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 14px 0 0;
   object-fit: contain;
   filter: drop-shadow(0 8px 16px rgba(0,0,0,.35));
 }
@@ -6210,12 +6247,15 @@ body.modal-open{ overflow:hidden; }
 .lb-ranking-podium-item .rank{
   display:none;
 }
-.lb-ranking-podium-item.pos-2{ left: 18%; top: 2px; }
-.lb-ranking-podium-item.pos-1{ left: 50%; top: -6px; }
-.lb-ranking-podium-item.pos-3{ left: 82%; top: 2px; }
+.lb-ranking-podium-item.pos-2{ left: 18%; top: 12px; }
+.lb-ranking-podium-item.pos-1{ left: 50%; top: 4px; }
+.lb-ranking-podium-item.pos-3{ left: 82%; top: 12px; }
 @media (max-width: 420px){
   .lb-ranking-podium-visual{
-    padding-top: 34px;
+    padding-top: 14px;
+  }
+  .lb-ranking-podium-art{
+    margin-top: 10px;
   }
   .lb-ranking-podium-item .podium-caption{
     padding: 3px 5px;
@@ -6242,6 +6282,47 @@ body.modal-open{ overflow:hidden; }
   font-size:.73rem;
 }
 .lb-ranking-row.me{ color:#8df7ff; border-color: rgba(0,240,255,.35); }
+.lb-rank-cell{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:22px;
+}
+.lb-rank-medal{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:16px;
+  height:16px;
+  filter: drop-shadow(0 0 6px rgba(0,240,255,.25));
+}
+.lb-rank-medal img{
+  width:100%;
+  height:100%;
+  object-fit:contain;
+  display:block;
+}
+.lb-rank-medal--profile{
+  width:48px;
+  height:48px;
+}
+
+#lbAuthModal .lb-grade-inline .lb-grade-rank-badge{
+  min-width:0 !important;
+  padding:0 !important;
+  border:none !important;
+  background:transparent !important;
+  box-shadow:none !important;
+  top:8px !important;
+  right:calc(50% - 56px) !important;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-rank-badge__label{
+  display:none !important;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-rank-badge__value{
+  color:inherit !important;
+  text-shadow:none !important;
+}
 
 .lb-pseudo-trigger{
   display:inline-flex;
@@ -6430,7 +6511,7 @@ body.modal-open{ overflow:hidden; }
   gap: 4px;
   border-radius: 16px;
 }
-#lbAuthModal .lb-grade-inline img{
+#lbAuthModal .lb-grade-inline #lbProfileGradeImage{
   width: 98px;
   height: 98px;
 }
@@ -6567,7 +6648,7 @@ body.modal-open{ overflow:hidden; }
     padding:7px 8px;
     font-size:.8rem;
   }
-  #lbAuthModal .lb-grade-inline img{
+  #lbAuthModal .lb-grade-inline #lbProfileGradeImage{
     width:92px;
     height:92px;
   }
@@ -10061,6 +10142,18 @@ body.page-carte #affluence{ display:none !important; }
 #lbAuthModal .lb-grade-inline .lb-grade-rank-badge__label{ font-size:.49rem !important; }
 #lbAuthModal .lb-grade-inline .lb-grade-rank-badge__value{ font-size:.8rem !important; }
 
+/* Rang profil: médaille seule (sans fond/contour de capsule) */
+#lbAuthModal .lb-grade-inline .lb-grade-rank-badge{
+  min-width:0 !important;
+  padding:0 !important;
+  border:none !important;
+  background:transparent !important;
+  box-shadow:none !important;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-rank-badge__label{
+  display:none !important;
+}
+
 </style>
   <style>
 @supports (-webkit-touch-callout: none) {
@@ -11129,12 +11222,10 @@ body{
           <div class="lb-profile-ranking-top">
             <div class="lb-ranking-head lb-ranking-head--inline">
               <div class="lb-profile-title" style="margin:0;">Classement</div>
-              <select id="lbRankingFilterInline" class="lb-ranking-filter">
-                <option value="top10" selected>Top 10</option>
-                <option value="top3">Top 3</option>
-                <option value="top50">Top 50</option>
-                <option value="around">Autour de moi</option>
-              </select>
+              <div class="lb-ranking-actions">
+                <span class="lb-ranking-default">Top 10</span>
+                <button id="lbRankingLoadMoreInline" class="lb-ranking-loadmore" type="button" aria-label="Afficher plus de rangs">+</button>
+              </div>
             </div>
             <div class="lb-profile-rank-badge"><b>Rang</b><span id="lbProfileRankInline">—</span></div>
           </div>
@@ -11209,12 +11300,10 @@ body{
       <h3 id="lbRankingTitle">Classement du troupeau</h3>
       <div class="lb-ranking-head">
         <div class="lb-profile-title" style="margin:0;">Classement</div>
-        <select id="lbRankingFilter" class="lb-ranking-filter">
-          <option value="top10" selected>Top 10</option>
-          <option value="top3">Top 3</option>
-          <option value="top50">Top 50</option>
-          <option value="around">Autour de moi</option>
-        </select>
+        <div class="lb-ranking-actions">
+          <span class="lb-ranking-default">Top 10</span>
+          <button id="lbRankingLoadMore" class="lb-ranking-loadmore" type="button" aria-label="Afficher plus de rangs">+</button>
+        </div>
       </div>
       <div id="lbRankingPodium" class="lb-ranking-podium"></div>
       <div id="lbRankingList" class="lb-ranking-list"></div>
@@ -22395,6 +22484,7 @@ function scheduleWeatherAfterTableSettled(){
   let currentUser = null;
   window.currentUser = null;
   const lbGamificationState = { profile: null, ranking: [], myRank: null, me: null, lastFetchAt: 0, inflight: null };
+  let lbRankingVisibleCount = 10;
   const LB_GRADE_LEVELS = [
     { name: 'Mouton égaré', min: 0, image: 'Mouton égaré.png' },
     { name: 'Poulet du Quai', min: 120, image: 'Poulet du Quai.png' },
@@ -23076,6 +23166,25 @@ function scheduleWeatherAfterTableSettled(){
     })).filter((it)=> it.rank > 0).sort((a,b)=> a.rank - b.rank);
   }
 
+  function rankMedalSrc(rank){
+    const safeRank = Number(rank || 0) || 0;
+    if (safeRank === 1) return 'https://raw.githubusercontent.com/TekMaTe-lux/Assistant-train/main/MedailleOR.png';
+    if (safeRank === 2) return 'https://raw.githubusercontent.com/TekMaTe-lux/Assistant-train/main/MedailleARGENT.png';
+    if (safeRank === 3) return 'https://raw.githubusercontent.com/TekMaTe-lux/Assistant-train/main/MedailleBRONZE.png';
+    if (safeRank === 4) return 'https://raw.githubusercontent.com/TekMaTe-lux/Assistant-train/main/MedailleCHOCO.png';
+    return '';
+  }
+
+  function rankDisplayHtml(rank, options = {}){
+    const safeRank = Number(rank || 0) || 0;
+    const medalSrc = rankMedalSrc(safeRank);
+    if (medalSrc){
+      const extraClass = options.profile ? ' lb-rank-medal--profile' : '';
+      return `<span class="lb-rank-medal${extraClass}" aria-label="Rang ${safeRank}" title="Rang ${safeRank}"><img src="${medalSrc}" alt="Médaille rang ${safeRank}" loading="lazy" decoding="async"></span>`;
+    }
+    return safeRank > 0 ? `#${safeRank}` : '—';
+  }
+
   function renderGamificationUI(){
     const host = $("lbProfileTroupeau");
     const rankingHostInline = $("lbProfileRankingInline");
@@ -23083,18 +23192,8 @@ function scheduleWeatherAfterTableSettled(){
     const listEl = $("lbRankingList");
     const podiumInline = $("lbRankingPodiumInline");
     const listElInline = $("lbRankingListInline");
-    const filter = $("lbRankingFilter");
-    const filterInline = $("lbRankingFilterInline");
-    if (filterInline && filter && !filterInline.dataset.lbMirrorBound){
-      filterInline.dataset.lbMirrorBound = '1';
-      filterInline.addEventListener('change', ()=>{
-        if (filter) filter.value = filterInline.value || 'top10';
-        renderGamificationUI();
-      });
-    }
-    if (filter && filterInline && filter.value !== filterInline.value){
-      filterInline.value = filter.value || 'top10';
-    }
+    const loadMoreBtn = $("lbRankingLoadMore");
+    const loadMoreBtnInline = $("lbRankingLoadMoreInline");
     const canShowProfile = window.lbIsAuthed === true;
     if (host) host.style.display = canShowProfile ? "grid" : "none";
     if (rankingHostInline) rankingHostInline.style.display = "none";
@@ -23108,9 +23207,10 @@ function scheduleWeatherAfterTableSettled(){
     if ($("lbProfilePseudoDisplay")) $("lbProfilePseudoDisplay").textContent = pseudo || "—";
     if ($("lbProfileGrade")) $("lbProfileGrade").textContent = grade || "—";
     if ($("lbProfilePoints")) $("lbProfilePoints").textContent = `${points} meuh`;
-    if ($("lbProfileRank")) $("lbProfileRank").textContent = myRank ? `#${myRank}` : "—";
-    if ($("lbProfileRankInline")) $("lbProfileRankInline").textContent = myRank ? `#${myRank}` : "—";
-    if ($("lbProfileRankBadgeText")) $("lbProfileRankBadgeText").textContent = myRank ? `#${myRank}` : "—";
+    const profileRankHtml = rankDisplayHtml(myRank, { profile: true });
+    if ($("lbProfileRank")) $("lbProfileRank").innerHTML = profileRankHtml;
+    if ($("lbProfileRankInline")) $("lbProfileRankInline").innerHTML = profileRankHtml;
+    if ($("lbProfileRankBadgeText")) $("lbProfileRankBadgeText").innerHTML = profileRankHtml;
     renderPrefsGradeCard(grade, points);
 
     const top3 = ranking.slice(0, 3);
@@ -23138,26 +23238,24 @@ function scheduleWeatherAfterTableSettled(){
     if (podium) podium.innerHTML = podiumHtml;
     if (podiumInline) podiumInline.innerHTML = podiumHtml;
 
-    const mode = (filterInline?.value || filter?.value || 'top10');
-    if (filter) filter.value = mode;
-    if (filterInline) filterInline.value = mode;
-    let rows = ranking;
-    if (mode === 'top3') rows = ranking.slice(0, 3);
-    else if (mode === 'top10') rows = ranking.slice(0, 10);
-    else if (mode === 'top50') rows = ranking.slice(0, 50);
-    else if (mode === 'around'){
-      const aroundRank = myRank || Number(lbGamificationState?.me?.rank || 0) || ranking.find((it)=> it.me)?.rank || null;
-      if (aroundRank){
-        rows = ranking.filter((it)=> Math.abs(it.rank - aroundRank) <= 2).slice(0, 7);
-      } else {
-        rows = ranking.slice(0, 10);
-      }
-    }
+    const visibleCount = Math.max(10, Number(lbRankingVisibleCount || 10));
+    const rows = ranking.slice(0, visibleCount);
     const listHtml = rows.length
-      ? rows.map((it)=> `<div class="lb-ranking-row${(myRank && it.rank === myRank) ? ' me' : ''}"><span>#${it.rank}</span><span title="${escapeHtml(it.grade)}">${escapeHtml(it.pseudo)}</span><span>${escapeHtml(String(it.points))} 🐮</span></div>`).join('')
+      ? rows.map((it)=> `<div class="lb-ranking-row${(myRank && it.rank === myRank) ? ' me' : ''}"><span class="lb-rank-cell">${rankDisplayHtml(it.rank)}</span><span title="${escapeHtml(it.grade)}">${escapeHtml(it.pseudo)}</span><span>${escapeHtml(String(it.points))} 🐮</span></div>`).join('')
       : '<div class="live-wall-empty">Classement indisponible.</div>';
     if (listEl) listEl.innerHTML = listHtml;
     if (listElInline) listElInline.innerHTML = listHtml;
+    const canLoadMore = ranking.length > visibleCount;
+    if (loadMoreBtn){
+      loadMoreBtn.style.display = ranking.length > 10 ? "inline-flex" : "none";
+      loadMoreBtn.disabled = !canLoadMore;
+      loadMoreBtn.textContent = canLoadMore ? '+' : '✓';
+    }
+    if (loadMoreBtnInline){
+      loadMoreBtnInline.style.display = ranking.length > 10 ? "inline-flex" : "none";
+      loadMoreBtnInline.disabled = !canLoadMore;
+      loadMoreBtnInline.textContent = canLoadMore ? '+' : '✓';
+    }
   }
 
   function resetGamificationUI(){
@@ -23167,6 +23265,7 @@ function scheduleWeatherAfterTableSettled(){
     lbGamificationState.me = null;
     lbGamificationState.lastFetchAt = 0;
     lbGamificationState.inflight = null;
+    lbRankingVisibleCount = 10;
     lbProfileCache = null;
     lbRankingCache = null;
     lbCurrentMe = null;
@@ -24542,8 +24641,8 @@ if (statsEl){
   const prefsSaveBtn = $("lbSavePrefs");
   const prefsAddListBtn = $("lbAddPrefsList");
   const prefsResetBtn = $("lbResetPresets");
-  const rankingFilter = $("lbRankingFilter");
-  const rankingFilterInline = $("lbRankingFilterInline");
+  const rankingLoadMoreBtn = $("lbRankingLoadMore");
+  const rankingLoadMoreBtnInline = $("lbRankingLoadMoreInline");
   const quickAddListBtn = $("lbQuickAddList");
   const registerModal = $("lbRegisterModal");
   const rankingModal = $("lbRankingModal");
@@ -24560,17 +24659,17 @@ if (statsEl){
 
   if (!openBtn || !closeBtn || !modal || !submitBtn || !logoutBtn) return;
 
-  if (rankingFilter && !rankingFilter.dataset.bound){
-    rankingFilter.dataset.bound = '1';
-    rankingFilter.addEventListener('change', ()=>{
-      if (rankingFilterInline) rankingFilterInline.value = rankingFilter.value || 'top10';
+  if (rankingLoadMoreBtn && !rankingLoadMoreBtn.dataset.bound){
+    rankingLoadMoreBtn.dataset.bound = '1';
+    rankingLoadMoreBtn.addEventListener('click', ()=>{
+      lbRankingVisibleCount += 10;
       renderGamificationUI();
     });
   }
-  if (rankingFilterInline && !rankingFilterInline.dataset.bound){
-    rankingFilterInline.dataset.bound = '1';
-    rankingFilterInline.addEventListener('change', ()=>{
-      if (rankingFilter) rankingFilter.value = rankingFilterInline.value || 'top10';
+  if (rankingLoadMoreBtnInline && !rankingLoadMoreBtnInline.dataset.bound){
+    rankingLoadMoreBtnInline.dataset.bound = '1';
+    rankingLoadMoreBtnInline.addEventListener('click', ()=>{
+      lbRankingVisibleCount += 10;
       renderGamificationUI();
     });
   }


### PR DESCRIPTION
### Motivation
- Replace the old select-based ranking filter with a simpler "Top" display and a progressive "load more" control to improve usability and mobile layout. 
- Show medal icons for top ranks and display a compact medal-only badge in profile modal to make rank presentation clearer. 
- Tweak podium and avatar sizing/positioning to better fit the redesigned visuals and responsive breakpoints.

### Description
- Reworked ranking UI: replaced `#lbRankingFilter`/`#lbRankingFilterInline` selects with `.lb-ranking-actions` containing a `span.lb-ranking-default` and a `button.lb-ranking-loadmore`, and added related CSS styles.  
- Added client-side state `lbRankingVisibleCount` and click handlers that increment it to implement progressive loading via the `lbRankingLoadMore`/`lbRankingLoadMoreInline` buttons.  
- Introduced `rankMedalSrc` and `rankDisplayHtml` functions to render rank medals (first 4 ranks use remote PNGs) and replaced textual `#N` rank output with medal HTML where applicable.  
- Updated `renderGamificationUI`/`resetGamificationUI` to use `lbRankingVisibleCount`, produce rows with `.lb-rank-cell` and medal markup, and toggle the load-more button state and label.  
- CSS and layout changes: renamed avatar selector to `#lbProfileGradeImage`, adjusted podium art width/margins, podium item positions, modal badge styling (medal-only look in `#lbAuthModal`), and added classes for `.lb-rank-medal`, `.lb-rank-cell`, `.lb-ranking-actions`, and related styles.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df54d8d5e4832dac250787c0e946f3)