### PR TITLE
Enhance platform/track parsing and selection; add CFL fallback safeguards and dep/arr mode

### DIFF
--- a/index63.html
+++ b/index63.html
@@ -13842,6 +13842,25 @@ function normalizeVoiesBaseTime(raw){
   return null;
 }
 
+function normalizeVoieValue(raw){
+  if (raw == null) return null;
+  const txt = String(raw).trim();
+  if (!txt || /^(-+|n\/?a|nc|null|undefined)$/i.test(txt)) return null;
+  return txt.replace(/^voie\s*/i, '').replace(/^track\s*/i, '').trim() || null;
+}
+
+function pickVoieFromEntry(entry, mode = 'dep'){
+  if (!entry) return null;
+  if (typeof entry === 'string') return normalizeVoieValue(entry);
+  if (typeof entry !== 'object') return null;
+  const dep = normalizeVoieValue(entry.depTrack ?? entry.departure_track ?? entry.dep ?? entry.voie_depart);
+  const arr = normalizeVoieValue(entry.arrTrack ?? entry.arrival_track ?? entry.arr ?? entry.voie_arrivee);
+  const generic = normalizeVoieValue(entry.genericTrack ?? entry.track ?? entry.platform ?? entry.voie ?? entry.quai);
+  return mode === 'arr'
+    ? (arr || generic || dep)
+    : (dep || generic || arr);
+}
+
 const LB_ENDPOINTS = Object.freeze({
   voiesByTrain: 'https://vps.labetaillere.fr/gtfs/voies_by_train.json',
   retardsCfl: 'https://vps.labetaillere.fr/gtfs/retards_cfl.json',
@@ -13868,9 +13887,25 @@ function normalizeVoiesPayload(data){
     if (rawEntries && typeof rawEntries === 'object') {
       Object.entries(rawEntries).forEach(([k, v]) => {
         const normKey = normalizeVoiesStopKey(k);
-        const val = (v && typeof v === 'object') ? (v.voie || v.value || v.label || '') : v;
-        const voie = String(val || '').trim();
-        if (normKey && voie) entriesMap.set(normKey, voie);
+        if (!normKey) return;
+        if (v && typeof v === 'object') {
+          const depTrack = normalizeVoieValue(v.depTrack ?? v.departure_track ?? v.dep_track ?? v.dep_platform ?? v.dep_voie ?? v.voie_depart ?? v.voie_dep);
+          const arrTrack = normalizeVoieValue(v.arrTrack ?? v.arrival_track ?? v.arr_track ?? v.arr_platform ?? v.arr_voie ?? v.voie_arrivee ?? v.voie_arr);
+          const genericTrack = normalizeVoieValue(v.genericTrack ?? v.track ?? v.platform ?? v.voie ?? v.quai ?? v.value ?? v.label);
+          if (!depTrack && !arrTrack && !genericTrack) return;
+          const prev = entriesMap.get(normKey);
+          const merged = (prev && typeof prev === 'object')
+            ? {
+                depTrack: prev.depTrack || depTrack || null,
+                arrTrack: prev.arrTrack || arrTrack || null,
+                genericTrack: prev.genericTrack || genericTrack || null
+              }
+            : { depTrack, arrTrack, genericTrack };
+          entriesMap.set(normKey, merged);
+          return;
+        }
+        const voie = normalizeVoieValue(v);
+        if (voie) entriesMap.set(normKey, voie);
       });
     }
     if (entriesMap.size) out.set(normalizedTrain, entriesMap);
@@ -14170,7 +14205,7 @@ function resolveCflVoieForStop({ voiesMap, stopName }){
   return null;
 }
 
-function resolveVoieForStop({ voiesMap, stopName, baseTimeRaw, timeCandidates }){
+function resolveVoieForStop({ voiesMap, stopName, baseTimeRaw, timeCandidates, mode = 'dep' }){
   if (!(voiesMap instanceof Map) || !stopName) return null;
 
   // (1) Match strict: stop + heure (comportement actuel)
@@ -14181,12 +14216,13 @@ function resolveVoieForStop({ voiesMap, stopName, baseTimeRaw, timeCandidates })
     if (!timeHHMM) continue;
     const key = normalizeVoiesStopKey(`${stopName}|${timeHHMM}`);
     if (!key) continue;
-    const voie = voiesMap.get(key);
+    const voie = pickVoieFromEntry(voiesMap.get(key), mode);
     if (voie) return voie;
   }
 
-  // (2) Fallback "secours": match sur le stop uniquement (ignore l'heure)
-  // Utile quand le flux des voies est décalé de quelques minutes vs Navitia (ex: 88526)
+  // (2) Fallback "secours": même logique prudente que la carte.
+  // On ne prend une voie du même arrêt que si l'heure est proche,
+  // pour éviter les mauvais quais/voies (ex: Thionville voie 1 alors que B/C).
   const stopNorm = normalizeVoiesTrainKey(stopName);
   if (!stopNorm) return null;
 
@@ -14206,16 +14242,14 @@ function resolveVoieForStop({ voiesMap, stopName, baseTimeRaw, timeCandidates })
 
   let bestVoie = null;
   let bestDiff = Infinity;
+  const MAX_FALLBACK_DIFF_MIN = 7;
 
   for (const [k, v] of voiesMap.entries()){
     // k est du type "pagnysurmoselle|14:06"
     if (typeof k !== 'string') continue;
     if (!k.startsWith(stopNorm + '|')) continue;
 
-    if (refMin == null) {
-      // Pas de référence horaire -> 1ère voie trouvée
-      return v || null;
-    }
+    if (refMin == null) continue;
 
     const hhmm = k.slice((stopNorm + '|').length);
     const km = parseMin(hhmm);
@@ -14224,11 +14258,12 @@ function resolveVoieForStop({ voiesMap, stopName, baseTimeRaw, timeCandidates })
     const diff = Math.abs(km - refMin);
     if (diff < bestDiff){
       bestDiff = diff;
-      bestVoie = v || null;
+      bestVoie = pickVoieFromEntry(v, mode);
     }
   }
 
-  return bestVoie;
+  if (bestDiff <= MAX_FALLBACK_DIFF_MIN) return bestVoie;
+  return null;
 }
 
 function formatVoieLabel(raw){
@@ -15537,6 +15572,36 @@ function getEquivalentCflStopKeys(stopName){
 
 function isLikelyCflStopName(stopName){
   return getEquivalentCflStopKeys(stopName).length > 0;
+}
+
+const FRENCH_BORDER_STOPS = new Set([
+  'thionville',
+  'uckange',
+  'hagondange',
+  'maiziereslesmetz',
+  'woippy',
+  'metznord',
+  'metz',
+  'pagnysurmoselle',
+  'pontamousson',
+  'nancy',
+  'hettangegrande'
+]);
+
+function isLikelyFrenchStopContext({ stopName, stopPointId } = {}){
+  const stopNorm = normalizeVoiesTrainKey(stopName);
+  const rawId = String(stopPointId || '').trim();
+
+  // Navitia SNCF ids: stop_area / stop_point OCE* (réseau France)
+  if (/^stop(area|point):oce/i.test(rawId) || /:OCE/i.test(rawId) || /^OCE/i.test(rawId)) return true;
+
+  // Si le stop est clairement CFL (alias connu), on ne le marque pas FR.
+  if (stopNorm && isLikelyCflStopName(stopName)) return false;
+
+  // Arrêts frontaliers/côté France fréquemment présents dans le tableau.
+  if (stopNorm && FRENCH_BORDER_STOPS.has(stopNorm)) return true;
+
+  return false;
 }
     
 function stripLeadingZerosForDisplay(value){
@@ -19409,17 +19474,21 @@ const stopHasSchedule = (result, stopName) => {
           stop?.arrival_time,
           base
         ];
-        const preferCflVoie = !!result.cflVoies && isLikelyCflStopName(stopName);
+        const stopPointId = stop?.stop_point?.id || imp?.stop_point?.id || '';
+        const allowCflFallback = !isLikelyFrenchStopContext({ stopName, stopPointId });
+        const preferCflVoie = allowCflFallback && !!result.cflVoies && isLikelyCflStopName(stopName);
+        const voieMode = (imp?.base_departure_time || imp?.amended_departure_time || stop?.departure_time) ? 'dep' : 'arr';
         let voieLabel = null;
         if (!preferCflVoie) {
           voieLabel = resolveVoieForStop({
             voiesMap: result.voies,
             stopName,
             baseTimeRaw: base,
-            timeCandidates: voieTimeCandidates
+            timeCandidates: voieTimeCandidates,
+            mode: voieMode
           });
         }
-        if (!voieLabel) {
+        if (!voieLabel && allowCflFallback) {
           voieLabel = resolveCflVoieForStop({ voiesMap: result.cflVoies || result.voies, stopName });
         }
         if (!voieLabel && preferCflVoie) {
@@ -19427,7 +19496,8 @@ const stopHasSchedule = (result, stopName) => {
             voiesMap: result.voies,
             stopName,
             baseTimeRaw: base,
-            timeCandidates: voieTimeCandidates
+            timeCandidates: voieTimeCandidates,
+            mode: voieMode
           });
         }
         const baseClock = ft(base);
@@ -24202,6 +24272,7 @@ function getGtfsDelayForStop(trainNumber, stopName){
 
     // voies (quais) : même logique que le tableau
     const voiesMap = (typeof getVoiesForTrain === 'function') ? getVoiesForTrain(trainNumber) : null;
+    const cflVoiesMap = (typeof getCflVoiesForTrain === 'function') ? getCflVoiesForTrain(trainNumber) : null;
 
     // Helpers locaux (évite les ReferenceError si ces helpers ne sont pas dans le scope global)
     const toHHMM = (t) => {
@@ -24299,9 +24370,11 @@ function getGtfsDelayForStop(trainNumber, stopName){
           const mm = amendedMin % 60;
           candidates.push(String(hh).padStart(2,'0') + String(mm).padStart(2,'0'));
         }
-        voieLabel = resolveVoieForStop({ voiesMap, stopName: name, baseTimeRaw: plannedRaw, timeCandidates: candidates });
+        const voieMode = (impAny?.base_departure_time || impAny?.amended_departure_time || st?.departure_time) ? 'dep' : 'arr';
+        voieLabel = resolveVoieForStop({ voiesMap, stopName: name, baseTimeRaw: plannedRaw, timeCandidates: candidates, mode: voieMode });
       }
-	if (!voieLabel && cflVoiesMap && typeof resolveCflVoieForStop === 'function') {
+      const allowCflFallback = !isLikelyFrenchStopContext({ stopName: name });
+	if (!voieLabel && allowCflFallback && cflVoiesMap && typeof resolveCflVoieForStop === 'function') {
         voieLabel = resolveCflVoieForStop({ voiesMap: cflVoiesMap, stopName: name });
       }
 
@@ -24506,9 +24579,12 @@ function getGtfsDelayForStop(trainNumber, stopName){
           const mm = amendedMin % 60;
           candidates.push(String(hh).padStart(2,'0') + String(mm).padStart(2,'0'));
         }
-        voieLabel = resolveVoieForStop({ voiesMap, stopName: name, baseTimeRaw: plannedRaw, timeCandidates: candidates });
+        const voieMode = (imp?.base_departure_time || imp?.amended_departure_time || st?.departure_time) ? 'dep' : 'arr';
+        voieLabel = resolveVoieForStop({ voiesMap, stopName: name, baseTimeRaw: plannedRaw, timeCandidates: candidates, mode: voieMode });
       }
-      if (!voieLabel && cflVoiesMap && typeof resolveCflVoieForStop === 'function') {
+      const stopPointId = st?.stop_point?.id || imp?.stop_point?.id || '';
+      const allowCflFallback = !isLikelyFrenchStopContext({ stopName: name, stopPointId });
+      if (!voieLabel && allowCflFallback && cflVoiesMap && typeof resolveCflVoieForStop === 'function') {
         voieLabel = resolveCflVoieForStop({ voiesMap: cflVoiesMap, stopName: name });
       }
 
@@ -26015,7 +26091,8 @@ if (statsEl){
         const voies = (typeof getVoiesForTrain === 'function') ? getVoiesForTrain(trainNumber) : null;
         const cflVoies = (typeof getCflVoiesForTrain === 'function') ? getCflVoiesForTrain(trainNumber) : null;
         const voieTimeCandidates = [baseTimeRaw];
-        const preferCflVoie = !!cflVoies && isLikelyCflStopName(stopName);
+        const allowCflFallback = !isLikelyFrenchStopContext({ stopName });
+        const preferCflVoie = allowCflFallback && !!cflVoies && isLikelyCflStopName(stopName);
         let voieLabel = null;
 
         if (!preferCflVoie && typeof resolveVoieForStop === 'function') {
@@ -26023,11 +26100,12 @@ if (statsEl){
             voiesMap: voies,
             stopName,
             baseTimeRaw,
-            timeCandidates: voieTimeCandidates
+            timeCandidates: voieTimeCandidates,
+            mode: 'dep'
           });
         }
 
-        if (!voieLabel && typeof resolveCflVoieForStop === 'function') {
+        if (!voieLabel && allowCflFallback && typeof resolveCflVoieForStop === 'function') {
           voieLabel = resolveCflVoieForStop({ voiesMap: cflVoies || voies, stopName });
         }
 
@@ -26036,7 +26114,8 @@ if (statsEl){
             voiesMap: voies,
             stopName,
             baseTimeRaw,
-            timeCandidates: voieTimeCandidates
+            timeCandidates: voieTimeCandidates,
+            mode: 'dep'
           });
         }
 


### PR DESCRIPTION
### Motivation
- Make extraction of voie/track values robust to many provider payload shapes and to explicit departure/arrival fields.
- Avoid wrongly applying CFL static voies to stops that are likely on the French side or otherwise mismatched. 
- Reduce erroneous fallback matches by preferring nearby-time entries and supporting dep/arr-specific selection.

### Description
- Added `normalizeVoieValue` and `pickVoieFromEntry` to normalize string/object entries and pick `depTrack`/`arrTrack`/`genericTrack` values.
- Updated `normalizeVoiesPayload` to aggregate per-stop entries as objects with `depTrack`, `arrTrack` and `genericTrack` instead of only plain strings.
- Extended `resolveVoieForStop` to accept a `mode` (`'dep'` or `'arr'`), use `pickVoieFromEntry`, and enforce a maximum fallback time difference of 7 minutes when selecting a nearby voie.
- Introduced `FRENCH_BORDER_STOPS` and `isLikelyFrenchStopContext` and changed callers to compute `allowCflFallback` so CFL voies are used only when appropriate.
- Updated multiple callers (table updates, next-stops rendering, favorites, etc.) to pass the new `mode` and to gate CFL fallback by `allowCflFallback`.

### Testing
- Ran the project test suite with `npm test` and linting with `npm run lint`, both completed successfully.
- Built the project with `npm run build` and executed a smoke check of voie resolution logic against representative payloads with no regressions observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86aa9676c832d936b6b098c486a2f)