### PR TITLE
Default TER branding, affluence UI overhaul, and PWA cache/index update

### DIFF
--- a/carte.html
+++ b/carte.html
@@ -734,6 +734,8 @@ function escapeHTML(str){
       prefix = 'TGV ROI';
     } else if (isCfl && CFL_ROUTE_PREFIXES.has(normalizedShort)){
       prefix = CFL_ROUTE_PREFIXES.get(normalizedShort);
+    } else if (category === 'sncf'){
+      prefix = 'TER';
     }
 
     const rawDigits = rawNumberKey != null ? String(rawNumberKey) : null;
@@ -774,10 +776,9 @@ function escapeHTML(str){
   }
 
   function formatTrainLabel(train, { includeTrainWord = true, fallbackId } = {}){
-    const { label, category } = trainLabelParts(train, fallbackId);
+    const { label } = trainLabelParts(train, fallbackId);
     if (!label) return fallbackId || '';
-    if (!includeTrainWord || category === 'tgv-roi') return label;
-    return `Train ${label}`;
+    return label;
   }
 
   function formatTrainAriaLabel(train, fallbackId){
@@ -4759,7 +4760,7 @@ const mapContainerEl = map.getContainer();
           : `<div class="station-board-time">${escapeHTML(realtimeText || '—')}</div>`);
       const btnId = escapeAttr(row.trainId);
       const btnLabel = escapeAttr(`Ouvrir le détail du ${row.ariaLabel || (row.number ? `train ${row.number}` : 'service')}`);
-      const trainLabel = row.number ? `Train ${row.number}` : (row.label || row.trainId);
+      const trainLabel = row.number || row.label || row.trainId;
       const rowClass = row.isCancelled
         ? ' class="station-board-row-cancelled"'
         : (row.isImminent ? ' class="station-board-row-imminent"' : '');

--- a/index63.html
+++ b/index63.html
@@ -11978,7 +11978,7 @@ body{
   <h2>Carte en direct</h2>
   <div class="map-embed-shell">
     <iframe
-      src="carte.html?embed=1"
+      src="carte.html?embed=1&v=20260421-1"
       title="Carte La Bétaillère"
       loading="lazy"
       referrerpolicy="strict-origin-when-cross-origin"
@@ -12067,34 +12067,26 @@ body{
     .affls-unit > span{
       border-right:2px solid #111;
       position:relative;
-      display:block;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      overflow:hidden;
     }
     .affls-unit > span:last-child{ border-right:none; }
-    .affls-dot{
-      width:10px; height:10px; border-radius:50%;
-      position:absolute; left:50%; top:50%;
-      transform:translate(-50%,-50%);
-      border:2px solid #111;
-      background:#bbb;
-      box-sizing:border-box;
-    }
-    .affls-dot.good{ background:#24c25a; } /* <50% */
-    .affls-dot.mid{  background:#f1c40f; } /* 50–69% */
-    .affls-dot.warn{ background:#ff8a1a; } /* 70–84% */
-    .affls-dot.bad{  background:#ff3131; } /* 85–94% */
-    .affls-dot.sat{  background:#000; }   /* ≥95% */
-    .affls-pct{
+    .affls-car{
       position:absolute;
-      left:50%;
-      top:-16px;
-      transform:translateX(-50%);
+      inset:0;
+      background:#bbb;
+      opacity:.95;
+    }
+    .affls-pct{
+      position:relative;
+      z-index:1;
       font-size:10px;
       font-weight:800;
-      color:#111;
-      background:rgba(255,255,255,.92);
-      border:1px solid rgba(0,0,0,.15);
-      border-radius:6px;
-      padding:1px 4px;
+      color:#fff;
+      text-shadow:0 1px 1px rgba(0,0,0,.55);
+      padding:0 2px;
       line-height:1.2;
       white-space:nowrap;
       pointer-events:none;
@@ -27341,23 +27333,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const cls = 'affls-rame' + (isUnknown ? ' affls-unk' : '');
     let out = `<span class="${cls}" aria-label="schéma affluence">`;
 
-    const pctToDot = (pct)=>{
-      const p = Number(pct);
-      if (!Number.isFinite(p)) return 'mid';
-      if (p < 50) return 'good';
-      if (p < 70) return 'mid';
-      if (p < 85) return 'warn';
-      if (p < 95) return 'bad';
-      return 'sat';
+    const wagonColor = (pct, band)=>{
+      if (Number.isFinite(Number(pct))) return pctToColor(Number(pct));
+      return affBandColor[normBand(band, null)] || '#999';
     };
-    const bandToDot = (band)=>{
-      const b = String(band || '').toLowerCase();
-      if (b === 'green') return 'good';
-      if (b === 'yellow') return 'mid';
-      if (b === 'orange') return 'warn';
-      if (b === 'red') return 'bad';
-      if (b === 'black') return 'sat';
-      return 'mid';
+    const wagonTextColor = (bg)=>{
+      const hex = String(bg || '').trim();
+      const m = /^#([0-9a-f]{6})$/i.exec(hex);
+      if (!m) return '#fff';
+      const val = m[1];
+      const r = parseInt(val.slice(0,2), 16);
+      const g = parseInt(val.slice(2,4), 16);
+      const b = parseInt(val.slice(4,6), 16);
+      const luma = (0.299*r) + (0.587*g) + (0.114*b);
+      return luma > 160 ? '#0b1118' : '#fff';
     };
 
     const units = Math.ceil(n / 3) || 1;
@@ -27367,9 +27356,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const idx = u*3 + i;
         const pct = pcts[idx];
         const band = bands[idx];
-        const dotCls = Number.isFinite(Number(pct)) ? pctToDot(pct) : bandToDot(band);
+        const bgColor = wagonColor(pct, band);
+        const fgColor = wagonTextColor(bgColor);
         const label = Number.isFinite(Number(pct)) ? (Math.round(Number(pct)) + '%') : '—';
-        out += `<span><span class="affls-dot ${dotCls}"></span><span class="affls-pct">${label}</span></span>`;
+        out += `<span><span class="affls-car" style="background:${bgColor}"></span><span class="affls-pct" style="color:${fgColor}">${label}</span></span>`;
       }
       out += '</span>';
     }

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "La Bétaillère",
   "short_name": "La Bétaillère",
-  "start_url": "./index42.html#home",
+  "start_url": "./index63.html#home",
   "display": "standalone",
   "background_color": "#0b0f1a",
   "theme_color": "#0b0f1a",
@@ -20,7 +20,7 @@
       "purpose": "any maskable"
     }
   ],
-  "id": "/index42.html",
+  "id": "/index63.html",
   "scope": "./",
   "display_override": [
     "standalone",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = 'lbetaillere-v6';
+const CACHE_NAME = 'lbetaillere-v8';
 const ASSETS = [
   './',
-  './index42.html',
-  './index42.html#home',
+  './index63.html',
+  './index63.html#home',
   './manifest.webmanifest',
   './service-worker.js',
   './logoText.png',
@@ -48,7 +48,7 @@ self.addEventListener('fetch', (event) => {
           }
           return response;
         })
-        .catch(() => caches.match('./index40.html'));
+        .catch(() => caches.match('./index63.html'));
     })
   );
 });


### PR DESCRIPTION
### Motivation
- Ensure SNCF services get a sensible default prefix (TER) in branding when no other prefix applies.
- Simplify train labels presented in the UI by removing the automatic `Train ` word and harmonize accessibility labels.
- Replace the small-dot affluence visualization with colored car blocks that use numeric percentages or band colors plus readable contrast, and update related styles for better rendering.
- Point the PWA assets and service worker to the new `index63.html` entry and bump the cache version to force refresh of cached assets.

### Description
- Add default `prefix = 'TER'` when the computed `category` is `sncf` inside the branding logic in `carte.html`.
- Simplify `formatTrainLabel` to no longer prepend `Train ` to labels and adjust station-board row label generation to match the new behavior in `carte.html`.
- Revamp affluence wagon rendering in `index63.html` by replacing dot-based indicators with `.affls-car` blocks, updating CSS (`.affls-unit`, `.affls-car`, `.affls-pct`) and rewriting `wagonSchemaHtml` to compute background colors using percentage/band logic and to choose contrasting text color via a luma check.
- Minor UI change: add a version query parameter to the embedded map iframe (`carte.html?embed=1&v=20260421-1`) in `index63.html`.
- Update PWA metadata in `manifest.webmanifest` to use `./index63.html` for `start_url` and `id`.
- Bump service worker `CACHE_NAME` to `lbetaillere-v8`, update cached `ASSETS` to include `index63.html`, and change the fetch error fallback to `./index63.html` in `service-worker.js`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7210186c8832db2cca9ab58fe239f)