### PR TITLE
Add grade help popover, normalize grade levels and adjust related UI/CSS

### DIFF
--- a/index69.html
+++ b/index69.html
@@ -6199,6 +6199,82 @@ body.modal-open{ overflow:hidden; }
   margin-top: 0;
   font-size: 1rem;
 }
+.lb-grade-title-row{
+  margin-top: 4px;
+  display:flex;
+  justify-content:center;
+}
+.lb-grade-help-btn{
+  appearance:none;
+  -webkit-appearance:none;
+  padding:0 !important;
+  min-width:16px !important;
+  min-height:16px !important;
+  max-width:16px !important;
+  max-height:16px !important;
+  border-radius:50% !important;
+  flex:0 0 16px;
+  width:16px;
+  height:16px;
+  border:1px solid rgba(126,247,255,.45);
+  background:rgba(0,240,255,.08);
+  color:rgba(174,245,255,.95);
+  font-weight:900;
+  font-size:.58rem;
+  line-height:1;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  box-shadow:none;
+  margin-left:6px;
+  vertical-align:middle;
+}
+.lb-grade-help-pop{
+  position:absolute;
+  right:6px;
+  top:88px;
+  z-index:25;
+  width:min(230px, 72vw);
+  border:1px solid rgba(0,240,255,.36);
+  border-radius:12px;
+  background:linear-gradient(180deg, rgba(7,20,34,.96), rgba(3,12,22,.96));
+  padding:8px 10px;
+  box-shadow:0 12px 28px rgba(0,0,0,.36), 0 0 20px rgba(0,240,255,.16);
+}
+.lb-grade-title-row .lb-grade-name{
+  white-space:nowrap;
+  text-align:center;
+  margin:0;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+}
+.lb-grade-help-pop[hidden]{ display:none !important; }
+.lb-grade-help-title{
+  margin:0 0 6px;
+  color:#86f7ff;
+  font-size:.65rem;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  font-weight:900;
+}
+.lb-grade-help-list{
+  margin:0;
+  padding:0;
+  list-style:none;
+  display:flex;
+  flex-direction:column;
+  gap:3px;
+}
+.lb-grade-help-list li{
+  display:flex;
+  justify-content:space-between;
+  gap:8px;
+  font-size:.68rem;
+  color:#d9f4ff;
+}
+.lb-grade-help-list .v{ color:#7ef7ff; font-weight:800; white-space:nowrap; }
 .lb-grade-inline .lb-grade-points{
   margin-top: 0;
   font-size: .88rem;
@@ -10353,6 +10429,7 @@ body.page-carte #affluence{ display:none !important; }
   font-size:.84rem !important;
   font-weight:700 !important;
   letter-spacing:.02em;
+  white-space: nowrap !important;
 }
 #lbAuthModal .lb-grade-inline .lb-grade-points{
   margin-top:1px !important;
@@ -11521,7 +11598,13 @@ body{
               <img id="lbProfileGradeImage" src="./Mouton%20%C3%A9gar%C3%A9.png" alt="Grade du profil">
             </div>
           </div>
-          <div id="lbProfileGradeName" class="lb-grade-name">Mouton égaré</div>
+          <div class="lb-grade-title-row">
+            <div class="lb-grade-name"><span id="lbProfileGradeName">Mouton égaré</span><button type="button" id="lbGradeHelpBtn" class="lb-grade-help-btn" aria-expanded="false" aria-controls="lbGradeHelpPop" title="Voir les paliers">i</button></div>
+          </div>
+          <div id="lbGradeHelpPop" class="lb-grade-help-pop" hidden>
+            <p class="lb-grade-help-title">Paliers des grades</p>
+            <ul id="lbGradeHelpList" class="lb-grade-help-list"></ul>
+          </div>
           <div id="lbProfileGradePoints" class="lb-grade-points">0 meuh</div>
           <div class="lb-grade-progress">
             <div class="lb-grade-progress-track">
@@ -23187,14 +23270,14 @@ function scheduleWeatherAfterTableSettled(){
   window.currentUser = null;
   const lbGamificationState = { profile: null, ranking: [], myRank: null, me: null, lastFetchAt: 0, inflight: null };
   const LB_GRADE_LEVELS = [
+    { name: 'Porc en déroute', min: -20, image: 'Porc en déroute.png' },
     { name: 'Mouton égaré', min: 0, image: 'Mouton égaré.png' },
-    { name: 'Poulet du Quai', min: 120, image: 'Poulet du Quai.png' },
-    { name: 'Porc en déroute', min: 280, image: 'Porc en déroute.png' },
-    { name: 'Porc entassé du couloir', min: 500, image: 'Porc entassé du couloir.png' },
-    { name: 'Bélier du sas', min: 800, image: 'Bélier du sas.png' },
-    { name: 'Architecte Chèvre de la galère', min: 1150, image: 'Architecte Chèvre de la galère.png' },
-    { name: 'Golden Vache', min: 1550, image: 'Golden Vache.png' },
-    { name: 'Ministre dindon du chaos ferroviaire', min: 2000, image: 'Ministre dindon du chaos ferroviaire.png' }
+    { name: 'Poulette du quai', min: 20, image: 'Poulet du Quai.png' },
+    { name: 'Porc entassé du couloir', min: 40, image: 'Porc entassé du couloir.png' },
+    { name: 'Bélier du sas', min: 80, image: 'Bélier du sas.png' },
+    { name: 'Architecte Chèvre de la galère', min: 120, image: 'Architecte Chèvre de la galère.png' },
+    { name: 'Ministre dindon du chaos ferroviaire', min: 180, image: 'Ministre dindon du chaos ferroviaire.png' },
+    { name: 'Golden Vache', min: 250, image: 'Golden Vache.png' }
   ];
   let lbProfileCache = null;
   let lbRankingCache = null;
@@ -23221,6 +23304,36 @@ function scheduleWeatherAfterTableSettled(){
     const next = LB_GRADE_LEVELS[idx + 1] || null;
     return { current, next };
   }
+  function renderGradeHelpList(){
+    const listEl = $("lbGradeHelpList");
+    if (!listEl) return;
+    const rows = [...LB_GRADE_LEVELS].sort((a,b)=> Number(b.min) - Number(a.min));
+    listEl.innerHTML = rows.map((it)=>{
+      const threshold = Number(it.min);
+      const label = Number.isFinite(threshold)
+        ? (threshold < 0 ? '< 0 meuh' : `${threshold}+ meuh`)
+        : '—';
+      return `<li><span>${escapeHtml(it.name)}</span><span class="v">${escapeHtml(label)}</span></li>`;
+    }).join('');
+  }
+  function bindGradeHelpToggle(){
+    const btn = $("lbGradeHelpBtn");
+    const pop = $("lbGradeHelpPop");
+    if (!btn || !pop || btn.dataset.bound === '1') return;
+    btn.dataset.bound = '1';
+    const close = ()=>{ pop.hidden = true; btn.setAttribute('aria-expanded', 'false'); };
+    const open = ()=>{ pop.hidden = false; btn.setAttribute('aria-expanded', 'true'); };
+    btn.addEventListener('click', (e)=>{
+      e.stopPropagation();
+      if (pop.hidden) open();
+      else close();
+    });
+    document.addEventListener('click', (e)=>{
+      if (pop.hidden) return;
+      if (e.target === btn || pop.contains(e.target)) return;
+      close();
+    });
+  }
   function replayGradeAppear(imgEl){
     if (!imgEl) return;
     imgEl.classList.remove('lb-grade-appear');
@@ -23228,6 +23341,8 @@ function scheduleWeatherAfterTableSettled(){
     imgEl.classList.add('lb-grade-appear');
   }
   function renderPrefsGradeCard(grade, points){
+    renderGradeHelpList();
+    bindGradeHelpToggle();
     const safePoints = Number(points || 0) || 0;
     const { current, next } = resolveGradeMeta(grade, safePoints);
     const span = next ? Math.max(1, (next.min - current.min)) : 1;
@@ -31191,10 +31306,14 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 	grid-area: badge !important;
     align-self:center !important;
     justify-self:end !important;
+    margin-right: 2px !important;
     font-size: .52rem !important;
     padding: 2px 6px !important;
     white-space: nowrap !important;
     flex: 0 0 auto !important;
+  }
+  #homeFavSlot .home-fav-trainline{
+    padding-right: 6px !important;
   }
   .home-card[forwarding="ber"]{
     display: none !important;
@@ -31313,6 +31432,12 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 #favTrainsWidget .fav-aff .fav-aff-schema--compact .affls-unit{
   width:calc(var(--seg-count, 3) * 32px) !important;
   height:16px !important;
+  border-color: rgba(120, 240, 255, .72) !important;
+  background: rgba(4, 14, 24, .86) !important;
+  box-shadow: 0 0 0 1px rgba(0,240,255,.16), inset 0 0 10px rgba(0,0,0,.22) !important;
+}
+#favTrainsWidget .fav-aff .fav-aff-schema--compact .affls-unit > span{
+  border-right-color: rgba(120, 240, 255, .52) !important;
 }
 #favTrainsWidget .fav-aff .fav-aff-schema--compact .affls-dot{
   width:7px !important;


### PR DESCRIPTION
### Motivation
- Provide a discoverable help UI for gamification grade thresholds so users can see grade paliers directly in the profile card. 
- Normalize and simplify grade level definitions and thresholds to match updated progression logic. 
- Polish layout and visual consistency for grade card and some favorites widgets to avoid overflow and contradictory rules.

### Description
- Added a compact help button and popover to the profile grade card in the markup: `#lbGradeHelpBtn` and `#lbGradeHelpPop` with an empty list `#lbGradeHelpList` to be populated at runtime. 
- Introduced CSS for the help button/popover and small layout tweaks: `.lb-grade-title-row`, `.lb-grade-help-btn`, `.lb-grade-help-pop`, `.lb-grade-help-list`, and related rules; also added `white-space: nowrap` to `#lbAuthModal .lb-grade-inline .lb-grade-name`. 
- Reworked `LB_GRADE_LEVELS` array ordering and `min` thresholds (including adding a negative threshold level) to the new normalized progression and updated images mapping. 
- Implemented `renderGradeHelpList()` to render the sorted threshold list into `#lbGradeHelpList` and `bindGradeHelpToggle()` to handle open/close behavior; integrated both calls into `renderPrefsGradeCard()`. 
- Minor CSS adjustments for favorites and home fav slot visuals (margins, unit styling and box shadows) to reduce conflicting rules and improve spacing.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d5b94d58832d998bb65682987f32)