### PR TITLE
Add selection-details metadata, toggle and improved refresh UI (mobile + loading state)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4350,6 +4350,13 @@ body.page-carte .train-detail-panel{
   flex-wrap:wrap;
   text-align:right;
 }
+#lastUpdated .refresh-inline-btn__label{
+  margin-left:6px;
+  font-size:.72rem;
+  font-weight:800;
+  letter-spacing:.02em;
+  white-space:nowrap;
+}
 #lastUpdated .last-updated-text{
   min-width:0;
 }
@@ -4360,8 +4367,9 @@ body.page-carte .train-detail-panel{
   background:rgba(0, 240, 255, 0.10);
   color:#9ffcff;
   border-radius:999px;
-  width:34px;
-  height:34px;
+  min-width:44px;
+  min-height:44px;
+  padding:0 12px;
   display:inline-flex;
   align-items:center;
   justify-content:center;
@@ -4385,6 +4393,30 @@ body.page-carte .train-detail-panel{
   animation:lbspin 0.9s linear infinite;
 }
 @keyframes lbspin{ from{transform:rotate(0deg);} to{transform:rotate(360deg);} }
+@media (max-width: 768px){
+  #lastUpdated{
+    justify-content:center;
+    text-align:center;
+    margin:8px max(8px, env(safe-area-inset-left, 0px)) 0;
+  }
+  #lastUpdated .last-updated-text{
+    flex:1 1 100%;
+  }
+  #lastUpdated .refresh-inline-btn{
+    width:min(100%, 320px);
+    min-height:46px;
+    border-color:rgba(0, 240, 255, 0.58);
+    background:linear-gradient(135deg, rgba(0,240,255,.18), rgba(0,120,255,.14));
+  }
+  #lastUpdated .refresh-inline-btn__label{
+    display:inline;
+  }
+}
+@media (min-width: 769px){
+  #lastUpdated .refresh-inline-btn__label{
+    display:none;
+  }
+}
 
 /* Ancien bouton centré : on le masque (remplacé par l'icône à droite du "Généré le…") */
 #refreshContainer{ display:none !important; }
@@ -4876,6 +4908,25 @@ body.page-carte .train-detail-panel{
   }
 }   
 
+#selectionDetailsToggle{
+  appearance:none;
+  border:1px solid rgba(0, 240, 255, 0.38);
+  background:rgba(0, 240, 255, 0.10);
+  color:#9ffcff;
+  border-radius:999px;
+  padding:4px 9px;
+  font-family:'Orbitron', sans-serif;
+  font-size:.72rem;
+  font-weight:800;
+  cursor:pointer;
+  box-shadow:0 0 8px rgba(0, 240, 255, 0.16);
+}
+#selectionDetailsToggle[hidden]{ display:none !important; }
+#selectionDetailsToggle[aria-pressed="true"]{
+  background:linear-gradient(135deg, rgba(0,255,255,.85), rgba(0,170,255,.85));
+  color:#00111a;
+}
+
 /* ===== Grille des chips sélectionnées (optimisée mobile) ===== */
 #selectionChips{
   box-sizing:border-box !important;      /* padding inclus */
@@ -4911,7 +4962,7 @@ body.page-carte .train-detail-panel{
 
 /* Style d’une chip sélectionnée (clic = supprimer) */
 #selectionChips .chip-tag{
-  position:relative; display:flex; align-items:center; gap:6px;
+  position:relative; display:flex; align-items:center; justify-content:center; gap:3px;
   width:100%; padding:6px 9px; min-height:32px;
   border:1px solid #00ffff55; border-radius:10px;
   background:linear-gradient(180deg, rgba(0,20,30,.55), rgba(0,10,18,.35));
@@ -4939,9 +4990,35 @@ body.page-carte .train-detail-panel{
 #selectionChips .chip-tag:active{ transform:scale(.98); }
 #selectionChips .chip-tag:focus{ outline:2px solid #00ffff; outline-offset:2px; }
 #selectionChips .chip-tag .t-num{ font-variant-numeric:tabular-nums; font-size:.9rem; }
+#selectionChips .chip-tag .t-detail{
+  display:none;
+  max-width:100%;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  font-size:.58rem;
+  line-height:1.05;
+  opacity:.82;
+  font-weight:600;
+  letter-spacing:-.02em;
+}
+#selectionChips.has-details{
+  grid-template-columns:repeat(auto-fit, minmax(145px, 1fr)) !important;
+}
+#selectionChips.has-details .chip-tag{
+  min-height:42px;
+  align-items:flex-start;
+  flex-direction:column;
+  justify-content:center;
+}
+#selectionChips.has-details .chip-tag .t-detail{ display:block; }
 @media (max-width:600px){
   #selectionChips .chip-tag{ padding:5px 8px; min-height:28px; }
   #selectionChips .chip-tag .t-num{ font-size:.86rem; }
+  #selectionChips.has-details{ grid-template-columns:repeat(2, minmax(0, 1fr)) !important; }
+  #selectionChips.has-details .chip-tag{ min-height:40px; padding:5px 6px; }
+  #selectionChips.has-details .chip-tag .t-num{ font-size:.78rem !important; }
+  #selectionChips.has-details .chip-tag .t-detail{ font-size:.52rem; }
 }
 #selectionChips .chip-tag .close{ display:none !important; }  /* croix supprimée */
 .selection-flyout{
@@ -13533,6 +13610,7 @@ body.monde-betaillere #homeFavSlot .home-fav-badge .fav-state-badge{
       <div id="selectionBlock" class="chips-panel" hidden>
         <div class="chips-header">
           <div style="font-weight:700">Sélection active</div>
+          <button id="selectionDetailsToggle" type="button" aria-pressed="false" hidden>Détails</button>
           <div class="chips-count"><span id="selCount">0</span> sélection(s)</div>
         </div> 
 
@@ -13564,6 +13642,7 @@ body.monde-betaillere #homeFavSlot .home-fav-badge .fav-state-badge{
   <button type="button" class="tableau-view-tab" role="tab" aria-selected="false" data-tableau-view="perturbations">Perturbations</button>
   <button type="button" class="tableau-view-tab tableau-view-tab--search" role="tab" aria-selected="false" data-tableau-view="search">Nouvelle recherche</button>
   <button type="button" class="tableau-view-tab" role="tab" aria-selected="true" data-tableau-view="global">Image tableau</button>
+  <button id="refreshMobile" type="button" class="tableau-view-tab tableau-view-tab--refresh" data-tableau-action="refresh" title="Actualiser les données" aria-label="Actualiser les données du tableau">↻ Actualiser</button>
 </div>
 
 <div id="loisirsViewNav" role="tablist" aria-label="Sous-navigation Loisirs" hidden>
@@ -14325,6 +14404,22 @@ html, body{
   box-shadow: 0 0 0 1px rgba(170,255,255,.38) inset, 0 0 16px rgba(0,240,255,.45), inset 0 0 12px rgba(0,220,255,.28);
 }
 #tableauViewNav .tableau-view-tab--search{ font-weight: 800; letter-spacing: .03em; }
+#tableauViewNav .tableau-view-tab--refresh{
+  flex: 0.9 1 0;
+  border-color: rgba(0, 240, 255, 0.58);
+  background: linear-gradient(135deg, rgba(0,255,255,.20), rgba(0,150,255,.18));
+  color:#9ffcff;
+  font-weight: 800;
+}
+#tableauViewNav .tableau-view-tab--refresh[disabled]{
+  opacity:.62;
+  cursor:wait;
+  transform:none;
+}
+#tableauViewNav .tableau-view-tab--refresh .spin{
+  display:inline-block;
+  animation:lbspin 0.9s linear infinite;
+}
 @media (max-width: 768px){
   body.tableau-view-nav-visible{ --tableau-viewbar-h: 64px; }
   #tableauViewNav.is-visible{
@@ -19642,6 +19737,8 @@ function renderTransferCards(transfers, startName, endName){
         const label2 = t.label2 || `${t.num2}`;
         TRAIN_LABEL_REGISTRY.set(t.num1, label1);
         TRAIN_LABEL_REGISTRY.set(t.num2, label2);
+        registerTrainSelectionMeta(t.num1, { from: t.from1 || startName, to: t.to1 || t.viaName || '', dep: t.dep1, arr: t.arr1 });
+        registerTrainSelectionMeta(t.num2, { from: t.from2 || t.viaName || '', to: t.to2 || endName, dep: t.dep2, arr: t.arr2 });
         const cls = ['chip','transfer'];
         if (t.source1 === 'CFL' || t.source2 === 'CFL') cls.push('cfl-train');
         const label1Class = `train-label${t.source1 === 'CFL' ? ' cfl' : ''}`;
@@ -20070,6 +20167,7 @@ async function proposerTrainsOD(eventOrOptions){
       const dataNum = t.selectionKey || t.numero || '';
       const label = t.displayLabel || (t.numero ? `${t.numero}` : 'Train');
       TRAIN_LABEL_REGISTRY.set(dataNum, label);
+      registerTrainSelectionMeta(dataNum, { from: t.from || startName, to: t.to || endName, dep: t.dep, arr: t.arr });
       const safeLabel = escapeHtml(label);
       const safeNum = escapeHtml(dataNum);
       const safeDep = escapeHtml(t.dep || '?');
@@ -20339,6 +20437,31 @@ function updatePresetHighlights(kind){
 /* ====================== ÉTAT CENTRAL ====================== */
 const selectedTrains = new Set();
 const TRAIN_LABEL_REGISTRY = new Map();
+const TRAIN_SELECTION_META_REGISTRY = new Map();
+let selectionDetailsVisible = false;
+
+function registerTrainSelectionMeta(key, meta = {}){
+  const k = String(key || '').trim();
+  if (!k) return;
+  TRAIN_SELECTION_META_REGISTRY.set(k, {
+    from: String(meta.from || '').trim(),
+    to: String(meta.to || '').trim(),
+    dep: String(meta.dep || '').trim(),
+    arr: String(meta.arr || '').trim()
+  });
+}
+
+function formatSelectionTrainMeta(key){
+  const meta = TRAIN_SELECTION_META_REGISTRY.get(String(key || '').trim());
+  if (!meta) return '';
+  const from = meta.from || '';
+  const to = meta.to || '';
+  const dep = meta.dep || '';
+  const arr = meta.arr || '';
+  const left = [from, dep].filter(Boolean).join(' ');
+  const right = [to, arr].filter(Boolean).join(' ');
+  return [left, right].filter(Boolean).join(' → ');
+}
 
 function extractCflTrainTypeFromResult(result){
   if (!result || typeof result !== 'object') return '';
@@ -20547,6 +20670,7 @@ function clearProposals(){
     section.classList.remove('is-empty');
   }
   TRAIN_LABEL_REGISTRY.clear();
+  TRAIN_SELECTION_META_REGISTRY.clear();
 }
     
 function chipsUpdateCount(){
@@ -20568,8 +20692,16 @@ function updateSelectionUI(){
     input.value = numericOnly.join(',');
   }
   // 2) rendu des chips sélection
+  const detailsToggle = document.getElementById('selectionDetailsToggle');
+  const hasDetails = arr.some(num => !!formatSelectionTrainMeta(num));
+  if (detailsToggle) {
+    detailsToggle.hidden = !hasDetails;
+    detailsToggle.textContent = selectionDetailsVisible ? 'Masquer' : 'Détails';
+    detailsToggle.setAttribute('aria-pressed', selectionDetailsVisible ? 'true' : 'false');
+  }
   const zone = document.getElementById('selectionChips');
   if (zone){
+    zone.classList.toggle('has-details', selectionDetailsVisible && hasDetails);
     // (ré)génère le HTML des chips
     zone.innerHTML = arr.map(num => {
       const isBetailleireMode = !!(document.body && document.body.classList.contains('monde-betaillere'));
@@ -20587,10 +20719,13 @@ function updateSelectionUI(){
       const officialFullBetailleireName = (isBetailleireMode && window.LB_BETAILLERE_TRAIN_NAME)
         ? window.LB_BETAILLERE_TRAIN_NAME(num, { compact:false, fallback:'' })
         : '';
-      const safeTitle = escapeHtml(officialFullBetailleireName || label);
+      const detail = formatSelectionTrainMeta(num);
+      const safeDetail = escapeHtml(detail);
+      const safeTitle = escapeHtml([officialFullBetailleireName || label, detail].filter(Boolean).join(' — '));
       return `
       <span class="${classes.join(' ')}" data-num="${safeNum}" role="button" tabindex="0" title="Retirer ${safeTitle}">
         <span class="t-num">${safeLabel}</span>
+        ${detail ? `<span class="t-detail">${safeDetail}</span>` : ''}
       </span>`;
     }).join('');
 
@@ -20693,6 +20828,14 @@ function chipsSetSelection(list){
   chipsUpdateCount();
   updateSelectionUI();
 }
+document.addEventListener('click', (event) => {
+  const btn = event.target?.closest?.('#selectionDetailsToggle');
+  if (!btn) return;
+  event.preventDefault();
+  selectionDetailsVisible = !selectionDetailsVisible;
+  updateSelectionUI();
+});
+
 function usePresetEverywhere(list){
   const arr = Array.isArray(list) ? list : [];
   if (document.querySelector('#propositions .chip')) {
@@ -20749,13 +20892,24 @@ async function applyRapidPreset(kind, options = {}){
       const startName = pickQueryEndpoint($start, config.queryStart, $start.val() || '');
       const endName = pickQueryEndpoint($end, config.queryEnd, $end.val() || '');
       const ymd = dateInputToYMD($('#trainDate').val()) || todayYMDLux().replace(/-/g,'');
-      await computeItineraryProposals({
+      const presetProposals = await computeItineraryProposals({
         startName,
         endName,
         fromHHMM: config.from,
         toHHMM: config.to,
         allowTransfers: false,
         ymd
+      });
+      (presetProposals?.directs || []).forEach((train) => {
+        const key = train.selectionKey || train.numero || '';
+        if (!key || !numbers.includes(key)) return;
+        TRAIN_LABEL_REGISTRY.set(key, train.displayLabel || train.numero || key);
+        registerTrainSelectionMeta(key, {
+          from: train.from || startName,
+          to: train.to || endName,
+          dep: train.dep,
+          arr: train.arr
+        });
       });
     } catch (err) {
       console.error('Impossible de calculer le preset rapide', err);
@@ -22248,18 +22402,38 @@ scheduleWeatherAfterTableSettled();
     // ===== FIN handler "#loadTrains"
 
     } finally {
+      if (typeof setRefreshButtonsLoading === 'function') setRefreshButtonsLoading(false);
       window.__mainTableBusy = false;
     }
   });
 
   // Bouton "Actualiser" (icône à droite du "Généré le…") : refetch FRESH puis régénère
+function getRefreshButtons(){
+  return Array.from(document.querySelectorAll('#refreshInline, #refreshMobile, #refreshButton'));
+}
+
+function setRefreshButtonsLoading(isLoading){
+  getRefreshButtons().forEach((btn) => {
+    if (isLoading) {
+      btn.disabled = true;
+      btn.dataset.refreshing = 'true';
+      if (!btn.dataset.originalHtml) btn.dataset.originalHtml = btn.innerHTML;
+      const label = btn.id === 'refreshMobile' ? ' Actualisation…' : '<span class="refresh-inline-btn__label">Actualisation…</span>';
+      btn.innerHTML = `<span class="spin" aria-hidden="true">🔄</span>${label}`;
+      return;
+    }
+
+    btn.disabled = false;
+    btn.removeAttribute('data-refreshing');
+    btn.innerHTML = btn.dataset.originalHtml || (btn.id === 'refreshMobile' ? '↻ Actualiser' : '<span aria-hidden="true">🔄</span><span class="refresh-inline-btn__label">Actualiser</span>');
+    delete btn.dataset.originalHtml;
+  });
+}
+
 const __lbDoRefresh = async () => {
+  if (window.__mainTableBusy) return;
   const statusEl = document.getElementById('lastUpdated');
-  const btn = document.getElementById('refreshInline') || document.getElementById('refreshButton');
-  if (btn){
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spin">🔄</span>';
-  }
+  setRefreshButtonsLoading(true);
   if (statusEl) statusEl.querySelector?.('.last-updated-text') 
     ? (statusEl.querySelector('.last-updated-text').textContent = 'Actualisation en cours…')
     : (statusEl.textContent = 'Actualisation en cours…');
@@ -22279,21 +22453,21 @@ const __lbDoRefresh = async () => {
   } catch (e) {
     console.error('[GTFS-RT] Actualiser ->', e);
     alert("Échec de l'actualisation GTFS-RT.\n" + (e && e.message ? e.message : ''));
-    if (btn){
-      btn.disabled = false;
-      btn.textContent = '🔄';
-    }
+    setRefreshButtonsLoading(false);
     return; // on ne régénère pas avec des données inchangées
   }
 
-  $('#loadTrains').click();
-  setLastUpdated();
-  // le bouton inline est recréé par setLastUpdated(), donc rien d'autre à faire
+  // Le handler #loadTrains est async et remettra les boutons au repos dans son finally.
+  $('#loadTrains').trigger('click');
 };
 
 // Ancien bouton (si un jour tu le réactives) + nouveau bouton inline
 $('#refreshButton').off('click').on('click', __lbDoRefresh);
 $(document).off('click', '#refreshInline').on('click', '#refreshInline', (e) => {
+  e.preventDefault();
+  __lbDoRefresh();
+});
+$(document).off('click', '#refreshMobile').on('click', '#refreshMobile', (e) => {
   e.preventDefault();
   __lbDoRefresh();
 });
@@ -22821,7 +22995,7 @@ function setLastUpdated() {
     const [y, m, day] = d.split('-');
     validTxt = `${day}/${m}/${y}`;
   }
-  el.innerHTML = `<span class="last-updated-text">Généré le ${nowTxt} — Données valables le <strong>${validTxt}</strong></span>` + ` <button id="refreshInline" class="refresh-inline-btn" type="button" title="Actualiser les données" aria-label="Actualiser les données">🔄</button>`;
+  el.innerHTML = `<span class="last-updated-text">Généré le ${nowTxt} — Données valables le <strong>${validTxt}</strong></span>` + ` <button id="refreshInline" class="refresh-inline-btn" type="button" title="Actualiser les données" aria-label="Actualiser les données"><span aria-hidden="true">🔄</span><span class="refresh-inline-btn__label">Actualiser</span></button>`;
 }
 function todayYMDLux(){
   const parts = new Intl.DateTimeFormat('en-CA', {
@@ -34294,6 +34468,17 @@ body{ padding-bottom: calc(var(--bottom-bar-height, 58px) + 10px) !important; }
   }
   #selectionModal #selectionChips .chip-tag .t-num{
     font-size: .8rem !important;
+  }
+  #selectionModal #selectionChips.has-details{
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  #selectionModal #selectionChips.has-details .chip-tag{
+    min-height: 39px !important;
+    height: auto !important;
+    align-items: flex-start !important;
+  }
+  #selectionModal #selectionChips.has-details .chip-tag .t-detail{
+    font-size: .51rem !important;
   }
   #selectionModal #selectionBlock .selection-manual-card{
     margin: 5px 0 6px !important;


### PR DESCRIPTION
### Motivation
- Improve selection chips with contextual metadata (from/to/dep/arr) and allow users to toggle detailed view for each selected train. 
- Provide clear, consistent refresh UI across inline, mobile and existing refresh buttons with a loading state to prevent duplicate actions. 
- Improve responsive styling for selection chips, last-updated refresh button and new mobile refresh control.

### Description
- Added a `TRAIN_SELECTION_META_REGISTRY` and helper functions `registerTrainSelectionMeta` and `formatSelectionTrainMeta` to store and format per-train selection metadata. 
- Registered selection metadata when generating proposals and transfers (`proposerTrainsOD`, `renderTransferCards`, `applyRapidPreset`) and clear it in `clearProposals`. 
- Extended the selection UI: added a `#selectionDetailsToggle` button, a `selectionDetailsVisible` flag, an event handler to toggle details, and rendering logic to show a `.t-detail` line inside each chip when details are available. 
- Updated chip grid CSS and modal variants to support a `.has-details` layout and added styles for `.t-detail`, `#selectionDetailsToggle`, and responsive rules. 
- Added a mobile refresh button `#refreshMobile` into the tableau nav and unified refresh behavior via `__lbDoRefresh`, plus helper functions `getRefreshButtons` and `setRefreshButtonsLoading` to show loading/disabled states and animated spinner markup for all refresh controls. 
- Modified `setLastUpdated` to render the new inline refresh button markup with a label/span for accessibility and consistent replacement during loading. 
- Ensured refresh handlers (`#refreshButton`, `#refreshInline`, `#refreshMobile`) call the unified `__lbDoRefresh` and that `__lbDoRefresh` triggers `#loadTrains` once GTFS-RT data loads.

### Testing
- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ecee73c44832d8ddf23f83bb49a0f)