### PR TITLE
Add FAQ modal, grade-help popover and UI/style updates for live wall and profile

### DIFF
--- a/index69.html
+++ b/index69.html
@@ -897,6 +897,84 @@ body {
   font-size:.72rem;
   font-weight:800;
 }
+.faq-btn{
+  appearance:none;
+  -webkit-appearance:none;
+  font-size:11px;
+  margin-left:0;
+  cursor:pointer;
+  color:#8ef8ff;
+  opacity:.88;
+  transition:transform .16s ease, box-shadow .18s ease, opacity .18s ease, border-color .18s ease;
+  background:linear-gradient(180deg, rgba(6,26,42,.92), rgba(4,18,30,.92));
+  border:1px solid rgba(126,247,255,.44);
+  border-radius:999px;
+  width:22px;
+  height:22px;
+  min-width:22px !important;
+  min-height:22px !important;
+  padding:0;
+  line-height:1;
+  box-shadow: inset 0 0 0 1px rgba(0,240,255,.10), 0 0 10px rgba(0,240,255,.16) !important;
+}
+.faq-btn:hover{
+  opacity:1;
+  transform:translateY(-1px);
+  border-color:rgba(126,247,255,.8);
+  box-shadow: inset 0 0 0 1px rgba(0,240,255,.18), 0 0 14px rgba(0,240,255,.34) !important;
+}
+.voice-header,
+.live-wall-head{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+}
+.live-wall-head-actions{
+  display:flex;
+  align-items:center;
+  gap:6px;
+  padding:2px 4px 2px 8px;
+  border-radius:999px;
+  border:1px solid rgba(0,240,255,.20);
+  background:linear-gradient(180deg, rgba(2,18,30,.62), rgba(2,14,24,.55));
+  box-shadow: inset 0 0 0 1px rgba(0,240,255,.08);
+}
+#homeLiveWallCount.live-wall-badge{
+  min-width:24px;
+  padding:2px 8px;
+  border-color:rgba(126,247,255,.44);
+  background:linear-gradient(180deg, rgba(6,30,46,.86), rgba(4,17,28,.84));
+  box-shadow: inset 0 0 0 1px rgba(0,240,255,.12);
+}
+.faq-modal{
+  width:100%;
+  height:100%;
+  border:none;
+  background:rgba(5,10,20,.72);
+  padding:0;
+}
+.faq-modal::backdrop{ background:rgba(2,8,14,.72); }
+.faq-container{
+  width:min(760px, calc(100vw - 22px));
+  max-height:calc(100dvh - var(--top-bar-height, 72px) - var(--bottom-bar-height, 84px) - 16px);
+  margin:calc(var(--top-bar-height, 72px) + 8px) auto calc(var(--bottom-bar-height, 84px) + 8px);
+  padding:14px 14px 12px;
+  color:white;
+  overflow:auto;
+  border-radius:18px;
+  border:1px solid rgba(0,240,255,.34);
+  background:linear-gradient(180deg, rgba(6,18,32,.95), rgba(3,10,20,.96));
+  box-shadow:0 20px 45px rgba(0,0,0,.45), inset 0 0 0 1px rgba(0,240,255,.12);
+}
+.faq-header{
+  display:flex; justify-content:space-between; align-items:center;
+  font-size:1.02rem; margin-bottom:12px;
+}
+.faq-content{ display:flex; flex-direction:column; gap:10px; padding-bottom:2px; }
+.faq-item{ background:rgba(0,20,40,.42); border:1px solid rgba(0,234,255,.68); border-radius:12px; padding:10px 11px; }
+.faq-item p{ margin:6px 0 0; color:#d4e6f4; line-height:1.3; }
+.faq-item b{ color:#00eaff; }
+#closeFaq{ flex:0 0 auto; }
 .live-wall-feed{
   display:grid;
   gap:6px;
@@ -6199,6 +6277,83 @@ body.modal-open{ overflow:hidden; }
   margin-top: 0;
   font-size: 1rem;
 }
+.lb-grade-title-row{
+  margin-top: 4px;
+  display:flex;
+  justify-content:center;
+}
+.lb-grade-help-btn{
+  appearance:none;
+  -webkit-appearance:none;
+  padding:0 !important;
+  min-width:14px !important;
+  min-height:14px !important;
+  max-width:14px !important;
+  max-height:14px !important;
+  border-radius:50% !important;
+  flex:0 0 14px;
+  width:14px;
+  height:14px;
+  border:1px solid rgba(126,247,255,.45);
+  background:rgba(0,240,255,.08);
+  color:rgba(174,245,255,.95);
+  font-weight:900;
+  font-size:.5rem;
+  line-height:1;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  box-shadow:none;
+  margin-left:4px;
+  vertical-align:middle;
+}
+.lb-grade-help-pop{
+  position:absolute;
+  right:6px;
+  top:88px;
+  z-index:25;
+  width:min(230px, 72vw);
+  border:1px solid rgba(0,240,255,.36);
+  border-radius:12px;
+  background:linear-gradient(180deg, rgba(7,20,34,.96), rgba(3,12,22,.96));
+  padding:8px 10px;
+  box-shadow:0 12px 28px rgba(0,0,0,.36), 0 0 20px rgba(0,240,255,.16);
+}
+.lb-grade-title-row .lb-grade-name{
+  white-space:nowrap;
+  text-align:center;
+  margin:0;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  line-height:1;
+}
+.lb-grade-help-pop[hidden]{ display:none !important; }
+.lb-grade-help-title{
+  margin:0 0 6px;
+  color:#86f7ff;
+  font-size:.65rem;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  font-weight:900;
+}
+.lb-grade-help-list{
+  margin:0;
+  padding:0;
+  list-style:none;
+  display:flex;
+  flex-direction:column;
+  gap:3px;
+}
+.lb-grade-help-list li{
+  display:flex;
+  justify-content:space-between;
+  gap:8px;
+  font-size:.68rem;
+  color:#d9f4ff;
+}
+.lb-grade-help-list .v{ color:#7ef7ff; font-weight:800; white-space:nowrap; }
 .lb-grade-inline .lb-grade-points{
   margin-top: 0;
   font-size: .88rem;
@@ -10346,13 +10501,15 @@ body.page-carte #affluence{ display:none !important; }
   border-radius:999px;
   width:fit-content;
   max-width:100%;
-  padding:5px 10px 4px !important;
+  padding:2px 7px 2px !important;
   border:1px solid rgba(113,244,255,.4);
   background:linear-gradient(180deg, rgba(7,27,43,.8), rgba(4,17,29,.9));
   color:#e6fbff !important;
   font-size:.84rem !important;
   font-weight:700 !important;
   letter-spacing:.02em;
+  white-space: nowrap !important;
+  line-height: 1 !important;
 }
 #lbAuthModal .lb-grade-inline .lb-grade-points{
   margin-top:1px !important;
@@ -11453,7 +11610,10 @@ body{
     <article class="home-card live-wall-card live-wall-card--home home-comments-compact" aria-label="Mur de commentaires">
       <div class="live-wall-head">
         <h2 class="live-wall-title">La Voix du Bétail</h2>
-        <span class="live-wall-badge" id="homeLiveWallCount">0</span>
+        <div class="live-wall-head-actions">
+          <button type="button" id="faqBtn" class="faq-btn" aria-label="Ouvrir la FAQ">❓</button>
+          <span class="live-wall-badge" id="homeLiveWallCount">0</span>
+        </div>
       </div>
 	  <div class="lb-community-actions" aria-label="Actions collaboratives">
         <button type="button" class="lb-community-btn lb-community-btn--signal" id="lbOpenSignalModal">⚠️ Signaler</button>
@@ -11468,6 +11628,25 @@ body{
         <button type="submit" class="auth-button">Envoyer</button>
       </form>
     </article>
+
+    <dialog id="faqModal" class="faq-modal" aria-labelledby="faqModalTitle">
+      <div class="faq-container">
+        <div class="faq-header">
+          <span id="faqModalTitle">🐮 FAQ — La Bétaillère</span>
+          <button type="button" id="closeFaq" class="lb-auth-close tron-close-button" aria-label="Fermer la FAQ"></button>
+        </div>
+        <div class="faq-content">
+          <div class="faq-item"><b>🐮 Pourquoi “La Bétaillère” ?</b><p>Parce que c’est la réalité. Trains bondés, retards… on a juste mis un mot dessus.</p></div>
+          <div class="faq-item"><b>🚆 C’est une appli officielle ?</b><p>Non. Juste un usager qui en avait marre.</p></div>
+          <div class="faq-item"><b>📊 D’où viennent les infos ?</b><p>SNCF, CFL… et surtout les utilisateurs.</p></div>
+          <div class="faq-item"><b>⚠️ Pourquoi il peut y avoir des erreurs ?</b><p>Parce que même les données officielles en ont.</p></div>
+          <div class="faq-item"><b>🐄 C’est quoi les meuh ?</b><p>Des points gagnés en participant (signalement, votes…)</p></div>
+          <div class="faq-item"><b>🏆 Les grades servent à quoi ?</b><p>Valoriser les contributeurs de la communauté.</p></div>
+          <div class="faq-item"><b>💬 La Voix du Bétail ?</b><p>L’info terrain. Direct. Sans filtre.</p></div>
+          <div class="faq-item"><b>🔥 Pourquoi ça existe ?</b><p>Parce que personne ne faisait le lien entre données et réalité.</p></div>
+        </div>
+      </div>
+    </dialog>
 
     <article class="home-card home-quick-card" aria-label="Tableau rapide">
       <h2>Tableau dynamique</h2>
@@ -11521,7 +11700,13 @@ body{
               <img id="lbProfileGradeImage" src="./Mouton%20%C3%A9gar%C3%A9.png" alt="Grade du profil">
             </div>
           </div>
-          <div id="lbProfileGradeName" class="lb-grade-name">Mouton égaré</div>
+          <div class="lb-grade-title-row">
+            <div class="lb-grade-name"><span id="lbProfileGradeName">Mouton égaré</span><button type="button" id="lbGradeHelpBtn" class="lb-grade-help-btn" aria-expanded="false" aria-controls="lbGradeHelpPop" title="Voir les paliers">i</button></div>
+          </div>
+          <div id="lbGradeHelpPop" class="lb-grade-help-pop" hidden>
+            <p class="lb-grade-help-title">Paliers des grades</p>
+            <ul id="lbGradeHelpList" class="lb-grade-help-list"></ul>
+          </div>
           <div id="lbProfileGradePoints" class="lb-grade-points">0 meuh</div>
           <div class="lb-grade-progress">
             <div class="lb-grade-progress-track">
@@ -23187,14 +23372,14 @@ function scheduleWeatherAfterTableSettled(){
   window.currentUser = null;
   const lbGamificationState = { profile: null, ranking: [], myRank: null, me: null, lastFetchAt: 0, inflight: null };
   const LB_GRADE_LEVELS = [
+    { name: 'Porc en déroute', min: -20, image: 'Porc en déroute.png' },
     { name: 'Mouton égaré', min: 0, image: 'Mouton égaré.png' },
-    { name: 'Poulet du Quai', min: 120, image: 'Poulet du Quai.png' },
-    { name: 'Porc en déroute', min: 280, image: 'Porc en déroute.png' },
-    { name: 'Porc entassé du couloir', min: 500, image: 'Porc entassé du couloir.png' },
-    { name: 'Bélier du sas', min: 800, image: 'Bélier du sas.png' },
-    { name: 'Architecte Chèvre de la galère', min: 1150, image: 'Architecte Chèvre de la galère.png' },
-    { name: 'Golden Vache', min: 1550, image: 'Golden Vache.png' },
-    { name: 'Ministre dindon du chaos ferroviaire', min: 2000, image: 'Ministre dindon du chaos ferroviaire.png' }
+    { name: 'Poulette du quai', min: 20, image: 'Poulet du Quai.png' },
+    { name: 'Porc entassé du couloir', min: 40, image: 'Porc entassé du couloir.png' },
+    { name: 'Bélier du sas', min: 80, image: 'Bélier du sas.png' },
+    { name: 'Architecte Chèvre de la galère', min: 120, image: 'Architecte Chèvre de la galère.png' },
+    { name: 'Ministre dindon du chaos ferroviaire', min: 180, image: 'Ministre dindon du chaos ferroviaire.png' },
+    { name: 'Golden Vache', min: 250, image: 'Golden Vache.png' }
   ];
   let lbProfileCache = null;
   let lbRankingCache = null;
@@ -23221,6 +23406,36 @@ function scheduleWeatherAfterTableSettled(){
     const next = LB_GRADE_LEVELS[idx + 1] || null;
     return { current, next };
   }
+  function renderGradeHelpList(){
+    const listEl = $("lbGradeHelpList");
+    if (!listEl) return;
+    const rows = [...LB_GRADE_LEVELS].sort((a,b)=> Number(b.min) - Number(a.min));
+    listEl.innerHTML = rows.map((it)=>{
+      const threshold = Number(it.min);
+      const label = Number.isFinite(threshold)
+        ? (threshold < 0 ? '< 0 meuh' : `${threshold}+ meuh`)
+        : '—';
+      return `<li><span>${escapeHtml(it.name)}</span><span class="v">${escapeHtml(label)}</span></li>`;
+    }).join('');
+  }
+  function bindGradeHelpToggle(){
+    const btn = $("lbGradeHelpBtn");
+    const pop = $("lbGradeHelpPop");
+    if (!btn || !pop || btn.dataset.bound === '1') return;
+    btn.dataset.bound = '1';
+    const close = ()=>{ pop.hidden = true; btn.setAttribute('aria-expanded', 'false'); };
+    const open = ()=>{ pop.hidden = false; btn.setAttribute('aria-expanded', 'true'); };
+    btn.addEventListener('click', (e)=>{
+      e.stopPropagation();
+      if (pop.hidden) open();
+      else close();
+    });
+    document.addEventListener('click', (e)=>{
+      if (pop.hidden) return;
+      if (e.target === btn || pop.contains(e.target)) return;
+      close();
+    });
+  }
   function replayGradeAppear(imgEl){
     if (!imgEl) return;
     imgEl.classList.remove('lb-grade-appear');
@@ -23228,6 +23443,8 @@ function scheduleWeatherAfterTableSettled(){
     imgEl.classList.add('lb-grade-appear');
   }
   function renderPrefsGradeCard(grade, points){
+    renderGradeHelpList();
+    bindGradeHelpToggle();
     const safePoints = Number(points || 0) || 0;
     const { current, next } = resolveGradeMeta(grade, safePoints);
     const span = next ? Math.max(1, (next.min - current.min)) : 1;
@@ -31191,10 +31408,14 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 	grid-area: badge !important;
     align-self:center !important;
     justify-self:end !important;
+    margin-right: 2px !important;
     font-size: .52rem !important;
     padding: 2px 6px !important;
     white-space: nowrap !important;
     flex: 0 0 auto !important;
+  }
+  #homeFavSlot .home-fav-trainline{
+    padding-right: 6px !important;
   }
   .home-card[forwarding="ber"]{
     display: none !important;
@@ -31313,6 +31534,12 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
 #favTrainsWidget .fav-aff .fav-aff-schema--compact .affls-unit{
   width:calc(var(--seg-count, 3) * 32px) !important;
   height:16px !important;
+  border-color: rgba(120, 240, 255, .72) !important;
+  background: rgba(4, 14, 24, .86) !important;
+  box-shadow: 0 0 0 1px rgba(0,240,255,.16), inset 0 0 10px rgba(0,0,0,.22) !important;
+}
+#favTrainsWidget .fav-aff .fav-aff-schema--compact .affls-unit > span{
+  border-right-color: rgba(120, 240, 255, .52) !important;
 }
 #favTrainsWidget .fav-aff .fav-aff-schema--compact .affls-dot{
   width:7px !important;
@@ -33936,6 +34163,19 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     openLive: ()=> openCommunityModal('lbLiveModal'),
     openSignal: ()=> openCommunityModal('lbSignalModal')
   };
+})();
+</script>
+
+<script>
+(() => {
+  const faqModal = document.getElementById('faqModal');
+  const faqBtn = document.getElementById('faqBtn');
+  const closeFaq = document.getElementById('closeFaq');
+  if (!faqModal || !faqBtn || !closeFaq) return;
+  faqBtn.addEventListener('click', () => {
+    if (typeof faqModal.showModal === 'function') faqModal.showModal();
+  });
+  closeFaq.addEventListener('click', () => faqModal.close());
 })();
 </script>
 


### PR DESCRIPTION
### Motivation
- Provide an accessible in-app FAQ from the home Live Wall and clarify gamification grade thresholds and progression. 
- Improve profile grade UI by exposing grade level thresholds and a compact help popover for users to understand progress. 
- Polish various visual/layout details for the Live Wall, favorites widget and auth/profile card for a more consistent look.

### Description
- Add a FAQ dialog markup to the home page and introduce a `faq` button in the Live Wall header with styles (`.faq-btn`, `.faq-modal`, `.faq-container`, etc.) and a small script that binds `faqBtn` to open `faqModal` and `closeFaq` to close it. 
- Introduce a grade-help popover UI in the profile card with markup (`#lbGradeHelpPop`, `#lbGradeHelpList`) and styles (`.lb-grade-help-pop`, `.lb-grade-help-btn`, `.lb-grade-help-list`, etc.), and wire toggling via `bindGradeHelpToggle` and list rendering via `renderGradeHelpList`. 
- Rework `LB_GRADE_LEVELS` values and ordering to adjust level names and thresholds and update `resolveGradeMeta`/`renderPrefsGradeCard` to render progress and bind the help popover. 
- Miscellaneous CSS adjustments including tighter padding for the auth modal grade name, small layout/visual tweaks for favorite train cards and fav-unit appearance, and small shadow/border refinements.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d5b94d58832d998bb65682987f32)