### PR TITLE
Actualisation mobile-friendly du tableau des trains

### DIFF
--- a/index.html
+++ b/index.html
@@ -4350,6 +4350,13 @@ body.page-carte .train-detail-panel{
   flex-wrap:wrap;
   text-align:right;
 }
+#lastUpdated .refresh-inline-btn__label{
+  margin-left:6px;
+  font-size:.72rem;
+  font-weight:800;
+  letter-spacing:.02em;
+  white-space:nowrap;
+}
 #lastUpdated .last-updated-text{
   min-width:0;
 }
@@ -4360,8 +4367,9 @@ body.page-carte .train-detail-panel{
   background:rgba(0, 240, 255, 0.10);
   color:#9ffcff;
   border-radius:999px;
-  width:34px;
-  height:34px;
+  min-width:44px;
+  min-height:44px;
+  padding:0 12px;
   display:inline-flex;
   align-items:center;
   justify-content:center;
@@ -4385,6 +4393,30 @@ body.page-carte .train-detail-panel{
   animation:lbspin 0.9s linear infinite;
 }
 @keyframes lbspin{ from{transform:rotate(0deg);} to{transform:rotate(360deg);} }
+@media (max-width: 768px){
+  #lastUpdated{
+    justify-content:center;
+    text-align:center;
+    margin:8px max(8px, env(safe-area-inset-left, 0px)) 0;
+  }
+  #lastUpdated .last-updated-text{
+    flex:1 1 100%;
+  }
+  #lastUpdated .refresh-inline-btn{
+    width:min(100%, 320px);
+    min-height:46px;
+    border-color:rgba(0, 240, 255, 0.58);
+    background:linear-gradient(135deg, rgba(0,240,255,.18), rgba(0,120,255,.14));
+  }
+  #lastUpdated .refresh-inline-btn__label{
+    display:inline;
+  }
+}
+@media (min-width: 769px){
+  #lastUpdated .refresh-inline-btn__label{
+    display:none;
+  }
+}
 
 /* Ancien bouton centré : on le masque (remplacé par l'icône à droite du "Généré le…") */
 #refreshContainer{ display:none !important; }
@@ -13564,6 +13596,7 @@ body.monde-betaillere #homeFavSlot .home-fav-badge .fav-state-badge{
   <button type="button" class="tableau-view-tab" role="tab" aria-selected="false" data-tableau-view="perturbations">Perturbations</button>
   <button type="button" class="tableau-view-tab tableau-view-tab--search" role="tab" aria-selected="false" data-tableau-view="search">Nouvelle recherche</button>
   <button type="button" class="tableau-view-tab" role="tab" aria-selected="true" data-tableau-view="global">Image tableau</button>
+  <button id="refreshMobile" type="button" class="tableau-view-tab tableau-view-tab--refresh" data-tableau-action="refresh" title="Actualiser les données" aria-label="Actualiser les données du tableau">↻ Actualiser</button>
 </div>
 
 <div id="loisirsViewNav" role="tablist" aria-label="Sous-navigation Loisirs" hidden>
@@ -14325,6 +14358,22 @@ html, body{
   box-shadow: 0 0 0 1px rgba(170,255,255,.38) inset, 0 0 16px rgba(0,240,255,.45), inset 0 0 12px rgba(0,220,255,.28);
 }
 #tableauViewNav .tableau-view-tab--search{ font-weight: 800; letter-spacing: .03em; }
+#tableauViewNav .tableau-view-tab--refresh{
+  flex: 0.9 1 0;
+  border-color: rgba(0, 240, 255, 0.58);
+  background: linear-gradient(135deg, rgba(0,255,255,.20), rgba(0,150,255,.18));
+  color:#9ffcff;
+  font-weight: 800;
+}
+#tableauViewNav .tableau-view-tab--refresh[disabled]{
+  opacity:.62;
+  cursor:wait;
+  transform:none;
+}
+#tableauViewNav .tableau-view-tab--refresh .spin{
+  display:inline-block;
+  animation:lbspin 0.9s linear infinite;
+}
 @media (max-width: 768px){
   body.tableau-view-nav-visible{ --tableau-viewbar-h: 64px; }
   #tableauViewNav.is-visible{
@@ -22255,11 +22304,14 @@ scheduleWeatherAfterTableSettled();
   // Bouton "Actualiser" (icône à droite du "Généré le…") : refetch FRESH puis régénère
 const __lbDoRefresh = async () => {
   const statusEl = document.getElementById('lastUpdated');
-  const btn = document.getElementById('refreshInline') || document.getElementById('refreshButton');
-  if (btn){
+  const buttons = Array.from(document.querySelectorAll('#refreshInline, #refreshMobile, #refreshButton'));
+  buttons.forEach((btn) => {
     btn.disabled = true;
-    btn.innerHTML = '<span class="spin">🔄</span>';
-  }
+    btn.dataset.refreshing = 'true';
+    if (!btn.dataset.originalHtml) btn.dataset.originalHtml = btn.innerHTML;
+    const label = btn.id === 'refreshMobile' ? ' Actualisation…' : '<span class="refresh-inline-btn__label">Actualisation…</span>';
+    btn.innerHTML = `<span class="spin" aria-hidden="true">🔄</span>${label}`;
+  });
   if (statusEl) statusEl.querySelector?.('.last-updated-text') 
     ? (statusEl.querySelector('.last-updated-text').textContent = 'Actualisation en cours…')
     : (statusEl.textContent = 'Actualisation en cours…');
@@ -22279,10 +22331,12 @@ const __lbDoRefresh = async () => {
   } catch (e) {
     console.error('[GTFS-RT] Actualiser ->', e);
     alert("Échec de l'actualisation GTFS-RT.\n" + (e && e.message ? e.message : ''));
-    if (btn){
+    buttons.forEach((btn) => {
       btn.disabled = false;
-      btn.textContent = '🔄';
-    }
+      btn.removeAttribute('data-refreshing');
+      btn.innerHTML = btn.dataset.originalHtml || (btn.id === 'refreshMobile' ? '↻ Actualiser' : '<span aria-hidden="true">🔄</span><span class="refresh-inline-btn__label">Actualiser</span>');
+      delete btn.dataset.originalHtml;
+    });
     return; // on ne régénère pas avec des données inchangées
   }
 
@@ -22294,6 +22348,10 @@ const __lbDoRefresh = async () => {
 // Ancien bouton (si un jour tu le réactives) + nouveau bouton inline
 $('#refreshButton').off('click').on('click', __lbDoRefresh);
 $(document).off('click', '#refreshInline').on('click', '#refreshInline', (e) => {
+  e.preventDefault();
+  __lbDoRefresh();
+});
+$(document).off('click', '#refreshMobile').on('click', '#refreshMobile', (e) => {
   e.preventDefault();
   __lbDoRefresh();
 });
@@ -22821,7 +22879,7 @@ function setLastUpdated() {
     const [y, m, day] = d.split('-');
     validTxt = `${day}/${m}/${y}`;
   }
-  el.innerHTML = `<span class="last-updated-text">Généré le ${nowTxt} — Données valables le <strong>${validTxt}</strong></span>` + ` <button id="refreshInline" class="refresh-inline-btn" type="button" title="Actualiser les données" aria-label="Actualiser les données">🔄</button>`;
+  el.innerHTML = `<span class="last-updated-text">Généré le ${nowTxt} — Données valables le <strong>${validTxt}</strong></span>` + ` <button id="refreshInline" class="refresh-inline-btn" type="button" title="Actualiser les données" aria-label="Actualiser les données"><span aria-hidden="true">🔄</span><span class="refresh-inline-btn__label">Actualiser</span></button>`;
 }
 function todayYMDLux(){
   const parts = new Intl.DateTimeFormat('en-CA', {


### PR DESCRIPTION
### Motivation
- Rendre l’actualisation du tableau accessible et tactile sur mobile sans casser l’ergonomie desktop. 
- Améliorer la visibilité et la cible tactile du bouton d’actualisation affiché près de « Généré le… » pour éviter les erreurs de tap sur petits écrans. 
- Synchroniser l’état de chargement entre les contrôles existants et la nouvelle action mobile pour éviter des appels concurrents incohérents.

### Description
- Modifié `index.html` pour ajouter un bouton dédié `#refreshMobile` dans la sous-navigation `#tableauViewNav` et une étiquette lisible sur mobile pour le contrôle inline (`.refresh-inline-btn__label`).
- Ajouté du CSS responsive pour agrandir la cible tactile (`min-width:44px`, `min-height:44px`) et un style mobile spécifique (`min-height:46px`, largeur adaptative) tout en gardant l’affichage compact sur desktop.
- Réécrit la logique d’actualisation `__lbDoRefresh` pour désactiver et afficher l’état « Actualisation… » sur l’ensemble des contrôles (`#refreshInline`, `#refreshMobile`, `#refreshButton`) et re-générer le tableau après rechargement des données GTFS/voies.
- Mis à jour `setLastUpdated()` pour injecter le bouton inline avec icône + label mobile-friendly, et lié un handler click délégué pour `#refreshMobile` vers `__lbDoRefresh`.

### Testing
- Validation HTML via `html.parser` (script extraction) a réussi sans erreur et a produit les scripts inline vérifiés par `node --check` (tests statiques passés). 
- Exécutions de vérifications statiques (`node` regex checks) ont confirmé la présence du bouton mobile, la nouvelle étiquette et les règles CSS de cible tactile (tous PASS).
- Tentative d’un test E2E Playwright local a été préparée mais n’a pas pu être exécutée en raison d’un accès restreint au registre npm (erreur 403 dans cet environnement), donc les tests visuels/interaction réels n’ont pas pu être automatisés ici.
- Requête réseau vers la page publique a renvoyé un `403` côté tunnel dans cet environnement, mais les modifications sont locales et couvrent la logique d’UI/JS/CSS nécessaires pour le comportement demandé.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ecee73c44832d8ddf23f83bb49a0f)