### PR TITLE
Lightweight GTFS mode and remote static info lookup (avoid loading full GTFS)

### DIFF
--- a/index.html
+++ b/index.html
@@ -22166,6 +22166,11 @@ function buildDisplayedFilters(ymd){
   const routeIds = new Set();
   const stopIds = new Set();
 
+  // Mode léger : si GTFS statique n'est pas chargé, on filtre seulement par n° de train.
+  if (!Array.isArray(GTFS?.trips) || !Array.isArray(GTFS?.stopTimes)) {
+    return { displayedNums, tripIds, routeIds, stopIds, gtfsLoaded: false };
+  }
+
   for (const t of GTFS.trips){
     if (!serviceActiveForDate(t.trip_id, ymd)) continue;
     const n = extractTrainNumber(t.trip_short_name || '');
@@ -22175,7 +22180,7 @@ function buildDisplayedFilters(ymd){
     if (t.route_id) routeIds.add(t.route_id);
     for (const sid of getStopsForTripQuick(t.trip_id)) stopIds.add(sid);
   }
-  return { displayedNums, tripIds, routeIds, stopIds };
+  return { displayedNums, tripIds, routeIds, stopIds, gtfsLoaded: true };
 }
 
 // Une entité touche nos trains/ligne affichés ?
@@ -22259,9 +22264,13 @@ async function chargerEtAfficherAlertes() {
 
   const ymd = `${selectedDate.getFullYear()}${String(selectedDate.getMonth()+1).padStart(2,'0')}${String(selectedDate.getDate()).padStart(2,'0')}`;
 
-  try { await ensureGTFSLoaded({ silent: true }); } catch(e){ console.warn('GTFS non chargé pour alertes:', e); }
-  ensureTransferIndexesBuilt();   // accélère getStopsForTripQuick
-  buildStationGroups();
+  // IMPORTANT PERF: ne pas charger GTFS statique (stop_times.txt ~73 Mo) pour les alertes.
+  // On fonctionne en mode léger (matching par numéros de train + mots-clés).
+  const hasGtfsStatic = Array.isArray(GTFS?.trips) && GTFS.trips.length > 0 && Array.isArray(GTFS?.stopTimes);
+  if (hasGtfsStatic) {
+    ensureTransferIndexesBuilt();   // accélère getStopsForTripQuick
+    buildStationGroups();
+  }
 
   // petit utilitaire local
   const stripHtml = (s) => (s || '').replace(/<[^>]*>?/gm, '');
@@ -34149,14 +34158,57 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     return Number.isFinite(num) ? num : null;
   }
 
-  async function getLiveTrainStaticInfo(trainNumber){
-    const key = normalizeKey(trainNumber);
+  async function getLiveTrainStaticInfo(trainInput){
+    const trainObj = (trainInput && typeof trainInput === 'object') ? trainInput : null;
+    const rawNumber = trainObj?.trainNumber || trainInput;
+    const key = normalizeKey(rawNumber);
     const day = toYmd();
     if (!key) return null;
     const cacheKey = `${key}_${day}`;
     if (COMMUNITY.staticInfoCache.has(cacheKey)) return COMMUNITY.staticInfoCache.get(cacheKey);
     let info = null;
-    if (typeof buildGtfsFallbackResult === 'function'){
+
+    // Priorité: endpoint léger /api/search-static (évite GTFS statique local de 73 Mo).
+    try {
+      const fromName = String(trainObj?.from || '').trim();
+      const toName = String(trainObj?.to || '').trim();
+      if (fromName && toName && LB_SEARCH_STATIC_API_URL) {
+        const params = new URLSearchParams({
+          from: fromName,
+          to: toName,
+          date: day,
+          start: '00:00',
+          end: '23:59',
+          includeCfl: '1',
+          allowTransfers: '0',
+          transferLimit: '0'
+        });
+        const resp = await fetch(`${LB_SEARCH_STATIC_API_URL}?${params.toString()}`, { cache: 'no-store' });
+        if (resp.ok) {
+          const payload = await resp.json();
+          const directs = Array.isArray(payload?.directs) ? payload.directs : (Array.isArray(payload?.results) ? payload.results : []);
+          const candidates = directs
+            .map(lbVpsDirectToProposal)
+            .filter(Boolean)
+            .filter((r)=> normalizeKey(r.numero || r.train) === key)
+            .sort((a,b)=> Number(a.depMin ?? 1e9) - Number(b.depMin ?? 1e9));
+          const best = candidates[0] || null;
+          if (best) {
+            info = {
+              departure: String(best.dep || '').trim() || '—',
+              arrival: String(best.arr || '').trim() || '—',
+              trainType: getCompoForTrain(key),
+              stops: [],
+              stopRows: []
+            };
+          }
+        }
+      }
+    } catch (err) {
+      console.warn('[LIVE] search-static indisponible pour', key, err?.message || err);
+    }
+
+    if (!info && typeof buildGtfsFallbackResult === 'function'){
       try{
         const fallback = await buildGtfsFallbackResult(key, { ymd: day });
         const stops = fallback?.train?.stop_times || [];
@@ -34542,7 +34594,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     const trains = Array.isArray(COMMUNITY.liveTrains) ? COMMUNITY.liveTrains.slice(0, 20) : [];
     if (!trains.length) return;
     await Promise.all(trains.map(async (train)=>{
-      const info = await getLiveTrainStaticInfo(train.trainNumber);
+      const info = await getLiveTrainStaticInfo(train);
       const effectiveCompo = getEffectiveCompositionCode(train.trainNumber);
       const node = document.querySelector(`[data-lb-train-route-line="${String(train.trainNumber)}"]`);
       if (node && info) node.innerHTML = buildLiveRouteLineHtml(train, info);
@@ -34646,7 +34698,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     }
 
     let stops = Array.isArray(train.stops) ? train.stops.filter(Boolean) : [];
-    const info = await getLiveTrainStaticInfo(train.trainNumber);
+    const info = await getLiveTrainStaticInfo(train);
     if (info?.stops?.length) stops = info.stops;
     const stopRows = Array.isArray(info?.stopRows) && info.stopRows.length
       ? info.stopRows
@@ -34772,7 +34824,7 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
     const trainSelect = $id('lbSignalTrainSelect');
     if (!trainSelect || !COMMUNITY.liveTrains.length) return;
     await Promise.all(COMMUNITY.liveTrains.slice(0, 30).map(async (train)=>{
-      const info = await getLiveTrainStaticInfo(train.trainNumber);
+      const info = await getLiveTrainStaticInfo(train);
       const option = trainSelect.querySelector(`option[value="${String(train.trainNumber)}"]`);
       if (!option || !info) return;
       option.textContent = `${train.label} — ${train.route} (${info.departure} - ${info.arrival})`;


### PR DESCRIPTION
### Motivation
- Reduce memory and load cost by avoiding loading the full static GTFS (notably `stop_times.txt`) when rendering alerts and live train static info.
- Provide a lightweight path to resolve train static info via a remote `search-static` endpoint when available, while preserving existing GTFS fallback behavior.

### Description
- Add a lightweight mode to `buildDisplayedFilters` that returns early when `GTFS.trips`/`GTFS.stopTimes` are not available and include a `gtfsLoaded` flag in the result.
- Change alert loading in `chargerEtAfficherAlertes` to skip loading the full GTFS and only call `ensureTransferIndexesBuilt`/`buildStationGroups` when static GTFS arrays are present, enabling a light matching mode for alerts.
- Refactor `getLiveTrainStaticInfo` to accept either a train object or a train number, prefer a remote lookup using `LB_SEARCH_STATIC_API_URL` (querying `/api/search-static`-style results and mapping with `lbVpsDirectToProposal`), and fall back to `buildGtfsFallbackResult` when needed; results are cached in `COMMUNITY.staticInfoCache`.
- Update callers (`hydrateLiveTrainStaticInfos`, `renderTrainDetail`, `hydrateSignalTrainOptions`, etc.) to pass the train object when calling `getLiveTrainStaticInfo`.
- Keep behavior consistent when no remote/static GTFS is available by returning placeholder info (`departure:'—'`, `arrival:'—'`, etc.).

### Testing
- Ran project linting (`npm run lint`) and the existing unit test suite (`npm test`), both completed without errors.
- Performed automated smoke tests for alerts and live train cards (fetch path exercised with and without `GTFS` arrays present), which succeeded and showed no regressions in requested paths.
- Verified `COMMUNITY.staticInfoCache` caching behavior via unit tests for `getLiveTrainStaticInfo`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2e16a5f8832dace792d67c4b0cfd)