### PR TITLE
Rafraîchissement visuel mobile — Mon compte / Mon profil troupeau

### DIFF
--- a/index57.html
+++ b/index57.html
@@ -10048,79 +10048,211 @@ body.page-carte #affluence{ display:none !important; }
   }
 }
 
-/* ===== index55 premium account grade overrides ===== */
-.lb-profile-card{
-  border: none !important;
-  border-radius: 18px !important;
-  background: linear-gradient(180deg, rgba(6,18,30,.34), rgba(4,14,24,.18)) !important;
-  box-shadow: none !important;
-  padding: 4px 2px 2px !important;
+/* ===== Premium mobile refresh (Mon compte / Mon profil troupeau) ===== */
+#lbAuthModal::before{
+  content:"";
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  background: radial-gradient(circle at 55% 22%, rgba(2,24,42,.52), rgba(1,8,18,.68) 62%, rgba(0,4,10,.78));
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
 }
-.lb-grade-inline{
-  border: 1px solid rgba(0,240,255,.18) !important;
-  border-radius: 22px !important;
-  background:
-    radial-gradient(circle at 50% -12%, rgba(0,255,255,.12), transparent 52%),
-    linear-gradient(180deg, rgba(5,18,30,.86), rgba(3,12,22,.9)) !important;
-  box-shadow:
-    0 10px 24px rgba(0,0,0,.24),
-    inset 0 1px 0 rgba(160,245,255,.05) !important;
-  padding: 14px 14px 12px !important;
+#lbAuthModal .lb-auth-card{
+  position:relative;
+  z-index:1;
 }
-.lb-grade-inline .lb-grade-avatar-wrap{ position: relative; }
-.lb-grade-inline .lb-grade-rank-badge{
-  position:absolute !important;
-  top:2px !important;
-  right:calc(50% - 86px) !important;
-  min-width:64px !important;
-  padding:6px 10px 5px !important;
-  border-radius:14px !important;
-  border:1px solid rgba(255,214,102,.72) !important;
-  background:linear-gradient(180deg, rgba(74,55,16,.96), rgba(42,31,8,.94)) !important;
-  box-shadow:0 8px 18px rgba(0,0,0,.26), 0 0 14px rgba(255,196,44,.14), inset 0 1px 0 rgba(255,242,186,.22) !important;
-  backdrop-filter:none !important;
-  -webkit-backdrop-filter:none !important;
-  display:flex !important;
-  flex-direction:column !important;
-  align-items:center !important;
-  gap:2px !important;
-  z-index:2 !important;
-}
-.lb-grade-inline .lb-grade-rank-badge__label{
-  font-size:.54rem !important;
-  line-height:1 !important;
-  letter-spacing:.08em !important;
-  color:#f4d67a !important;
-  text-transform:uppercase !important;
+#lbAuthModal .lb-auth-card h3{
+  font-size:1.28rem !important;
   font-weight:800 !important;
+  color:#eafcff !important;
+  letter-spacing:.01em;
+  display:flex;
+  align-items:center;
+  gap:8px;
 }
-.lb-grade-inline .lb-grade-rank-badge__value{
-  font-size:.95rem !important;
-  line-height:1 !important;
-  color:#fff7d4 !important;
-  font-weight:900 !important;
-  text-shadow:none !important;
+#lbAuthModal .lb-auth-card h3::before{
+  content:"◈";
+  color:#7cf5ff;
+  font-size:.9em;
+  text-shadow: 0 0 8px rgba(77,236,255,.55);
+}
+#lbAuthModal .lb-profile-card{
+  margin: 5px 0 12px !important;
+  padding: 11px !important;
+  gap: 10px !important;
+  border-radius: 18px !important;
+  border: 1px solid rgba(95,241,255,.42) !important;
+  background:
+    radial-gradient(circle at 50% -8%, rgba(56,166,255,.2), transparent 54%),
+    linear-gradient(165deg, rgba(9,26,45,.86), rgba(5,15,28,.94) 68%, rgba(2,9,20,.97)) !important;
+  box-shadow:
+    0 10px 26px rgba(0,0,0,.34),
+    inset 0 1px 0 rgba(185,252,255,.08),
+    inset 0 -8px 20px rgba(0,0,0,.32),
+    inset 0 0 18px rgba(0,204,255,.09),
+    0 0 16px rgba(53,224,255,.14) !important;
+}
+#lbAuthModal .lb-profile-title{
+  font-size:.73rem !important;
+  letter-spacing:.12em !important;
+  color:#9edbe7 !important;
+  opacity:.92;
+}
+#lbAuthModal .lb-grade-inline{
+  border: 1px solid rgba(115,245,255,.28) !important;
+  border-radius: 17px !important;
+  background:
+    radial-gradient(circle at 50% -18%, rgba(56,223,255,.16), transparent 52%),
+    linear-gradient(180deg, rgba(7,22,38,.92), rgba(3,13,24,.95)) !important;
+  box-shadow:
+    inset 0 0 0 1px rgba(153,244,255,.03),
+    inset 0 -10px 22px rgba(0,0,0,.28),
+    0 6px 18px rgba(0,0,0,.24) !important;
+  padding: 12px 11px 11px !important;
+  gap: 7px !important;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-pseudo{
+  font-size:.94rem !important;
+  font-weight:800 !important;
+  color:#ecfcff !important;
+  text-shadow:0 1px 0 rgba(0,0,0,.34);
+}
+#lbAuthModal .lb-grade-inline .lb-grade-avatar-wrap{
+  position:relative;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-avatar-wrap::before{
+  content:"";
+  position:absolute;
+  width:112px;
+  height:112px;
+  left:50%;
+  top:50%;
+  transform:translate(-50%,-50%);
+  border-radius:50%;
+  background:radial-gradient(circle, rgba(0,239,255,.32) 0%, rgba(0,239,255,.14) 44%, rgba(0,239,255,0) 72%);
+  filter: blur(5px);
+  pointer-events:none;
+}
+#lbAuthModal .lb-grade-inline #lbProfileGradeImage{
+  position:relative;
+  width:92px !important;
+  height:92px !important;
+  border-radius:50%;
+  border:1px solid rgba(132,250,255,.6) !important;
+  box-shadow:
+    0 0 0 2px rgba(5,18,32,.9),
+    0 0 14px rgba(66,236,255,.22),
+    inset 0 1px 6px rgba(180,249,255,.16) !important;
 }
 #lbAuthModal .lb-grade-inline .lb-grade-rank-badge{
-  top:3px !important;
-  right:calc(50% - 72px) !important;
-  min-width:56px !important;
-  padding:5px 8px 4px !important;
-  border-radius:12px !important;
-}
-#lbAuthModal .lb-grade-inline .lb-grade-rank-badge__label{ font-size:.49rem !important; }
-#lbAuthModal .lb-grade-inline .lb-grade-rank-badge__value{ font-size:.8rem !important; }
-
-/* Rang profil: médaille seule (sans fond/contour de capsule) */
-#lbAuthModal .lb-grade-inline .lb-grade-rank-badge{
+  position:absolute !important;
+  top:-3px !important;
+  right:calc(50% - 61px) !important;
   min-width:0 !important;
   padding:0 !important;
   border:none !important;
+  border-radius:0 !important;
   background:transparent !important;
   box-shadow:none !important;
+  z-index:3 !important;
 }
 #lbAuthModal .lb-grade-inline .lb-grade-rank-badge__label{
   display:none !important;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-rank-badge__value{
+  width:28px;
+  height:28px;
+  border-radius:50%;
+  display:grid;
+  place-items:center;
+  font-size:.72rem !important;
+  font-weight:900 !important;
+  color:#fff8dd !important;
+  background:radial-gradient(circle at 35% 30%, #fff0b8, #d19a1f 54%, #8c5e00);
+  border:1px solid rgba(255,231,167,.8);
+  box-shadow: 0 3px 10px rgba(0,0,0,.35), 0 0 10px rgba(255,208,94,.3);
+  text-shadow:0 1px 1px rgba(71,44,0,.45);
+}
+#lbAuthModal .lb-grade-inline .lb-grade-name{
+  margin-top:4px !important;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  align-self:center;
+  border-radius:999px;
+  padding:7px 14px 6px !important;
+  border:1px solid rgba(113,244,255,.4);
+  background:linear-gradient(180deg, rgba(7,27,43,.8), rgba(4,17,29,.9));
+  color:#e6fbff !important;
+  font-size:.84rem !important;
+  font-weight:700 !important;
+  letter-spacing:.02em;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-points{
+  margin-top:1px !important;
+  font-size:.76rem !important;
+  color:#9bc2d7 !important;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-progress{
+  width:min(280px,100%) !important;
+  margin-top:4px !important;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-progress-track{
+  height:10px !important;
+  border-radius:999px !important;
+  border:1px solid rgba(108,242,255,.34) !important;
+  background:linear-gradient(180deg, rgba(6,20,32,.95), rgba(4,13,24,.95)) !important;
+  box-shadow: inset 0 2px 7px rgba(0,0,0,.34) !important;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-progress-fill{
+  background:linear-gradient(90deg, #12caef 0%, #47d9ff 35%, #69b7ff 100%) !important;
+  box-shadow: 0 0 12px rgba(88,226,255,.4) !important;
+}
+#lbAuthModal .lb-grade-inline .lb-grade-next{
+  margin-top:8px !important;
+  font-size:.67rem !important;
+  line-height:1.28 !important;
+  color:#b3d0e0 !important;
+  text-align:center !important;
+}
+#lbAuthModal .lb-auth-actions{
+  gap:9px !important;
+  margin-top: 9px !important;
+}
+#lbAuthModal .lb-auth-actions #lbBtnPrefs,
+#lbAuthModal .lb-auth-actions #lbBtnRanking,
+#lbAuthModal .lb-auth-actions #lbBtnLogout{
+  border:1px solid rgba(109,241,255,.42) !important;
+  border-radius:13px !important;
+  background:
+    linear-gradient(180deg, rgba(9,28,44,.92), rgba(5,17,30,.95)) !important;
+  color:#e8fbff !important;
+  box-shadow:
+    inset 0 1px 0 rgba(184,247,255,.08),
+    0 0 0 1px rgba(29,124,160,.22),
+    0 5px 14px rgba(0,0,0,.3),
+    0 0 12px rgba(58,220,255,.13) !important;
+  transition: transform .12s ease, box-shadow .16s ease, border-color .16s ease;
+}
+#lbAuthModal .lb-auth-actions #lbBtnPrefs:hover,
+#lbAuthModal .lb-auth-actions #lbBtnRanking:hover,
+#lbAuthModal .lb-auth-actions #lbBtnLogout:hover{
+  border-color:rgba(140,248,255,.65) !important;
+  box-shadow:
+    inset 0 1px 0 rgba(200,249,255,.1),
+    0 0 0 1px rgba(39,154,186,.24),
+    0 8px 18px rgba(0,0,0,.34),
+    0 0 15px rgba(70,230,255,.2) !important;
+}
+#lbAuthModal .lb-auth-actions #lbBtnPrefs:active,
+#lbAuthModal .lb-auth-actions #lbBtnRanking:active,
+#lbAuthModal .lb-auth-actions #lbBtnLogout:active{
+  transform:translateY(1px) scale(.995);
+  box-shadow:
+    inset 0 2px 10px rgba(0,0,0,.25),
+    0 3px 10px rgba(0,0,0,.26),
+    0 0 10px rgba(62,219,255,.18) !important;
 }
 
 </style>


### PR DESCRIPTION
### Motivation
- Donner un rendu plus premium, lisible et « app/dashboard » à la vue mobile de la zone Mon compte / Mon profil troupeau tout en restant 100% fidèle à l’univers sombre bleu/cyan de La Bétaillère. 
- Améliorer lisibilité et hiérarchie (titre, pseudo, avatar+médaille, grade, progression, actions) sans toucher à la logique métier ni aux sélecteurs utilisés par le JavaScript. 
- Isoler les changements au niveau présentation pour éviter toute régression fonctionnelle ou API. 

### Description
- Ajout d’un overlay assombrissant et léger blur sur `#lbAuthModal` et renforcement typographique du titre `Mon compte` pour une hiérarchie plus forte. 
- Refonte CSS de la carte profil (dans `index57.html` sous sélecteurs `#lbAuthModal .lb-profile-card` et `.lb-grade-inline`) avec dégradé sombre bleu/bleu-noir, contour cyan fin, inner-shadow discret et meilleure gérance des espacements. 
- Amélioration de l’avatar en conservant le rond et les IDs existants, ajout d’un halo cyan subtil via un pseudo-élément, et transformation de la médaille en badge flottant superposé en haut à droite de l’avatar sans changer le markup ni la logique. 
- Re-stylisation de la capsule grade, épaississement et gradient de la barre de progression, et traitement « glass/neon panel » des boutons `Mes préférences`, `Classement` et `Déconnexion` avec micro-interactions `:hover/:active`, le tout scoped à `#lbAuthModal` pour limiter les effets collatéraux. 

### Testing
- Exécution de `git diff --check` qui est passée proprement (aucune erreur signalée). 
- Vérification de l’état du dépôt avec `git status --short` et création du commit via `git commit` (message: "Polish mobile account profile card aesthetics"). 
- Aucun test automatisé d’interface visuelle disponible dans cet environnement, donc les validations visuelles restent manuelles à effectuer en navigateur mobile après déploiement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df87dd2ec0832d91ae5e8e48a6c5fb)