### PR TITLE
Animate profile avatar on auth modal open and ensure animation restarts

### DIFF
--- a/index58.html
+++ b/index58.html
@@ -10151,6 +10151,60 @@ body.page-carte #affluence{ display:none !important; }
     0 0 16px rgba(56,233,255,.7),
     0 0 34px rgba(27,206,255,.56),
     inset 0 1px 7px rgba(199,250,255,.25) !important;
+  transform-origin:50% 50%;
+}
+#lbAuthModal.lb-avatar-magic-on .lb-grade-inline #lbProfileGradeImage{
+  animation: lbAvatarMagicAppear 900ms cubic-bezier(.16,.84,.24,1) both;
+}
+@keyframes lbAvatarMagicAppear{
+  0%{
+    opacity:0;
+    filter: blur(12px) brightness(2.2) saturate(1.45) contrast(1.15);
+    transform: scale(.2) rotate(-18deg);
+    box-shadow:
+      0 0 0 1px rgba(205,253,255,.98),
+      0 0 0 4px rgba(80,240,255,.8),
+      0 0 40px rgba(95,241,255,.95),
+      0 0 64px rgba(59,220,255,.9),
+      inset 0 0 14px rgba(226,255,255,.42);
+  }
+  30%{
+    opacity:1;
+    filter: blur(5px) brightness(1.95) saturate(1.35) contrast(1.1);
+    transform: scale(1.16) rotate(8deg);
+  }
+  52%{
+    opacity:1;
+    filter: blur(1.1px) brightness(2.35) saturate(1.5) contrast(1.2);
+    transform: scale(.93) rotate(-4deg);
+    box-shadow:
+      0 0 0 1px rgba(232,255,255,1),
+      0 0 0 3px rgba(102,246,255,.9),
+      0 0 30px rgba(173,251,255,1),
+      0 0 54px rgba(118,236,255,.96),
+      inset 0 0 20px rgba(255,255,255,.62);
+  }
+  70%{
+    opacity:1;
+    filter: blur(.35px) brightness(1.16) saturate(1.1) contrast(1.05);
+    transform: scale(1.03) rotate(1deg);
+  }
+  100%{
+    opacity:1;
+    filter: blur(0) brightness(1) saturate(1);
+    transform: scale(1) rotate(0deg);
+    box-shadow:
+      0 0 0 1px rgba(142,250,255,.95),
+      0 0 0 2px rgba(52,234,255,.52),
+      0 0 16px rgba(56,233,255,.7),
+      0 0 34px rgba(27,206,255,.56),
+      inset 0 1px 7px rgba(199,250,255,.25);
+  }
+}
+@media (prefers-reduced-motion: reduce){
+  #lbAuthModal.lb-avatar-magic-on .lb-grade-inline #lbProfileGradeImage{
+    animation:none !important;
+  }
 }
 #lbAuthModal .lb-grade-inline .lb-grade-rank-badge{
   position:absolute !important;
@@ -23200,6 +23254,10 @@ function scheduleWeatherAfterTableSettled(){
     if (!modal) return;
     modal.style.display = "flex";
     modal.setAttribute("aria-hidden", "false");
+    modal.classList.remove("lb-avatar-magic-on");
+    const avatar = $("lbProfileGradeImage");
+    if (avatar) void avatar.offsetWidth;
+    modal.classList.add("lb-avatar-magic-on");
   };
 
   const closeModal = () => {


### PR DESCRIPTION
### Motivation

- Improve the visual entrance of the profile avatar in the authentication modal by adding an attention-grabbing animation and ensuring it reliably plays whenever the modal is opened.

### Description

- Add `transform-origin` and an animation rule so `#lbAuthModal.lb-avatar-magic-on .lb-grade-inline #lbProfileGradeImage` uses the new `lbAvatarMagicAppear` animation. 
- Introduce `@keyframes lbAvatarMagicAppear` that defines a multi-step appear animation with scale, rotation, filter and box-shadow transitions. 
- Add a `prefers-reduced-motion: reduce` rule to disable the animation for users who request reduced motion. 
- Modify the `openModal` code path to remove and re-add the `lb-avatar-magic-on` class and force a reflow via `void avatar.offsetWidth` so the animation reliably restarts each time the modal opens.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9a0b3a40832d9d78332747a78b2c)